### PR TITLE
Some small typo fixes in German translations

### DIFF
--- a/datamodels/2.x/itop-config/de.dict.itop-config.php
+++ b/datamodels/2.x/itop-config/de.dict.itop-config.php
@@ -30,7 +30,7 @@ Dict::Add('DE DE', 'German', 'Deutsch', array(
 	'config-apply' => 'Anwenden (Ctrl+S)',
 	'config-apply-title' => 'Anwenden (Ctrl+S)',
 	'config-cancel' => 'Zurücksetzen',
-    'config-saved' => 'Erfolgreich gesprichert',
+    'config-saved' => 'Erfolgreich gespeichert',
 	'config-confirm-cancel' => 'Ihre Änderungen werden nicht gespeichert.',
 	'config-no-change' => 'Keine Änderungen: Die Datei wurde nicht verändert.',
     'config-reverted' => 'Die Konfiguration wurde zurückgesetzt',

--- a/dictionaries/de.dictionary.itop.ui.php
+++ b/dictionaries/de.dictionary.itop.ui.php
@@ -1225,8 +1225,8 @@ Wenn Aktionen mit Trigger verknüpft sind, bekommt jede Aktion eine Auftragsnumm
 
 	'UI:GroupBy:count' => 'Anzahl',
 	'UI:GroupBy:count+' => 'Anzahl der Elemente',
-	'UI:GroupBy:sum' => 'Suumme',
-	'UI:GroupBy:sum+' => 'Suumme von %1$s',
+	'UI:GroupBy:sum' => 'Summe',
+	'UI:GroupBy:sum+' => 'Summe von %1$s',
 	'UI:GroupBy:avg' => 'Durchschnitt',
 	'UI:GroupBy:avg+' => 'Durchschnitt von %1$s',
 	'UI:GroupBy:min' => 'Minimum',


### PR DESCRIPTION
Fix typo in German dashlet translations (Group by sum)
Fix typo in German translation (config-saved)