### PR TITLE
fix core/expressioncache.class.inc.php multiple language support

### DIFF
--- a/core/expressioncache.class.inc.php
+++ b/core/expressioncache.class.inc.php
@@ -21,13 +21,13 @@ class ExpressionCache
 {
 	static private $aCache = array();
 
-	protected function GetLanguge() {
+	protected function GetLanguage() {
 		return str_replace(" ", "", Dict::GetUserLanguage());
 	}
 
 	protected function GetCacheClass() {
-		$lang = self::GetLanguge();
-		return "ExpressionCacheData" . $lang;
+		$sLang = self::GetLanguage();
+		return "ExpressionCacheData" . $sLang;
 	}
 
 	static public function GetCachedExpression($sClass, $sAttCode)
@@ -35,7 +35,7 @@ class ExpressionCache
 		// read current cache
 		@include_once (static::GetCacheFileName());
 
-		$className = self::GetCacheClass();
+		$sClassName = self::GetCacheClass();
 
 		$oExpr = null;
 		$sKey = static::GetKey($sClass, $sAttCode);
@@ -45,11 +45,11 @@ class ExpressionCache
 		}
 		else
 		{
-			if (class_exists($className))
+			if (class_exists($sClassName))
 			{
-				if (array_key_exists($sKey, $className::$aCache))
+				if (array_key_exists($sKey, $sClassName::$aCache))
 				{
-					$sVal = $className::$aCache[$sKey];
+					$sVal = $sClassName::$aCache[$sKey];
 					$oExpr = unserialize($sVal);
 					static::$aCache[$sKey] = $oExpr;
 				}
@@ -60,7 +60,7 @@ class ExpressionCache
 
 	static public function Warmup()
 	{
-		$className = self::GetCacheClass();
+		$sClassName = self::GetCacheClass();
 		$sFilePath = static::GetCacheFileName();
 
 		if (!is_file($sFilePath))
@@ -70,7 +70,7 @@ class ExpressionCache
 // Copyright (c) 2010-2017 Combodo SARL
 // Generated Expression Cache file
 
-class $className
+class $sClassName
 {
 	static \$aCache =  array(
 EOF;
@@ -112,8 +112,8 @@ EOF;
 
 	public static function GetCacheFileName()
 	{
-		$lang = self::GetLanguge();
-		return utils::GetCachePath().'expressioncache-' . $lang . '.php';
+		$sLang = self::GetLanguage();
+		return utils::GetCachePath().'expressioncache-' . $sLang . '.php';
 	}
 
 }

--- a/core/expressioncache.class.inc.php
+++ b/core/expressioncache.class.inc.php
@@ -21,10 +21,21 @@ class ExpressionCache
 {
 	static private $aCache = array();
 
+	protected function GetLanguge() {
+		return str_replace(" ", "", Dict::GetUserLanguage());
+	}
+
+	protected function GetCacheClass() {
+		$lang = self::GetLanguge();
+		return "ExpressionCacheData" . $lang;
+	}
+
 	static public function GetCachedExpression($sClass, $sAttCode)
 	{
 		// read current cache
 		@include_once (static::GetCacheFileName());
+
+		$className = self::GetCacheClass();
 
 		$oExpr = null;
 		$sKey = static::GetKey($sClass, $sAttCode);
@@ -34,11 +45,11 @@ class ExpressionCache
 		}
 		else
 		{
-			if (class_exists('ExpressionCacheData'))
+			if (class_exists($className))
 			{
-				if (array_key_exists($sKey, ExpressionCacheData::$aCache))
+				if (array_key_exists($sKey, $className::$aCache))
 				{
-					$sVal = ExpressionCacheData::$aCache[$sKey];
+					$sVal = $className::$aCache[$sKey];
 					$oExpr = unserialize($sVal);
 					static::$aCache[$sKey] = $oExpr;
 				}
@@ -47,9 +58,9 @@ class ExpressionCache
 		return $oExpr;
 	}
 
-
 	static public function Warmup()
 	{
+		$className = self::GetCacheClass();
 		$sFilePath = static::GetCacheFileName();
 
 		if (!is_file($sFilePath))
@@ -59,7 +70,7 @@ class ExpressionCache
 // Copyright (c) 2010-2017 Combodo SARL
 // Generated Expression Cache file
 
-class ExpressionCacheData
+class $className
 {
 	static \$aCache =  array(
 EOF;
@@ -101,7 +112,8 @@ EOF;
 
 	public static function GetCacheFileName()
 	{
-		return utils::GetCachePath().'expressioncache.php';
+		$lang = self::GetLanguge();
+		return utils::GetCachePath().'expressioncache-' . $lang . '.php';
 	}
 
 }

--- a/core/expressioncache.class.inc.php
+++ b/core/expressioncache.class.inc.php
@@ -34,14 +34,14 @@ class ExpressionCache
 	{
 		// read current cache
 		@include_once (static::GetCacheFileName());
-
+		$sLang = self::GetLanguage();
 		$sClassName = self::GetCacheClass();
 
 		$oExpr = null;
 		$sKey = static::GetKey($sClass, $sAttCode);
-		if (array_key_exists($sKey, static::$aCache))
+		if (array_key_exists($sLang, static::$aCache) && array_key_exists($sKey, static::$aCache[$sLang]))
 		{
-			$oExpr =  static::$aCache[$sKey];
+			$oExpr =  static::$aCache[$sLang][$sKey];
 		}
 		else
 		{
@@ -51,7 +51,7 @@ class ExpressionCache
 				{
 					$sVal = $sClassName::$aCache[$sKey];
 					$oExpr = unserialize($sVal);
-					static::$aCache[$sKey] = $oExpr;
+					static::$aCache[$sLang][$sKey] = $oExpr;
 				}
 			}
 		}

--- a/core/metamodel.class.php
+++ b/core/metamodel.class.php
@@ -6096,7 +6096,7 @@ abstract class MetaModel
             $oPHPClass::OnMetaModelStarted();
         }
 
-		ExpressionCache::Warmup();
+		//ExpressionCache::Warmup();
 	}
 
 	/**

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -357,6 +357,7 @@ try
 
 	require_once(APPROOT.'/application/loginwebpage.class.inc.php');
 	$sLoginMessage = LoginWebPage::DoLogin(); // Check user rights and prompt if needed
+	ExpressionCache::Warmup();
 	$oAppContext = new ApplicationContext();
 
 	$oKPI->ComputeAndReport('User login');


### PR DESCRIPTION
`Dict::GetUserLanguage()` get correct result only after `LoginWebPage::DoLogin()`, it made expressioncache always generated by default language(`EN US`), format define for `friendlyname` in other language will not work.

For example, default language is `EN US`, define
```php
// no Name define for EN US
Dict::Add('ZH CN', 'Chinese', '简体中文', array(
    'Class:ApplicationSolution/Name' => '%1$s / %2$s',
));
```
when user language is `ZH CN` , the format define above not work. It will display as default format `%1$s %2$s`