### PR TITLE
Add the ability to handle AttributeCustomFields for REST service

### DIFF
--- a/application/applicationextension.inc.php
+++ b/application/applicationextension.inc.php
@@ -1169,6 +1169,10 @@ class RestUtils
 				}
 				$value = DBObjectSet::FromArray($sLnkClass, $aLinks);
 			}
+			elseif ($oAttDef instanceof AttributeCustomFields)
+			{
+				$value = json_decode(json_encode($value), true);
+			}
             elseif ($oAttDef instanceof AttributeTagSet)
             {
                 if (!is_array($value))

--- a/core/restservices.class.inc.php
+++ b/core/restservices.class.inc.php
@@ -102,6 +102,10 @@ class ObjectResult
 					$value[] = $aLnkValues;
 				}
 			}
+			elseif ($oAttDef instanceof AttributeCustomFields)
+			{
+				$value = $oObject->Get($sAttCode)->GetValues();
+			}
 			else
 			{
 				$value = $oAttDef->GetForJSON($oObject->Get($sAttCode));


### PR DESCRIPTION
## Before 
rest api can not deal with `AttributeCustomFields`. For example, in extension [request-templates](https://www.itophub.io/wiki/page?id=extensions%3Arequest-templates) , defined a `AttributeCustomFields` named `service_details`, try to retrieve it, but return `NULL`
```php
$data = json_decode($iTopAPI->coreGet("UserRequest", $ID), true);
$Ticket = reset($data['objects']);
$service_details = $Ticket['fields']['service_details'];
if($service_details) {
	print_r($service_details['user_data']);
} else {
	var_dump($service_details);
}
```
can not get value of `service_details`
```bash
# ID=82 ./ticket_robot.php
NULL
```
## After
After fix, rest api will return value of `service_details`
```bash
# ID=82 ./ticket_robot.php 
Array
(
    [name] => fdss.test.com
    [businessprocess_id] => 15
)
```

## use case for this pr
I use `request-template` to deal with dns request  , use `service_details` value, I can use a script to auto insert new domain to iTop.