### PR TITLE
🔒 Adding more options to external authentication

### DIFF
--- a/.jenkins/configuration/default-environment/unattended_install/default-config-itop.php
+++ b/.jenkins/configuration/default-environment/unattended_install/default-config-itop.php
@@ -140,8 +140,15 @@ $MySettings = array(
 
 	'encryption_key' => '@iT0pEncr1pti0n!',
 
+	// ext_auth_variable: specify a PHP variable which contains the username when external authentication is used.
 	'ext_auth_variable' => '$_SERVER[\'REMOTE_USER\']',
 
+	// ext_auth_token_variable: specify a variable which contains the /authentication string/token when external authentication is used. For compatibility reasons, this is empty (=unused) by default.
+	'ext_auth_token_variable' => '',
+	
+	// ext_auth_url: specify a URL where the user should authenticate. For compatibility reasons, this is empty (=unused) by default.
+	'ext_auth_url' => '',
+	
 	'fast_reload_interval' => '60',
 
 	// graphviz_path: Path to the Graphviz "dot" executable for graphing objects lifecycle

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -65,6 +65,8 @@ define('DEFAULT_FAST_RELOAD_INTERVAL', 1 * 60);
 define('DEFAULT_SECURE_CONNECTION_REQUIRED', false);
 define('DEFAULT_ALLOWED_LOGIN_TYPES', 'form|basic|external');
 define('DEFAULT_EXT_AUTH_VARIABLE', '$_SERVER[\'REMOTE_USER\']');
+define('DEFAULT_EXT_AUTH_TOKEN_VARIABLE', ''); // For backward compatibility, this is empty by default.
+define('DEFAULT_EXT_AUTH_URL', ''); // For backward compatibility, this is empty by default.
 define('DEFAULT_ENCRYPTION_KEY', '@iT0pEncr1pti0n!'); // We'll use a random generated key later (if possible)
 define('DEFAULT_ENCRYPTION_LIB', 'Mcrypt'); // We'll define the best encryption available later
 /**
@@ -1273,10 +1275,20 @@ class Config
 	protected $m_sAllowedLoginTypes;
 
 	/**
-	 * @var string Name of the PHP variable in which external authentication information is passed by the web server
+	 * @var string Name of the PHP variable in which external authentication information (username) is passed by the web server
 	 */
 	protected $m_sExtAuthVariable;
 
+	/**
+	 * @var string Name of the PHP variable in which external authentication information (token) is passed by the web server
+	 */
+	protected $m_sExtAuthTokenVariable;
+	
+	/**
+	 * @var string Optional: external URL where user should authenticate.
+	 */
+	protected $m_sExtAuthUrl;
+		
 	/**
 	 * @var string Encryption key used for all attributes of type "encrypted string". Can be set to a random value
 	 *             unless you want to import a database from another iTop instance, in which case you must use
@@ -1336,6 +1348,8 @@ class Config
 		$this->m_sDefaultLanguage = 'EN US';
 		$this->m_sAllowedLoginTypes = DEFAULT_ALLOWED_LOGIN_TYPES;
 		$this->m_sExtAuthVariable = DEFAULT_EXT_AUTH_VARIABLE;
+		$this->m_sExtAuthTokenVariable = DEFAULT_EXT_AUTH_TOKEN_VARIABLE;
+		$this->m_sExtAuthUrl = DEFAULT_EXT_AUTH_URL;
 		$this->m_aCharsets = array();
 		$this->m_bQueryCacheEnabled = DEFAULT_QUERY_CACHE_ENABLED;
 
@@ -1489,6 +1503,8 @@ class Config
 		$this->m_sDefaultLanguage = isset($MySettings['default_language']) ? trim($MySettings['default_language']) : 'EN US';
 		$this->m_sAllowedLoginTypes = isset($MySettings['allowed_login_types']) ? trim($MySettings['allowed_login_types']) : DEFAULT_ALLOWED_LOGIN_TYPES;
 		$this->m_sExtAuthVariable = isset($MySettings['ext_auth_variable']) ? trim($MySettings['ext_auth_variable']) : DEFAULT_EXT_AUTH_VARIABLE;
+		$this->m_sExtAuthTokenVariable = isset($MySettings['ext_auth_token_variable']) ? trim($MySettings['ext_auth_token_variable']) : DEFAULT_EXT_AUTH_TOKEN_VARIABLE;
+		$this->m_sExtAuthUrl = isset($MySettings['ext_auth_url']) ? trim($MySettings['ext_auth_url']) : DEFAULT_EXT_AUTH_URL;
 		$this->m_sEncryptionKey = isset($MySettings['encryption_key']) ? trim($MySettings['encryption_key']) : $this->m_sEncryptionKey;
 		$this->m_sEncryptionLibrary = isset($MySettings['encryption_library']) ? trim($MySettings['encryption_library']) : $this->m_sEncryptionLibrary;
 		$this->m_aCharsets = isset($MySettings['csv_import_charsets']) ? $MySettings['csv_import_charsets'] : array();
@@ -1628,6 +1644,16 @@ class Config
 		return $this->m_sExtAuthVariable;
 	}
 
+	public function GetExternalAuthenticationTokenVariable()
+	{
+		return $this->m_sExtAuthTokenVariable;
+	}
+
+	public function GetExternalAuthenticationUrl()
+	{
+		return $this->m_sExtAuthUrl;
+	}
+	
 	public function GetCSVImportCharsets()
 	{
 		return $this->m_aCharsets;
@@ -1693,6 +1719,16 @@ class Config
 		$this->m_sExtAuthVariable = $sExtAuthVariable;
 	}
 
+	public function SetExternalAuthenticationTokenVariable($sExtAuthTokenVariable)
+	{
+		$this->m_sExtAuthTokenVariable = $sExtAuthTokenVariable;
+	}
+	
+	public function SetExternalAuthenticationUrl($sExtAuthUrl)
+	{
+		$this->m_sExtAuthUrl = $sExtAuthUrl;
+	}
+	
 	public function SetEncryptionKey($sKey)
 	{
 		$this->m_sEncryptionKey = $sKey;
@@ -1745,6 +1781,8 @@ class Config
 		$aSettings['default_language'] = $this->m_sDefaultLanguage;
 		$aSettings['allowed_login_types'] = $this->m_sAllowedLoginTypes;
 		$aSettings['ext_auth_variable'] = $this->m_sExtAuthVariable;
+		$aSettings['ext_auth_token_variable'] = $this->m_sExtAuthTokenVariable;
+		$aSettings['ext_auth_url'] = $this->m_sExtAuthUrl;
 		$aSettings['encryption_key'] = $this->m_sEncryptionKey;
 		$aSettings['encryption_library'] = $this->m_sEncryptionLibrary;
 		$aSettings['csv_import_charsets'] = $this->m_aCharsets;
@@ -1834,6 +1872,8 @@ class Config
 				'default_language' => $this->m_sDefaultLanguage,
 				'allowed_login_types' => $this->m_sAllowedLoginTypes,
 				'ext_auth_variable' => $this->m_sExtAuthVariable,
+				'ext_auth_token_variable' => $this->m_sExtAuthTokenVariable,
+				'ext_auth_url' => $this->m_sExtAuthUrl,
 				'encryption_key' => $this->m_sEncryptionKey,
 				'encryption_library' => $this->m_sEncryptionLibrary,
 				'csv_import_charsets' => $this->m_aCharsets,

--- a/datamodels/2.x/authent-external/en.dict.authent-external.php
+++ b/datamodels/2.x/authent-external/en.dict.authent-external.php
@@ -38,4 +38,6 @@
 Dict::Add('EN US', 'English', 'English', array(
 	'Class:UserExternal' => 'External user',
 	'Class:UserExternal+' => 'User authentified outside of iTop',
+	'Class:UserExternal/Attribute:token' => 'Token',
+	'Class:UserExternal/Attribute:token+' => 'User authentication string',
 ));

--- a/datamodels/2.x/authent-external/model.authent-external.php
+++ b/datamodels/2.x/authent-external/model.authent-external.php
@@ -42,16 +42,19 @@ class UserExternal extends User
 			"name_attcode" => "login",
 			"state_attcode" => "",
 			"reconc_keys" => array('login'),
-			"db_table" => "",
+			"db_table" => "priv_user_external",
 			"db_key_field" => "id",
 			"db_finalclass_field" => "",
 			"display_template" => "",
 		);
 		MetaModel::Init_Params($aParams);
 		MetaModel::Init_InheritAttributes();
+		
+		// Add token attribute
+		MetaModel::Init_AddAttribute(new AttributeOneWayPassword("token", array("allowed_values"=>null, "sql"=>"token", "default_value"=>null, "is_null_allowed"=>false, "depends_on"=>array())));
 
 		// Display lists
-		MetaModel::Init_SetZListItems('details', array('contactid', 'first_name', 'email', 'login', 'language', 'status', 'profile_list', 'allowed_org_list')); // Attributes to be displayed for the complete details
+		MetaModel::Init_SetZListItems('details', array('contactid', 'first_name', 'email', 'login', 'token', 'language', 'status', 'profile_list', 'allowed_org_list')); // Attributes to be displayed for the complete details
 		MetaModel::Init_SetZListItems('list', array('first_name', 'last_name', 'login', 'status')); // Attributes to be displayed for a list
 		// Search criteria
 		MetaModel::Init_SetZListItems('standard_search', array('login', 'contactid', 'status')); // Criteria of the std search form
@@ -59,14 +62,27 @@ class UserExternal extends User
 	}
 
 	/**
-	 * Check the user's password... always return true. Actually the password
-	 * is not even passed to this function, we trust the web server for authentifiying
-	 * the users
+	 * Check if authentication is valid. iTop Administrator determines whether iTop simply accepts the username (ext_auth_variable) or if validation is still needed (ext_auth_token_variable). 
 	 */
-	public function CheckCredentials($sPassword)
-	{
-		// External authentication: for iTop it's always Ok
-		return true;
+	public function CheckCredentials($sToken)
+	{ 
+		// If no ext_auth_token_variable is specified, always return 'true'
+		// This means that only the name needs to be passed through (default behavior)
+		if(MetaModel::GetConfig()->GetExternalAuthenticationTokenVariable() == '')
+		{
+			return true;
+		}
+		else 
+		{
+			$oPassword = $this->Get('token'); // ormPassword object
+			// Cannot compare directly the values since they are hashed.
+			// Let's use an internal function to check if the token is fine.
+			if ($oPassword->CheckPassword($sToken))
+			{
+				return true;
+			}
+			return false; 
+		}
 	}
 
 	public function TrustWebServerContext()

--- a/datamodels/2.x/authent-external/nl.dict.authent-external.php
+++ b/datamodels/2.x/authent-external/nl.dict.authent-external.php
@@ -36,4 +36,6 @@
 Dict::Add('NL NL', 'Dutch', 'Nederlands', array(
 	'Class:UserExternal' => 'Externe gebruiker',
 	'Class:UserExternal+' => 'Gebruiker aangemeld via externe authenticatie',
+	'Class:UserExternal/Attribute:token' => 'Token',
+	'Class:UserExternal/Attribute:token+' => 'Token of andere verificatiestring',
 ));


### PR DESCRIPTION
Extends **UserExternal** with two options. Currently only username is considered.

* ability to pass a token which will be validated (**optional** to be backward compatible)
* ability to specify an optional external URL login portal (used if the only authentication method is 'external' and user authentication within iTop fails)

---

* https://www.itophub.io/wiki/page?id=2_6_0%3Aadmin%3Auser_authentication_options 

I was a bit surprised to see an example where $_SERVER is not used, but $_COOKIE. Cookies can be easily manipulated. I'd at least recommend changing that to $_SESSION, but it may be vulnerable as well?

I can even imagine the easiest way to pass on information might still be to set a cookie in some cases, but then I think at least a second check (token) should be added. Hence the proposal to extend with an **optional** token-like variable. 

It's been tested before with the release/2.6 branch, I tried to find all things I changed and made a request now so it's open for discussion.

* Ticket: https://sourceforge.net/p/itop/tickets/1693/
* Thread: https://sourceforge.net/p/itop/discussion/1113906/thread/873dfa400c/