### PR TITLE
:bug: Synchro - Trigger - Before Update - dest_id could be null or equal to 0.

### DIFF
--- a/synchro/synchrodatasource.class.inc.php
+++ b/synchro/synchrodatasource.class.inc.php
@@ -844,7 +844,7 @@ EOF
 		$sTriggerUpdate .= "   FOR EACH ROW";
 		$sTriggerUpdate .= "   BEGIN";
 		$sTriggerUpdate .= "      IF @itopuser is null THEN";
-		$sTriggerUpdate .= "         UPDATE `{$sReplicaTable}` SET status_last_seen = NOW(), `status` = IF(`status` = 'obsolete', IF(`dest_id` IS NULL, 'new', 'modified'), IF(`status` IN ('synchronized') AND ($sIsModified), 'modified', `status`)) WHERE sync_source_id = {$this->GetKey()} AND id = OLD.id;";
+		$sTriggerUpdate .= "         UPDATE `{$sReplicaTable}` SET status_last_seen = NOW(), `status` = IF(`status` = 'obsolete', IF(`dest_id` IS NULL OR `dest_id` = 0, 'new', 'modified'), IF(`status` IN ('synchronized') AND ($sIsModified), 'modified', `status`)) WHERE sync_source_id = {$this->GetKey()} AND id = OLD.id;";
 		$sTriggerUpdate .= "         SET NEW.id = OLD.id;"; // make sure this id won't change
 		$sTriggerUpdate .= "      END IF;";
 		$sTriggerUpdate .= "   END;";

--- a/test/phpunit.xml.dist
+++ b/test/phpunit.xml.dist
@@ -50,6 +50,9 @@
         <testsuite name="Application">
             <directory>application</directory>
         </testsuite>
+        <testsuite name="Synchro">
+            <directory>synchro</directory>
+        </testsuite>
     </testsuites>
 
     <!-- Code coverage white list -->

--- a/test/synchro/SynchroDataSourceTest.php
+++ b/test/synchro/SynchroDataSourceTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Combodo\iTop\Test\UnitTest\Synchro;
+
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use CMDBSource;
+use MetaModel;
+use SynchroExecution;
+
+class SynchroDataSourceTest extends ItopDataTestCase
+{
+	// Need database COMMIT in order to create the FULLTEXT INDEX of MySQL
+	const USE_TRANSACTION = false;
+        
+        protected $sSynchroTrace = 'none';
+
+
+        public function testSynchroReplicaStatus()
+	{
+                $aParams = array(
+                    'name' => 'Test synchro replica status '.time(),
+                    'description' => 'unit test - created automatically',
+                    'status' => 'production',
+                    'scope_class' => 'OSFamily',
+                    'scope_restriction' => '',
+                    'full_load_periodicity' => '10',
+                    'delete_policy' => 'update',
+                    'delete_policy_update' => 'name:test_obsolescence'
+                );
+                
+		// Create the data source
+		$oSynchroDataSource = $this->createObject('SynchroDataSource', $aParams);
+                
+                //Create a replica from trigger
+                $sTable = $oSynchroDataSource->GetDataTable();
+	
+                $sSQL = "INSERT INTO `$sTable` (`primary_key`, `name`) VALUES ('test', 'test');";
+                CMDBSource::Query($sSQL);
+                
+                $oSynchroReplica = MetaModel::GetObjectByColumn('SynchroReplica', 'sync_source_id', $oSynchroDataSource->GetKey());
+                $this->assertEquals('new', $oSynchroReplica->Get('status'));
+                
+                //wait for the full load periodicity to be passed
+                sleep($aParams['full_load_periodicity'] + 5);
+                
+                //Remove log for this synchro
+                $oConfig = MetaModel::GetConfig();
+                $this->sSynchroTrace = $oConfig->Get('synchro_trace');
+                $oConfig->Set('synchro_trace', 'none');
+                MetaModel::LoadConfig($oConfig);
+                
+                //Launch synchro execution
+                $oSynchroExec = new SynchroExecution($oSynchroDataSource);
+                $oSynchroLog = $oSynchroExec->Process();
+                $this->assertEquals('completed', $oSynchroLog->Get('status'));
+                
+                $this->ReloadObject($oSynchroReplica);
+                $this->assertEquals('obsolete', $oSynchroReplica->Get('status'));
+	
+                //Update replica from trigger
+                $sSQL = "UPDATE `$sTable` SET `name` = 'test_2' WHERE `primary_key` = 'test';";
+                CMDBSource::Query($sSQL);
+                
+                $this->ReloadObject($oSynchroReplica);
+                $this->assertEquals('new', $oSynchroReplica->Get('status'));
+                
+                //Launch synchro execution
+                $oSynchroExec = new SynchroExecution($oSynchroDataSource);
+                $oSynchroLog = $oSynchroExec->Process();
+                $this->assertEquals('completed', $oSynchroLog->Get('status'));
+	}
+        
+        protected function tearDown() {
+            //Reset synchro_trace
+            $oConfig = MetaModel::GetConfig();
+            $oConfig->Set('synchro_trace', $this->sSynchroTrace);
+            MetaModel::LoadConfig($oConfig);
+            
+            parent::tearDown();
+        }
+}


### PR DESCRIPTION
A SynchroReplica dest_id is nullable but, as the default value in PHP for this field is 0, the TRIGGER BEFORE_UPDATE should check it as well.

A test for the bug is added as well. Here a manual test:
- Create a synchro, for example OSFamily (mine had id 10)
- Set the Full load interval to 30s (to avoid waiting to long for testing)
- Set to update the Delete policy and name:test_obsoleting the Update rules
- Create a new entry by SQL (`INSERT INTO synchro_data_osfamily_10(primary_key,name) VALUES ('test','test');`)
- Wait 40s (just to be sure)
- Check the SynchroReplica's status . Should be 'new' (`SELECT SynchroReplica WHERE sync_source_id = 10`)
- Launch a synchro_exec.php by cli/API (postman)
- Check the SynchroReplica's status . Should be 'obsolete'
- Update the entry by SQL (`UPDATE synchro_data_osfamily_10 SET name = 'test2345' WHERE primary_key = 'test';`)
- Check the SynchroReplica's status . Should be 'modified' with 'dest_id' equal to 0.
- Launch the synchro before the full load interval. It should raise an exception

The Synchro must but cannot find a object having id equal to 0.

> <p>#3071,Organization::0,>>> Beginning of SynchroReplica::Synchro, replica status is 'modified'.</p>
>         <p>ERROR: No result for the single row query: 'SELECT DISTINCT `OSFamily_typology`.`id` AS `OSFamilyid`, `OSFamily_typology`.`name` AS `OSFamilyname`, `OSFamily_typology`.`finalclass` AS `OSFamilyfinalclass`, CAST(CONCAT(COALESCE(`OSFamily_typology`.`name`, '')) AS CHAR) AS `OSFamilyfriendlyname` FROM `typology` AS `OSFamily_typology` WHERE ((`OSFamily_typology`.`id` = 0) AND COALESCE((`OSFamily_typology`.`finalclass` IN ('OSFamily')), 1))  '</p>

With checking if dest_id IS NULL OR dest_id = 0, the trigger will set the correct status.