### PR TITLE
Secure the server: prevent the users from browsing/getting files from…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
 
 # no slash at the end to handle also symlinks
 /toolkit
-/conf
 /env-*
+
+# listing prevention in conf directory
+/conf/**
+!/conf/.htaccess
+!/conf/index.php
+!/conf/web.config
 
 # composer reserver directory, from sources, populate/update using "composer install"
 vendor/*

--- a/conf/.htaccess
+++ b/conf/.htaccess
@@ -1,0 +1,13 @@
+# Apache 2.4
+<ifModule mod_authz_core.c>
+Require all denied
+</ifModule>
+
+# Apache 2.2
+<ifModule !mod_authz_core.c>
+deny from all
+Satisfy All
+</ifModule>
+
+# Apache 2.2 and 2.4
+IndexIgnore *

--- a/conf/index.php
+++ b/conf/index.php
@@ -1,0 +1,2 @@
+<?php
+echo 'Access denied';

--- a/conf/web.config
+++ b/conf/web.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <system.web>
+          <authorization>
+                  <deny users="*" /> <!-- Denies all users -->
+          </authorization>
+  </system.web>
+</configuration>


### PR DESCRIPTION
… the conf directories.

With Apache, it is still a must to enable htaccess with the spec "AllowOverride All". The index.php files are here to prevent from browsing whatever the HTTP server config.

Attention: I also modified the gitignore to not ignore whole conf. This means symlink for conf are not handled anymore.