### PR TITLE
:bug: composer.json dependencies correctness

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,6 @@
 {
   "require": {
     "php": ">=5.6.0",
-    "ext-mysql": "*",
-    "ext-ldap": "*",
-    "ext-mcrypt": "*",
-    "ext-cli": "*",
     "ext-soap": "*",
     "ext-json": "*",
     "ext-zip": "*",
@@ -12,6 +8,14 @@
     "ext-dom": "*",
     "ext-iconv": "*",
     "ext-gd": "*"
+  },
+  "suggest": {
+    "ext-libsodium": "Required to use the AttributeEncryptedString.",
+    "ext-openssl": "Can be used as a polyfill if libsodium is not installed",
+    "ext-mcrypt": "Can be used as a polyfill if either libsodium and openssl are not installed (libsodium and openssl are more secure)",
+    "ext-ldap": "Required to use LDAP as an identity provider",
+    "ext-posix": "Not required by the core, but some extensions uses it.",
+    "ext-imap": "Required by the extension \"Mail to ticket automation\""
   },
   "config": {
     "platform": {


### PR DESCRIPTION
Two dependencies which should not block composer are moved into the `suggest` block.
Several wrong dependencies are removed from `require`.
The `config` block was misused.

