### PR TITLE
Update cron.cmd

### DIFF
--- a/webservices/cron.cmd
+++ b/webservices/cron.cmd
@@ -2,17 +2,17 @@
 REM
 REM To be scheduled by the following command:
 REM
-REM schtasks /create /tn "iTop Cron" /sc minute /tr "\"C:\Program Files\EasyPHP-5.3.6.0\www\iTop-trunk\webservices\cron.cmd\""
+REM schtasks /create /tn "iTop Cron" /sc minute /tr "\"C:\www\iTop\webservices\cron.cmd\""
 REM
 REM
 REM PHP_PATH must point to php.exe, adjust the path to suit your own installation
-SET PHP_PATH=C:\Program Files\EasyPHP-5.3.6.0\php\php.exe
+SET PHP_PATH=%~f1
 REM PHP_INI must contain the full path to a PHP.ini file suitable for Command Line mode execution
-SET PHP_INI=C:\Program Files\EasyPHP-5.3.6.0\php\php-cli.ini
+SET PHP_INI=%~dp1php.ini
 REM The double dash (--) separates the parameters parsed by php.exe from the script's specific parameters
 REM %~p0 expands to the path to this file (including the trailing backslash)
-SET CRON_SCRIPT=%~p0cron.php
+SET CRON_SCRIPT=%~dp0cron.php
 REM Adjust the path below if you use a param files stored in a different location
-SET PARAMS_FILE=%~p0cron.params
+SET PARAMS_FILE=%~dp0cron.params
 REM Actual PHP invocation
-"%PHP_PATH%" -c "%PHP_INI%" -f "%CRON_SCRIPT%" -- --param_file="%PARAMS_FILE%" --verbose=1 >> "%~p0log.txt"
+"%PHP_PATH%" -c "%PHP_INI%" -f "%CRON_SCRIPT%" -- --param_file="%PARAMS_FILE%" --verbose=1 >> "%~dp0..\log\cron.log"

--- a/webservices/cron.cmd
+++ b/webservices/cron.cmd
@@ -5,14 +5,19 @@ REM
 REM schtasks /create /tn "iTop Cron" /sc minute /tr "\"C:\www\iTop\webservices\cron.cmd\""
 REM
 REM
-REM PHP_PATH must point to php.exe, adjust the path to suit your own installation
-SET PHP_PATH=%~f1
+REM PHP_COMMAND must point to php.exe, adjust the first to suit your own installation
+REM %~f1 expand the first argument to a fully qualified path name
+SET PHP_COMMAND=%~f1
 REM PHP_INI must contain the full path to a PHP.ini file suitable for Command Line mode execution
+REM %~dp1 expands to the path of the first argument (php command)
 SET PHP_INI=%~dp1php.ini
-REM The double dash (--) separates the parameters parsed by php.exe from the script's specific parameters
-REM %~p0 expands to the path to this file (including the trailing backslash)
-SET CRON_SCRIPT=%~dp0cron.php
+REM %~dp0 expands to the path to this file (including the trailing backslash)
+SET CRON_PATH=%~dp0
 REM Adjust the path below if you use a param files stored in a different location
-SET PARAMS_FILE=%~dp0cron.params
+SET PARAMS_FILE=%CRON_PATH%cron.params
+REM Adjust the path below if you want the log files stored in a different location
+SET LOG_FILE=%CRON_PATH%..\log\cron.log
+REM
 REM Actual PHP invocation
-"%PHP_PATH%" -c "%PHP_INI%" -f "%CRON_SCRIPT%" -- --param_file="%PARAMS_FILE%" --verbose=1 >> "%~dp0..\log\cron.log"
+REM The double dash (--) separates the parameters parsed by php.exe from the script's specific parameters
+"%PHP_COMMAND%" -c "%PHP_INI%" -f "%CRON_PATH%cron.php" -- --param_file="%PARAMS_FILE%" --verbose=1 >> "%LOG_FILE%"

--- a/webservices/cron.cmd
+++ b/webservices/cron.cmd
@@ -2,7 +2,7 @@
 REM
 REM To be scheduled by the following command:
 REM
-REM schtasks /create /tn "iTop Cron" /sc minute /tr "\"C:\www\iTop\webservices\cron.cmd\""
+REM schtasks /create /tn "iTop Cron" /sc minute /tr "C:\www\iTop\webservices\cron.cmd C:\php\php.exe"
 REM
 REM
 REM PHP_COMMAND must point to php.exe, adjust the first to suit your own installation


### PR DESCRIPTION
Updated the `cron.cmd` file so that an update of iTop does not require you to update this file afterwards. The location to `php.exe` is now an argument.

Also removes references to old and unsupported php version.