### PR TITLE
Make setup backup location and name similar as other backups

### DIFF
--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -460,11 +460,12 @@ class SetupUtils
 
 	/**
 	 * Check that the backup could be executed
-	 * @param $sDestDir
+	 * @param $sDBBackupPath
+	 * @param $sMySQLBinDir
 	 * @return array An array of CheckResults objects
 	 * @internal param Page $oP The page used only for its 'log' method
 	 */
-	static function CheckBackupPrerequisites($sDestDir, $sMySQLBinDir = null)
+	static function CheckBackupPrerequisites($sDBBackupPath, $sMySQLBinDir = null)
 	{
 		$aResult = array();
 		SetupPage::log('Info - CheckBackupPrerequisites');
@@ -528,6 +529,15 @@ class SetupUtils
 		foreach($aOutput as $sLine)
 		{
 			SetupPage::log('Info - mysqldump -V said: '.$sLine);
+		}
+		
+		// create and test destination location
+		//
+		$sDestDir = dirname($sDBBackupPath);
+		setuputils::builddir($sDestDir);
+		if (!is_dir($sDestDir))
+		{
+			$aResult[] = new CheckResult(CheckResult::ERROR, "$sDestDir does not exist and could not be created.");
 		}
 
 		// check disk space

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -220,7 +220,7 @@ class WizStepInstallOrUpgrade extends WizardStep
 		$sPreviousVersionDir = '';
 		if ($sInstallMode == '')
 		{
-			$sDBBackupPath = APPROOT.'data/'.ITOP_APPLICATION.strftime('-backup-%Y-%m-%d');
+			$sDBBackupPath = APPROOT.'data/backups/manual/__DB__-%Y-%m-%d_%H_%M';
 			$bDBBackup = true;
 			$aPreviousInstance = SetupUtils::GetPreviousInstance(APPROOT);
 			if ($aPreviousInstance['found'])

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -220,7 +220,7 @@ class WizStepInstallOrUpgrade extends WizardStep
 		$sPreviousVersionDir = '';
 		if ($sInstallMode == '')
 		{
-			$sDBBackupPath = APPROOT.'data/backups/manual/__DB__-%Y-%m-%d_%H_%M';
+			$sDBBackupPath = APPROOT.strftime('data/backups/manual/__DB__-%Y-%m-%d_%H_%M');
 			$bDBBackup = true;
 			$aPreviousInstance = SetupUtils::GetPreviousInstance(APPROOT);
 			if ($aPreviousInstance['found'])

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -220,7 +220,7 @@ class WizStepInstallOrUpgrade extends WizardStep
 		$sPreviousVersionDir = '';
 		if ($sInstallMode == '')
 		{
-			$sDBBackupPath = APPROOT.strftime('data/backups/manual/__DB__-%Y-%m-%d_%H_%M');
+			$sDBBackupPath = APPROOT.strftime('data/backups/manual/setup-%Y-%m-%d_%H_%M');
 			$bDBBackup = true;
 			$aPreviousInstance = SetupUtils::GetPreviousInstance(APPROOT);
 			if ($aPreviousInstance['found'])


### PR DESCRIPTION
As discussed in [#1309 Backup location during setup](https://sourceforge.net/p/itop/tickets/1309/), I have made a change so that the backup file that the setup generates is similar in naming convention as the backups created by the cron job.

I also included a check if the directory to place the backup exists.