### PR TITLE
Update Person list view

### DIFF
--- a/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
+++ b/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
@@ -833,7 +833,7 @@
         </search>
         <list>
           <items>
-            <item id="first_name">
+            <item id="name">
               <rank>10</rank>
             </item>
             <item id="org_id">


### PR DESCRIPTION
In the default data model, a list of persons has the columns friendly name, followed by first name. You can sort on both columns, but as friendly name also starts with the first name, it is not possible to sort by last name. Sorting by last name is  more logical in this context of persons, so I replaced the column `first_name` by `name` (the last name). By this, sorting on last name is possible.