### PR TITLE
:zap: Optimize Column load when using api core/get

### DIFF
--- a/core/restservices.class.inc.php
+++ b/core/restservices.class.inc.php
@@ -467,6 +467,12 @@ class CoreServices implements iRestServiceProvider
             }
 			else
 			{
+                                if (!$bExtendedOutput && RestUtils::GetOptionalParam($aParams, 'output_fields', '*') != '*') 
+                                {
+                                        $aAttToLoad = array($oObjectSet->GetClassAlias() => $aShowFields[$sClass]);
+                                        $oObjectSet->OptimizeColumnLoad($aAttToLoad);
+                                }
+                                
 				while ($oObject = $oObjectSet->Fetch())
 				{
 					$oResult->AddObject(0, '', $oObject, $aShowFields, $bExtendedOutput);

--- a/core/restservices.class.inc.php
+++ b/core/restservices.class.inc.php
@@ -469,7 +469,13 @@ class CoreServices implements iRestServiceProvider
 			{
                                 if (!$bExtendedOutput && RestUtils::GetOptionalParam($aParams, 'output_fields', '*') != '*') 
                                 {
-                                        $aAttToLoad = array($oObjectSet->GetClassAlias() => $aShowFields[$sClass]);
+                                        $aFields = $aShowFields[$sClass];
+                                        //Id is not a valid attribute to optimize
+                                        if (in_array('id', $aFields)) 
+                                        {
+                                            unset($aFields[array_search('id', $aFields)]);
+                                        }
+                                        $aAttToLoad = array($oObjectSet->GetClassAlias() => $aFields);
                                         $oObjectSet->OptimizeColumnLoad($aAttToLoad);
                                 }
                                 


### PR DESCRIPTION
Getting in SQL only desired columns to show
Used when output_fields != '*' || '*+'

When using to get 500 Server's name by a complex OQL, we reduce the delay to 
0.9s to 0.8s on the first query
Then 0.9s to 0.2s for the following (SQL cache)

Signed-off-by: Guy Couronné <gcouronne@sapiens.biz>