### PR TITLE
:memo: CONTRIBUTING : add a note on datamodel modifications

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,14 @@ You are welcome to create pull requests on any of those subjects:
 If you want to implement a **new feature**, please [create a corresponding ticket](https://sourceforge.net/p/itop/tickets/new/) for review.   
 If you ever want to begin implementation, do so in a fork, and add a link to the corresponding commits in the ticket.
 
-Please do so also if you need **default datamodel modifications**. 
-Such changes would impact all existing customers, and could prevent them from upgrading. 
+All **datamodel modification** should be done in an extension. Beware that such change would 
+impact all existing customers, and could prevent them from 
+upgrading!
 Combodo has a long experience of datamodel changes: they are very disruptive! 
-This is why we avoid them in iTop core, especially the changes on existing object/field. 
+This is why we avoid them in iTop core, especially the changes on existing objects/fields.   
+If you have an idea you're sure would benefit to all of iTop users, you may 
+[create a corresponding ticket](https://sourceforge.net/p/itop/tickets/new/) to submit it, but be warned that there are lots of good 
+reasons to refuse such changes.
 
 ### License
 iTop is distributed under the AGPL-3.0 license (see the [license.txt] file),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,11 @@ You are welcome to create pull requests on any of those subjects:
 If you want to implement a **new feature**, please [create a corresponding ticket](https://sourceforge.net/p/itop/tickets/new/) for review.   
 If you ever want to begin implementation, do so in a fork, and add a link to the corresponding commits in the ticket.
 
+Please do so also if you need **default datamodel modifications**. 
+Such changes would impact all existing customers, and could prevent them from upgrading. 
+Combodo has a long experience of datamodel changes : they are very disruptive ! 
+This is why we avoid them in iTop core, especially the changes on existing object/field. 
+
 ### License
 iTop is distributed under the AGPL-3.0 license (see the [license.txt] file),
 your code must comply with this license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ If you ever want to begin implementation, do so in a fork, and add a link to the
 
 Please do so also if you need **default datamodel modifications**. 
 Such changes would impact all existing customers, and could prevent them from upgrading. 
-Combodo has a long experience of datamodel changes : they are very disruptive ! 
+Combodo has a long experience of datamodel changes: they are very disruptive! 
 This is why we avoid them in iTop core, especially the changes on existing object/field. 
 
 ### License


### PR DESCRIPTION
As we saw for example on PR #51, there are really few datamodel modifications that we could allow.
So we should suggest not to create PR for such modifications !
This is my proposition to adapt the CONTRIBUTING file.