### PR TITLE
:bug: Sort tables when modifying links

### DIFF
--- a/js/jquery.tablesorter.js
+++ b/js/jquery.tablesorter.js
@@ -299,14 +299,29 @@
 
                 if (!node) return "";
 
-                if (!config.supportsTextContent) config.supportsTextContent = node.textContent || false;
+                if (!config.supportsTextContent) config.supportsTextContent = ( node.textContent == node.innerHTML ? node.textContent : false );
 
                 if (config.textExtraction == "simple") {
                     if (config.supportsTextContent) {
                         text = node.textContent;
                     } else {
                         if (node.childNodes[0] && node.childNodes[0].hasChildNodes()) {
-                            text = node.childNodes[0].innerHTML;
+							// User is editing links (example: relations between Network Devices)
+							// Set default fallback to textContent (as before), then check for editions (text inputs, selects) and retrieve the values
+							text = node.textContent;
+							if( $('.attribute-edit', node).length == 1 ) {
+								if( $('.attribute-edit select', node).length == 1 ) {
+									text = $('.attribute-edit select', node).val();
+								}
+									
+								if( $('.attribute-edit input', node).length == 1 ) {
+									text = $('.attribute-edit input', node).val();
+								}
+							}
+							else {
+								text = node.childNodes[0].innerHTML;
+							}
+							
                         } else {
                             text = node.innerHTML;
                         }


### PR DESCRIPTION
Fixes sort issue when modifying links (sort is not working when you edit links between objects, such as NetworkDevice to NetworkDevice)

This pull request takes into account the value which is set for input (text) and select elements, rather than textContent.

I only adjusted the "full" version of the JavaScript library, which seems to be used in the console. No adjustments to the minified version.