### PR TITLE
Add support to optionally mention username in password reset mail

### DIFF
--- a/application/loginwebpage.class.inc.php
+++ b/application/loginwebpage.class.inc.php
@@ -267,7 +267,7 @@ class LoginWebPage extends NiceWebPage
 			$oEmail->SetRecipientFrom($sFrom);
 			$oEmail->SetSubject(Dict::S('UI:ResetPwd-EmailSubject'));
 			$sResetUrl = utils::GetAbsoluteUrlAppRoot().'pages/UI.php?loginop=reset_pwd&auth_user='.urlencode($oUser->Get('login')).'&token='.urlencode($sToken);
-			$oEmail->SetBody(Dict::Format('UI:ResetPwd-EmailBody', $sResetUrl));
+			$oEmail->SetBody(Dict::Format('UI:ResetPwd-EmailBody', $sResetUrl, $oUser->Get('login')));
 			$iRes = $oEmail->Send($aIssues, true /* force synchronous exec */);
 			switch ($iRes)
 			{

--- a/application/loginwebpage.class.inc.php
+++ b/application/loginwebpage.class.inc.php
@@ -265,7 +265,7 @@ class LoginWebPage extends NiceWebPage
 			$oEmail->SetRecipientTO($sTo);
 			$sFrom = MetaModel::GetConfig()->Get('forgot_password_from');
 			$oEmail->SetRecipientFrom($sFrom);
-			$oEmail->SetSubject(Dict::S('UI:ResetPwd-EmailSubject'));
+			$oEmail->SetSubject(Dict::S('UI:ResetPwd-EmailSubject', $oUser->Get('login')));
 			$sResetUrl = utils::GetAbsoluteUrlAppRoot().'pages/UI.php?loginop=reset_pwd&auth_user='.urlencode($oUser->Get('login')).'&token='.urlencode($sToken);
 			$oEmail->SetBody(Dict::Format('UI:ResetPwd-EmailBody', $sResetUrl, $oUser->Get('login')));
 			$iRes = $oEmail->Send($aIssues, true /* force synchronous exec */);


### PR DESCRIPTION
Currently the password reset mail only adds the password reset url (which also includes the username).

If someone wants to modify the `UI:ResetPwd-EmailBody` dictionary, and also include the username into the text, it is not possible without change of iTop code. It is even not possible to change by extension.

So I have added extra parameter `%2$s` which will be replaced by the user login.
(Maybe also add the Person friendly name as option?)

This change does not impact current dictionary or reset mail.