### PR TITLE
:recycle: N°2222 Make ticket reference generation working with new sub-classes

### DIFF
--- a/datamodels/2.x/itop-change-mgmt-itil/datamodel.itop-change-mgmt-itil.xml
+++ b/datamodels/2.x/itop-change-mgmt-itil/datamodel.itop-change-mgmt-itil.xml
@@ -902,6 +902,17 @@
         </states>
       </lifecycle>
       <methods>
+				<method id="GetTicketRefFormat">
+					<static>true</static>
+					<access>public</access>
+					<type>Overload-DBObject</type>
+					<code><![CDATA[
+        public static function GetTicketRefFormat()
+        {
+                return 'C-%06d';
+        }
+        ]]></code>
+				</method>
         <method id="SetClosureDate">
           <comment><![CDATA[/**
 	 * To be deprecated: use SetCurrentDate() instead

--- a/datamodels/2.x/itop-change-mgmt/datamodel.itop-change-mgmt.xml
+++ b/datamodels/2.x/itop-change-mgmt/datamodel.itop-change-mgmt.xml
@@ -452,6 +452,17 @@
                 </states>
             </lifecycle>
             <methods>
+				<method id="GetTicketRefFormat">
+					<static>true</static>
+					<access>public</access>
+					<type>Overload-DBObject</type>
+					<code><![CDATA[
+        public static function GetTicketRefFormat()
+        {
+                return 'C-%06d';
+        }
+        ]]></code>
+				</method>
                 <method id="SetApprovalDate">
                     <comment><![CDATA[/**
 	 * To be deprecated: use SetCurrentDate() instead

--- a/datamodels/2.x/itop-incident-mgmt-itil/datamodel.itop-incident-mgmt-itil.xml
+++ b/datamodels/2.x/itop-incident-mgmt-itil/datamodel.itop-incident-mgmt-itil.xml
@@ -947,6 +947,17 @@
 				</states>
 			</lifecycle>
 			<methods>
+				<method id="GetTicketRefFormat">
+					<static>true</static>
+					<access>public</access>
+					<type>Overload-DBObject</type>
+					<code><![CDATA[
+        public static function GetTicketRefFormat()
+        {
+                return 'I-%06d';
+        }
+        ]]></code>
+				</method>
 				<method id="SetAssignedDate">
 					<comment><![CDATA[/**
 	 * To be deprecated: use SetCurrentDate() instead

--- a/datamodels/2.x/itop-problem-mgmt/datamodel.itop-problem-mgmt.xml
+++ b/datamodels/2.x/itop-problem-mgmt/datamodel.itop-problem-mgmt.xml
@@ -362,6 +362,17 @@
                 </states>
             </lifecycle>
             <methods>
+				<method id="GetTicketRefFormat">
+					<static>true</static>
+					<access>public</access>
+					<type>Overload-DBObject</type>
+					<code><![CDATA[
+        public static function GetTicketRefFormat()
+        {
+                return 'P-%06d';
+        }
+        ]]></code>
+				</method>
                 <method id="SetAssignedDate">
                     <comment><![CDATA[/**
 	 * To be deprecated: use SetCurrentDate() instead

--- a/datamodels/2.x/itop-request-mgmt-itil/datamodel.itop-request-mgmt-itil.xml
+++ b/datamodels/2.x/itop-request-mgmt-itil/datamodel.itop-request-mgmt-itil.xml
@@ -1074,6 +1074,17 @@
 				</states>
 			</lifecycle>
 			<methods>
+				<method id="GetTicketRefFormat">
+					<static>true</static>
+					<access>public</access>
+					<type>Overload-DBObject</type>
+					<code><![CDATA[
+        public static function GetTicketRefFormat()
+        {
+                return 'R-%06d';
+        }
+        ]]></code>
+				</method>
 				<method id="SetAssignedDate">
 					<comment><![CDATA[/**
 	 * To be deprecated: use SetCurrentDate() instead

--- a/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
+++ b/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
@@ -1086,6 +1086,17 @@
                 </states>
             </lifecycle>
             <methods>
+				<method id="GetTicketRefFormat">
+					<static>true</static>
+					<access>public</access>
+					<type>Overload-DBObject</type>
+					<code><![CDATA[
+        public static function GetTicketRefFormat()
+        {
+                return 'R-%06d';
+        }
+        ]]></code>
+				</method>
                 <method id="SetAssignedDate">
                     <comment><![CDATA[/**
 	 * To be deprecated: use SetCurrentDate() instead

--- a/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
+++ b/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
@@ -223,28 +223,18 @@
 					<code><![CDATA[
         protected function MakeTicketRef($iNextId)
         {
-                switch(true)
-                {
-                        case $this instanceof UserRequest:
-                        $sFormat = 'R-%06d';
-                        break;
-
-                        case $this instanceof Incident:
-                        $sFormat = 'I-%06d';
-                        break;
-
-                        case $this instanceof Change:
-                        $sFormat = 'C-%06d';
-                        break;
-
-                        case $this instanceof Problem:
-                        $sFormat = 'P-%06d';
-                        break;
-
-                        default:
-                        $sFormat = 'T-%06d';
-                }
-                return sprintf($sFormat, $iNextId);
+                return sprintf(static::GetTicketRefFormat(), $iNextId);
+        }
+        ]]></code>
+				</method>
+				<method id="GetTicketRefFormat">
+					<static>true</static>
+					<access>public</access>
+					<type>Overload-DBObject</type>
+					<code><![CDATA[
+        public static function GetTicketRefFormat()
+        {
+                return 'T-%06d';
         }
         ]]></code>
 				</method>

--- a/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
+++ b/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
@@ -223,24 +223,21 @@
 					<code><![CDATA[
         protected function MakeTicketRef($iNextId)
         {
-                switch(get_class($this))
+                switch(true)
                 {
-                        case 'UserRequest':
+                        case $this instanceof UserRequest:
                         $sFormat = 'R-%06d';
                         break;
 
-                        case 'Incident':
+                        case $this instanceof Incident:
                         $sFormat = 'I-%06d';
                         break;
 
-                        case 'Change':
-                        case 'RoutineChange':
-                        case 'EmergencyChange':
-                        case 'NormalChange':
+                        case $this instanceof Change:
                         $sFormat = 'C-%06d';
                         break;
 
-                        case 'Problem':
+                        case $this instanceof Problem:
                         $sFormat = 'P-%06d';
                         break;
 


### PR DESCRIPTION
When extending the default datamodel, sub-classes of UserRequest or Change for example will not have a corresponding reference (eg. R-12345 or C-12345) but the one from the default class (T-12345). This fixes this by checking is the current object is derivated from a class instead of checking the current class itself.