### PR TITLE
Fix cron crash when MySQL connection lost

### DIFF
--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -591,6 +591,22 @@ catch (Exception $e)
 		$oP->p($e->getTraceAsString());
 	}
 }
+finally
+{
+	try
+	{
+		unset($oMutex);
+	}
+	catch (Exception $e)
+	{
+		$oP->p("ERROR: '".$e->getMessage()."'");
+		if ($bDebug)
+		{
+			// Might contain verb parameters such a password...
+			$oP->p($e->getTraceAsString());
+		}
+	}
+}
 
 $oP->p("Exiting: ".time().' ('.date('Y-m-d H:i:s').')');
 

--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -573,8 +573,6 @@ try
 		}
 
 		CronExec($oP, $aProcesses, $bVerbose);
-
-		$oMutex->Unlock();
 	}
 	else
 	{
@@ -595,7 +593,7 @@ finally
 {
 	try
 	{
-		unset($oMutex);
+		$oMutex->Unlock();
 	}
 	catch (Exception $e)
 	{


### PR DESCRIPTION
Currently, cron.php crashes with "PHP Fatal error:  Uncaught Exception" when for example MySQL stops working during `CronExec`.

The first thrown exception is correctly catched, but after all code, the `iTopMutex` class does execute it's `__destruct` method which is doing a `RELEASE_LOCK` on the DB, which then results in an exception being throwed.

When you unset the mutex object in a try catch, this is cleaner.