### PR TITLE
🐛 N°2182 Fix default usage of iTopMutex when TLS is enabled

### DIFF
--- a/core/mutex.class.inc.php
+++ b/core/mutex.class.inc.php
@@ -45,7 +45,7 @@ class iTopMutex
 	static protected $aAcquiredLocks = array(); // Number of instances of the Mutex, having the lock, in this page
 
 	public function __construct(
-		$sName, $sDBHost = null, $sDBUser = null, $sDBPwd = null, $bDBTlsEnabled = false, $sDBTlsCA = null
+		$sName, $sDBHost = null, $sDBUser = null, $sDBPwd = null, $bDBTlsEnabled = null, $sDBTlsCA = null
 	)
 	{
 		// Compute the name of a lock for mysql


### PR DESCRIPTION
When MySQL is configured to only allow SSL connections, the _itop-backup status.php_ page throws an error. I could track it down to the _iTopMutex_ constructor defaulting `$bDBTlsEnabled` to `false`.

There might be other places where the same problem occurs as it also seems to be a problem on the setup page.

Impacted: iTop 2.5 & 2.6