### PR TITLE
Add html5 time tag when displaying attributes with date information

### DIFF
--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -5534,7 +5534,7 @@ class AttributeDateTime extends AttributeDBField
 
 	public function GetAsHTML($value, $oHostObject = null, $bLocalize = true)
 	{
-		return Str::pure2html(static::GetFormat()->format($value));
+		return sprintf('<time datetime="%s">%s</time>', $value, Str::pure2html(static::GetFormat()->format($value)));
 	}
 
 	public function GetAsXML($value, $oHostObject = null, $bLocalize = true)

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -7968,7 +7968,7 @@ class AttributeStopWatch extends AttributeDefinition
 		switch ($sItemCode)
 		{
 			case 'timespent':
-				$sHtml = Str::pure2html(AttributeDuration::FormatDuration($value));
+				$sHtml = sprintf('<time datetime="PT%dS">%s</time>', $value, Str::pure2html(AttributeDuration::FormatDuration($value)));
 				break;
 			case 'started':
 			case 'laststart':
@@ -7979,10 +7979,9 @@ class AttributeStopWatch extends AttributeDefinition
 				}
 				else
 				{
-					$oDateTime = new DateTime();
-					$oDateTime->setTimestamp($value);
+					$sDate = static::SecondsToDate($value);
 					$oDateTimeFormat = AttributeDateTime::GetFormat();
-					$sHtml = Str::pure2html($oDateTimeFormat->Format($oDateTime));
+					$sHtml = sprintf('<time datetime="%s">%s</time>', $sDate, Str::pure2html($oDateTimeFormat->Format($sDate)));
 				}
 				break;
 
@@ -7999,8 +7998,8 @@ class AttributeStopWatch extends AttributeDefinition
 							case 'deadline':
 								if ($value)
 								{
-									$sDate = date(AttributeDateTime::GetInternalFormat(), $value);
-									$sHtml = Str::pure2html(AttributeDeadline::FormatDeadline($sDate));
+									$sDate = static::SecondsToDate($value);
+									$sHtml = sprintf('<time datetime="%s">%s</time>', $sDate, Str::pure2html(AttributeDeadline::FormatDeadline($sDate)));
 								}
 								else
 								{
@@ -8012,7 +8011,7 @@ class AttributeStopWatch extends AttributeDefinition
 								$sHtml = $this->GetBooleanLabel($value);
 								break;
 							case 'overrun':
-								$sHtml = Str::pure2html(AttributeDuration::FormatDuration($value));
+								$sHtml = sprintf('<time datetime="PT%dS">%s</time>', $value, Str::pure2html(AttributeDuration::FormatDuration($value)));
 								break;
 						}
 					}

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -5900,7 +5900,7 @@ class AttributeDeadline extends AttributeDateTime
 	{
 		$sResult = self::FormatDeadline($value);
 
-		return $sResult;
+		return sprintf('<time datetime="%s">%s</time>', $value, Str::pure2html($sResult));
 	}
 
 	public static function FormatDeadline($value)

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -5727,7 +5727,7 @@ class AttributeDuration extends AttributeInteger
 
 	public function GetAsHTML($value, $oHostObject = null, $bLocalize = true)
 	{
-		return Str::pure2html(self::FormatDuration($value));
+		return sprintf('<time datetime="PT%dS">%s</time>', $value, Str::pure2html(self::FormatDuration($value)));
 	}
 
 	public static function FormatDuration($duration)

--- a/core/ormstopwatch.class.inc.php
+++ b/core/ormstopwatch.class.inc.php
@@ -198,6 +198,11 @@ class ormStopWatch
 		return $sCode;
 	}
 
+	/**
+	 * @param \AttributeStopWatch $oAttDef
+	 * @param \DBObject $oHostObject
+	 * @return string
+	 */
 	public function GetAsHTML($oAttDef, $oHostObject = null)
 	{
 		$aProperties = array();
@@ -219,14 +224,21 @@ class ormStopWatch
 		{
 			$aProperties['Elapsed'] = 'running <img src="../images/indicator.gif">';
 		}
+		
+		$oDateTimeFormat = AttributeDateTime::GetFormat();
+		$sHtml5Time = '<time datetime="%s">%s</time>';
 
-		$aProperties['Started'] = $oAttDef->SecondsToDate($this->iStarted);
-		$aProperties['LastStart'] = $oAttDef->SecondsToDate($this->iLastStart);
-		$aProperties['Stopped'] = $oAttDef->SecondsToDate($this->iStopped);
+		$sStarted = $oAttDef->SecondsToDate($this->iStarted);
+		$aProperties['Started'] = is_null($sStarted)?'':sprintf($sHtml5Time, $sStarted, str::pure2html($oDateTimeFormat->Format($sStarted)));
+		$sLastStart = $oAttDef->SecondsToDate($this->iLastStart);
+		$aProperties['LastStart'] = is_null($sLastStart)?'':sprintf($sHtml5Time, $sLastStart, str::pure2html($oDateTimeFormat->Format($sLastStart)));
+		$sStopped = $oAttDef->SecondsToDate($this->iStopped);
+		$aProperties['Stopped'] = is_null($sStopped)?'':sprintf($sHtml5Time, $sStopped, str::pure2html($oDateTimeFormat->Format($sStopped)));
 
 		foreach ($this->aThresholds as $iPercent => $aThresholdData)
 		{
-			$sThresholdDesc = $oAttDef->SecondsToDate($aThresholdData['deadline']);
+			$sThresholdDeadline = $oAttDef->SecondsToDate($aThresholdData['deadline']);
+			$sThresholdDesc = sprintf($sHtml5Time, $sThresholdDeadline, str::pure2html($oDateTimeFormat->Format($sThresholdDeadline)));
 			if ($aThresholdData['triggered'])
 			{
 				$sThresholdDesc .= " <b>TRIGGERED</b>";


### PR DESCRIPTION
This introduces useful machine readable date/time information, to be used by browser or other extensions.

[W3](https://www.w3.org/TR/2011/WD-html5-author-20110705/the-time-element.html)
[Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)