### PR TITLE
add ctype as required php extension

### DIFF
--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -105,6 +105,7 @@ class SetupUtils
 			'zlib',
 			'zip',
 			'gd', // test image type (always returns false if not installed), image resizing, PDF export
+			'ctype', // for iTop Portal 
 		);
 		$aOptionalExtensions = array(
 			'mcrypt, sodium or openssl' =>


### PR DESCRIPTION
Hi Guys

ctype is not in every php build integrated (for example like alpine).

cheers, Kevä
