### PR TITLE
:memo: iTop security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,12 @@ Here are some guidelines that will help us integrate your work!
 You are welcome to create pull requests on any of those subjects:
 
 * 🐛 `:bug:` bug fix
-* 🔒 `:lock:` security
 * 🌐 `:globe_with_meridians:` translation / i18n / l10n
 
 If you want to implement a **new feature**, please [create a corresponding ticket](https://sourceforge.net/p/itop/tickets/new/) for review.   
 If you ever want to begin implementation, do so in a fork, and add a link to the corresponding commits in the ticket.
+
+For all security related subjects, please see our [security policy](SECURITY.md).
 
 All **datamodel modification** should be done in an extension. Beware that such change would 
 impact all existing customers, and could prevent them from 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ Report security bugs in third-party modules to the person or team maintaining th
 
 ## 📆 Disclosure Policy
 
-Report sent to us will be acknowledge within the week. Then, a developer will be assigned to it and will:
+Report sent to us will be acknowledge within the week. Then, a Combodo developer will be assigned to it and will:
 
 * confirm the problem and determine the affected versions
 * audit the code to find any potential similar problems

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # 🔒 Reporting vulnerabilities
 
-We take all security bugs seriously. Thank you for improving the security of iTop ! We appreciate your efforts and
+We take all security bugs seriously. Thank you for improving the security of iTop! We appreciate your efforts and
 responsible disclosure and will make every effort to acknowledge your contributions.
 
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,30 +7,30 @@ responsible disclosure and will make every effort to acknowledge your contributi
 ## ✉️ How to report
 
 ### iTop vulnerabilities
-Please send a procedure to reproduce iTop vulnerabilities to itop-security@combodo.com.
+Please send a procedure to reproduce iTop vulnerabilities to [itop-security@combodo.com](mailto:itop-security@combodo.com).
 
-You can send us a standard given / then / when report, including iTop version, impacts, and maybe installed modules or datas if they are 
+You can send us a standard "given / then / when" report, including iTop version, impacts, and maybe installed modules or data if they are 
 needed to reproduce.
 
 ### Dependencies vulnerabilities
-Report security bugs in third-party modules to the person or team maintaining the module, and notify us of this report by sending a mail 
-to itop-security@combodo.com.
+Report security bugs in third-party modules to the person or team maintaining the module, and notify us of this report by sending an email 
+to [itop-security@combodo.com](mailto:itop-security@combodo.com).
 
 
 
 ## 📆 Disclosure Policy
 
-Report sent to us will be acknowledge within the week.
+Report sent to us will be acknowledged within the week.
 
-Then, a Combodo developer will be assigned to it and will:
+Then, a Combodo developer will be assigned to the reported issue and will:
 
-* confirm the problem and determine the affected versions
-* audit the code to find any potential similar problems
-* try to find workaround if any
+* confirm the problem and determine the affected iTop versions
+* audit the code to search any potential similar problems
+* try to find a workaround if any
 * create fixes for all releases still under maintenance
 * send you the commit(s) for review
 * send you the next version(s) that will contain the fix, and the estimated release dates
 
 Security issues always take precedence over bug fixes and feature work.
 
-The assignee will keep you informed of the work progress, and may ask for additional information or guidance.
+The assignee will keep you informed of the resolution progress, and may ask you for additional information or guidance.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ responsible disclosure and will make every effort to acknowledge your contributi
 ## ✉️ How to report
 
 ### iTop vulnerabilities
-Please send iTop vulnerabilities a procedure to reproduce to security@combodo.com.
+Please send a procedure to reproduce iTop vulnerabilities to security@combodo.com.
 
 You can send us a standard given / then / when, including iTop version, impacts, and maybe installed modules or datas if they are needed to reproduce.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ Report security bugs in third-party modules to the person or team maintaining th
 
 ## 📆 Disclosure Policy
 
-Report sent to us will be acknowledge within the week. Then, a developer will be assigned to it and will :
+Report sent to us will be acknowledge within the week. Then, a developer will be assigned to it and will:
 
 * confirm the problem and determine the affected versions
 * audit the code to find any potential similar problems

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# 🔒 Reporting vulnerabilities
+
+We take all security bugs seriously. Thank you for improving the security of iTop ! We appreciate your efforts and
+responsible disclosure and will make every effort to acknowledge your contributions.
+
+
+## ✉️ How to report
+
+### iTop vulnerabilities
+Please send iTop vulnerabilities a procedure to reproduce to security@combodo.com.
+
+You can send us a standard given / then / when, including iTop version, impacts, and maybe installed modules or datas if they are needed to reproduce.
+
+### Dependencies vulnerabilities
+Report security bugs in third-party modules to the person or team maintaining the module, and notify us of the report by sending a mail to security@combodo.com.
+
+
+
+## 📆 Disclosure Policy
+
+Report sent to us will be acknowledge within the week. Then, a developer will be assigned to it and will :
+
+* confirm the problem and determine the affected versions
+* audit the code to find any potential similar problems
+* try to find workaround if any
+* create an official report as draft, crediting you as vulnerability finder
+* prepare fixes for all releases still under maintenance
+* send communications to customers, publish official report
+
+Security issues always take precedence over bug fixes and feature work.
+
+The assignee will keep you informed of the work progress, and may ask for additional information or guidance.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,25 +7,29 @@ responsible disclosure and will make every effort to acknowledge your contributi
 ## ✉️ How to report
 
 ### iTop vulnerabilities
-Please send a procedure to reproduce iTop vulnerabilities to security@combodo.com.
+Please send a procedure to reproduce iTop vulnerabilities to itop-security@combodo.com.
 
-You can send us a standard given / then / when, including iTop version, impacts, and maybe installed modules or datas if they are needed to reproduce.
+You can send us a standard given / then / when report, including iTop version, impacts, and maybe installed modules or datas if they are 
+needed to reproduce.
 
 ### Dependencies vulnerabilities
-Report security bugs in third-party modules to the person or team maintaining the module, and notify us of the report by sending a mail to security@combodo.com.
+Report security bugs in third-party modules to the person or team maintaining the module, and notify us of this report by sending a mail 
+to itop-security@combodo.com.
 
 
 
 ## 📆 Disclosure Policy
 
-Report sent to us will be acknowledge within the week. Then, a Combodo developer will be assigned to it and will:
+Report sent to us will be acknowledge within the week.
+
+Then, a Combodo developer will be assigned to it and will:
 
 * confirm the problem and determine the affected versions
 * audit the code to find any potential similar problems
 * try to find workaround if any
-* create an official report as draft, crediting you as vulnerability finder
-* prepare fixes for all releases still under maintenance
-* send communications to customers, publish official report
+* create fixes for all releases still under maintenance
+* send you the commit(s) for review
+* send you the next version(s) that will contain the fix, and the estimated release dates
 
 Security issues always take precedence over bug fixes and feature work.
 


### PR DESCRIPTION
GitHub doc reference : https://help.github.com/en/categories/managing-security-vulnerabilities

Some examples :
https://github.com/electron/electron/blob/master/SECURITY.md
https://github.com/standard/standard/blob/master/SECURITY.md
https://github.com/TryGhost/Ghost/blob/master/SECURITY.md
https://github.com/symfony/symfony/security/policy

We should create security@combodo.com !

This will be reviewed by both R&D and products team.