### PR TITLE
:bug: iTop stuck in setup (realpath issue) (SF 1817)

### DIFF
--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -840,7 +840,7 @@ class utils
 
 		$sCurrentScript = realpath($_SERVER['SCRIPT_FILENAME']);
 		$sCurrentScript = str_replace('\\', '/', $sCurrentScript); // canonical path
-		$sAppRoot = str_replace('\\', '/', APPROOT); // canonical path
+		$sAppRoot = str_replace('\\', '/', realpath(APPROOT)); // canonical path
 		$sCurrentRelativePath = str_replace($sAppRoot, '', $sCurrentScript);
 	
 		$sAppRootPos = strpos($sAbsoluteUrl, $sCurrentRelativePath);


### PR DESCRIPTION
* fixes (Windows) issue where realpath returns lowercase path, causing str_replace to fail

---

SF https://sourceforge.net/p/itop/tickets/1817/

---

There's an issue with **realpath**.

For development purposes, I installed XAMPP x64 (C:\xampp64) recently.
I created a symbolic link so C:\xampp64\htdocs actually is C:\xampp\htdocs

Now, with realpath on Windows 10 and using this XAMPP version ( Windows NT ASUSJ 10.0 build 18362 (Windows 10) AMD64 , PHP Version 7.2.23 ), an issue occurs when running the setup (upgrade).

It happens after the step showing "Information about the upgrade from version 2.6.1.4463 to 2.6.1.4463".

The cause is in utils::GetDefaultUrlAppRoot(), and more specifically in the use of realpath().

I did some digging:
`$_SERVER['SCRIPT_FILENAME'] : C:/xampp64/htdocs/itop/web/setup/index.php`
But running realpath() on that, I get:
`c:\xampp\htdocs\itop\web\setup\index.php`

The difference is very small (it correctly identifies the real file), but the consequence is the setup crashes. Because `C: has become c:`

* https://www.php.net/manual/en/function.realpath.php

> Note: For case-insensitive filesystems realpath() may or may not normalize the character case.

Now, it works when changing str_replace to **str_ireplace** for the assignment of $sCurrentRelativePath (2 times)

**There might be more similar issues in iTop.**

Also, I did not work this out yet, but I'm wondering if this check + fallback method can't be simplified to one case with some **preg_match**
