### PR TITLE
Support array for json_data posted in rest/json service

### DIFF
--- a/webservices/rest.php
+++ b/webservices/rest.php
@@ -80,7 +80,7 @@ try
 	utils::UseParamFile();
         
 	$oKPI->ComputeAndReport('Data model loaded');
-        
+
 	$iRet = LoginWebPage::DoLogin(false, false, LoginWebPage::EXIT_RETURN); // Starting with iTop 2.2.0 portal users are no longer allowed to access the REST/JSON API
         $oKPI->ComputeAndReport('User login');
         
@@ -131,11 +131,26 @@ try
 	{
 		throw new Exception("Missing parameter 'json_data'", RestResult::MISSING_JSON);
 	}
-	$aJsonData = @json_decode($sJsonString);
-	if ($aJsonData == null)
+
+	if (is_string($sJsonString))
 	{
-		throw new Exception("Parameter json_data is not a valid JSON structure", RestResult::INVALID_JSON);
-	}
+        $aJsonData = @json_decode($sJsonString);
+    }
+	elseif(is_array($sJsonString))
+    {
+        $aJsonData = (object) $sJsonString;
+        $sJsonString = json_encode($aJsonData);
+    }
+	else
+    {
+        $aJsonData = null;
+    }
+
+    if ($aJsonData == null)
+    {
+        throw new Exception('Parameter json_data is not a valid JSON structure', RestResult::INVALID_JSON);
+    }
+
 	$oKPI->ComputeAndReport('Parameters validated');
 
 


### PR DESCRIPTION
When using x-www-form-urlencoded we could leverage the possibility to send array instead of raw json as PHP support it out of the box.

This change/bugfix is not BC-Break.

I do not know if this is a bug or not, when reading [current documentation](https://www.itophub.io/wiki/page?id=latest%3Aadvancedtopics%3Arest_json), it is not clearly stated that `json_data` should be a string.

```
auth_user=my_user&auth_pwd=my_password&json_data%5Boperation%5D=core%2Fget&json_data%5Bclass%5D=ServiceChange&json_data%5Bkey%5D=SELECT+ServiceChange+WHERE+id%3D1&json_data%5Boutput_fields%5D=request_state
```
**instead of**
```
auth_user=my_user&auth_pwd=my_password&json_data=%7B%22operation%22%3A+%22core%2Fget%22%2C+%22class%22%3A+%22ServiceChange%22%2C+%22key%22%3A+%22SELECT+ServiceChange+WHERE+id%3D1%22%2C+%22output_fields%22%3A+%22request_state%22%7D
```

It is more convenient to post json_data[operation]=core/get instead of json_data={"operation": "core/get"..
