### PR TITLE
Feature/faf log modularity

### DIFF
--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -99,11 +99,11 @@ class Config
 	 * @since 2.7.0 export_pdf_font param
 	 */
 	protected $m_aSettings = array(
-		'min_log_level' => array(
+		'log_level_min' => array(
 			'type' => 'array',
-			'description' => 'min log level',
-			'default' => 'Ok',
-			'value' => 'Ok',
+			'description' => 'Optional min log level per channel',
+			'default' => '',
+			'value' => '',
 			'source_of_value' => '',
 			'show_in_conf_sample' => false,
 		),

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -99,6 +99,14 @@ class Config
 	 * @since 2.7.0 export_pdf_font param
 	 */
 	protected $m_aSettings = array(
+		'min_log_level' => array(
+			'type' => 'array',
+			'description' => 'min log level',
+			'default' => 'Ok',
+			'value' => 'Ok',
+			'source_of_value' => '',
+			'show_in_conf_sample' => false,
+		),
 		'app_env_label' => array(
 			'type' => 'string',
 			'description' => 'Label displayed to describe the current application environment, defaults to the environment name (e.g. "production")',

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -271,6 +271,8 @@ abstract class LogAPI
 //	const LEVEL_ALERT       = 'Alert';
 //	const LEVEL_EMERGENCY   = 'Emergency';
 
+	protected static $m_oMockMetaModelConfig = null;
+
 	protected static $aLevelsPriority = array(
 		self::LEVEL_DEBUG   => 100,
 		self::LEVEL_OK      => 150,
@@ -283,6 +285,12 @@ abstract class LogAPI
 	{
 		// m_oFileLog is not defined as a class attribute so that each impl will have its own
 		static::$m_oFileLog = new FileLog($sTargetFile);
+	}
+
+	public static function MockStaticObjects($oFileLog, $oMetaModelConfig=null)
+	{
+		static::$m_oFileLog = $oFileLog;
+		static::$m_oMockMetaModelConfig = $oMetaModelConfig;
 	}
 
 	public static function Error($sMessage, $sChannel = null, $aContext = array())
@@ -357,7 +365,7 @@ abstract class LogAPI
 	 */
 	private static function GetMinLogLevel($sChannel)
 	{
-		$oConfig = \MetaModel::GetConfig();
+		$oConfig = (static::$m_oMockMetaModelConfig === null) ? static::$m_oMockMetaModelConfig :  \MetaModel::GetConfig();
 		if (!$oConfig instanceof Config)
 		{
 			return self::LEVEL_OK;

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -358,25 +358,31 @@ abstract class LogAPI
 	private static function GetMinLogLevel($sChannel)
 	{
 		$oConfig = \MetaModel::GetConfig();
-		if (! $oConfig instanceof Config)
+		if (!$oConfig instanceof Config)
 		{
 			return self::LEVEL_OK;
 		}
 
-		$sMinLogLevel = $oConfig->Get('min_log_level');
-		if (! is_array($sMinLogLevel))
+		$sLogLevelMin = $oConfig->Get('log_level_min');
+
+		if (empty($sLogLevelMin))
 		{
-			return $sMinLogLevel;
+			return self::LEVEL_OK;
 		}
 
-		if (isset($sMinLogLevel[$sChannel]))
+		if (!is_array($sLogLevelMin))
 		{
-			return $sMinLogLevel[$sChannel];
+			return $sLogLevelMin;
 		}
 
-		if (isset($sMinLogLevel[static::CHANNEL_DEFAULT]))
+		if (isset($sLogLevelMin[$sChannel]))
 		{
-			return $sMinLogLevel[$sChannel];
+			return $sLogLevelMin[$sChannel];
+		}
+
+		if (isset($sLogLevelMin[static::CHANNEL_DEFAULT]))
+		{
+			return $sLogLevelMin[$sChannel];
 		}
 
 		return self::LEVEL_OK;

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -201,41 +201,34 @@ class FileLog
 
 	public function Error($sText, $sChannel = '', $aContext = array())
 	{
-		$sLevel   = str_pad(__FUNCTION__, 7).' | ';
-		$sChannel = empty($sChannel) ? '' : " | $sChannel";
-		$this->Write("{$sLevel}{$sText}{$sChannel}", $aContext);
+		$this->Write($sText, __FUNCTION__, $sChannel, $aContext);
 	}
 
 	public function Warning($sText, $sChannel = '', $aContext = array())
 	{
-		$sLevel   = str_pad(__FUNCTION__, 7).' | ';
-		$sChannel = empty($sChannel) ? '' : " | $sChannel";
-		$this->Write("{$sLevel}{$sText}{$sChannel}", $aContext);
+		$this->Write($sText, __FUNCTION__, $sChannel, $aContext);
 	}
 
 	public function Info($sText, $sChannel = '', $aContext = array())
 	{
-		$sLevel   = str_pad(__FUNCTION__, 7).' | ';
-		$sChannel = empty($sChannel) ? '' : " | $sChannel";
-		$this->Write("{$sLevel}{$sText}{$sChannel}", $aContext);
+		$this->Write($sText, __FUNCTION__, $sChannel, $aContext);
 	}
 
 	public function Ok($sText, $sChannel = '', $aContext = array())
 	{
-		$sLevel   = str_pad(__FUNCTION__, 7).' | ';
-		$sChannel = empty($sChannel) ? '' : " | $sChannel";
-		$this->Write("{$sLevel}{$sText}{$sChannel}", $aContext);
+		$this->Write($sText, __FUNCTION__, $sChannel, $aContext);
 	}
 
 	public function Debug($sText, $sChannel = '', $aContext = array())
 	{
-		$sLevel   = str_pad(__FUNCTION__, 7).' | ';
-		$sChannel = empty($sChannel) ? '' : " | $sChannel";
-		$this->Write("{$sLevel}{$sText}{$sChannel}", $aContext);
+		$this->Write($sText, __FUNCTION__, $sChannel, $aContext);
 	}
 
-	protected function Write($sText, $aContext = array())
+	protected function Write($sText, $sLevel = '', $sChannel = '', $aContext = array())
 	{
+		$sTextPrefix = empty($sLevel) ? '' : (str_pad($sLevel, 7).' | ');
+		$sTextSuffix = empty($sChannel) ? '' : " | $sChannel";
+		$sText = "{$sTextPrefix}{$sText}{$sTextSuffix}";
 		$sLogFilePath = $this->oFileNameBuilder->GetLogFilePath();
 
 		if (empty($sLogFilePath))

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -365,7 +365,7 @@ abstract class LogAPI
 	 */
 	private static function GetMinLogLevel($sChannel)
 	{
-		$oConfig = (static::$m_oMockMetaModelConfig === null) ? static::$m_oMockMetaModelConfig :  \MetaModel::GetConfig();
+		$oConfig = (static::$m_oMockMetaModelConfig !== null) ? static::$m_oMockMetaModelConfig :  \MetaModel::GetConfig();
 		if (!$oConfig instanceof Config)
 		{
 			return self::LEVEL_OK;

--- a/test/core/LogAPITest.php
+++ b/test/core/LogAPITest.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Created by PhpStorm.
+ * User: Eric
+ * Date: 31/08/2018
+ * Time: 17:03
+ */
+
+namespace Combodo\iTop\Test\UnitTest\Core;
+
+
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ * @backupGlobals disabled
+ */
+class LogAPITest extends ItopTestCase
+{
+	private $mockFileLog;
+	private $oMetaModelConfig;
+
+	protected function setUp()
+	{
+		parent::setUp();
+		$this->mockFileLog = $this->createMock('FileLog');
+		$this->oMetaModelConfig = $this->createMock('Config');
+	}
+
+
+	/**
+	/**
+	 * @dataProvider LogApiProvider
+	 * @test
+	 * @backupGlobals disabled
+	 */
+	public function TestLogApi($oConfigObject, $sMessage, $Channel, $sExpectedLevel, $sExpectedMessage, $sExpectedChannel = '')
+	{
+		\IssueLog::MockStaticObjects($this->mockFileLog, $oConfigObject);
+
+		$this->mockFileLog->expects($this->exactly(1))
+			->method($sExpectedLevel)
+			->with($sExpectedMessage, $sExpectedChannel);
+
+		\IssueLog::Error($sMessage, $Channel);
+	}
+
+	public function LogApiProvider()
+	{
+		return [
+			[ $this->oMetaModelConfig, "log msg", '' , "Error", "log msg"],
+			[ $this->oMetaModelConfig, "log msg", 'PoudlardChannel' , "Error", "log msg", 'PoudlardChannel'],
+			[  array(), "log msg", '' , "Error", "log msg"], // Bruno?
+		];
+	}
+
+	/**
+	/** TODISCUSS
+	 * @test
+	 * @backupGlobals disabled
+	 */
+	public function TestUnknownLevel()
+	{
+		$this->mockFileLog->expects($this->exactly(1))
+			->method("Error")
+			->with("invalid log level 'TotoLevel'");
+
+		\IssueLog::Log('TotoLevel', "log msg");
+	}
+
+	/**
+	/**
+	 * @dataProvider LogWithChannelLogLevelApiProvider
+	 * @test
+	 * @backupGlobals disabled
+	 */
+	public function TestLogWithChannelLogLevelApi($expectedCallNb, $sExpectedLevel, $ConfigReturnedObject, $bExceptionRaised=false)
+	{
+		$this->oMetaModelConfig
+			->method("Get")
+			->with('log_level_min')
+			->willReturn($ConfigReturnedObject);
+
+		\IssueLog::MockStaticObjects($this->mockFileLog, $this->oMetaModelConfig);
+
+		$this->mockFileLog->expects($this->exactly($expectedCallNb))
+			->method($sExpectedLevel)
+			->with("log msg", "GaBuZoMeuChannel");
+
+		try{
+			\IssueLog::Warning("log msg", "GaBuZoMeuChannel");
+			if ($bExceptionRaised)
+			{
+				$this->fail("raised should have been raised");
+			}
+		}
+		catch(Exception $e)
+		{
+			if (!$bExceptionRaised)
+			{
+				$this->fail("raised should NOT have been raised");
+			}
+		}
+	}
+
+	public function LogWithChannelLogLevelApiProvider()
+	{
+		return [
+			[ 0, "Ok", ''],
+			[ 0, "Ok", 'TotoLevel'],
+			[ 0, "Ok", array()],
+			[ 0, "Ok", ["GaBuZoMeuChannel" => "TotoLevel"], true],
+			[ 1, "Error", ["GaBuZoMeuChannel" => "Error"]],
+			[ 0, "Info", ["GaBuZoMeuChannel" => "Info"]],
+		];
+	}
+
+}

--- a/test/core/LogAPITest.php
+++ b/test/core/LogAPITest.php
@@ -31,7 +31,6 @@ class LogAPITest extends ItopTestCase
 
 
 	/**
-	/**
 	 * @dataProvider LogApiProvider
 	 * @test
 	 * @backupGlobals disabled
@@ -57,7 +56,6 @@ class LogAPITest extends ItopTestCase
 	}
 
 	/**
-	/** TODISCUSS
 	 * @test
 	 * @backupGlobals disabled
 	 */
@@ -71,12 +69,11 @@ class LogAPITest extends ItopTestCase
 	}
 
 	/**
-	/**
-	 * @dataProvider LogWithChannelLogLevelApiProvider
+	 * @dataProvider LogWarningWithASpecificChannelProvider
 	 * @test
 	 * @backupGlobals disabled
 	 */
-	public function TestLogWithChannelLogLevelApi($expectedCallNb, $sExpectedLevel, $ConfigReturnedObject, $bExceptionRaised=false)
+	public function TestLogWarningWithASpecificChannel($expectedCallNb, $sExpectedLevel, $ConfigReturnedObject, $bExceptionRaised=false)
 	{
 		$this->oMetaModelConfig
 			->method("Get")
@@ -96,7 +93,7 @@ class LogAPITest extends ItopTestCase
 				$this->fail("raised should have been raised");
 			}
 		}
-		catch(Exception $e)
+		catch(\Exception $e)
 		{
 			if (!$bExceptionRaised)
 			{
@@ -105,15 +102,59 @@ class LogAPITest extends ItopTestCase
 		}
 	}
 
-	public function LogWithChannelLogLevelApiProvider()
+	public function LogWarningWithASpecificChannelProvider()
 	{
 		return [
-			[ 0, "Ok", ''],
-			[ 0, "Ok", 'TotoLevel'],
-			[ 0, "Ok", array()],
-			[ 0, "Ok", ["GaBuZoMeuChannel" => "TotoLevel"], true],
-			[ 1, "Error", ["GaBuZoMeuChannel" => "Error"]],
-			[ 0, "Info", ["GaBuZoMeuChannel" => "Info"]],
+			"empty config" => [ 0, "Ok", ''],
+			"Default Unknown Level" => [ 0, "Ok", 'TotoLevel', true],
+			"Info as Default Level" => [ 1 , "Warning", 'Info'],
+			"Error as Default Level" => [ 0, "Warning", 'Error'],
+			"Empty array" => [ 0, "Ok", array()],
+			"Channel configured on an undefined level" => [ 0, "Ok", ["GaBuZoMeuChannel" => "TotoLevel"], true],
+			"Channel defined with Error" => [ 0, "Warning", ["GaBuZoMeuChannel" => "Error"]],
+			"Channel defined with Info" => [ 1, "Warning", ["GaBuZoMeuChannel" => "Info"]],
+		];
+	}
+
+	/**
+	 * @dataProvider LogOkWithASpecificChannel
+	 * @test
+	 * @backupGlobals disabled
+	 */
+	public function TestLogOkWithASpecificChannel($expectedCallNb, $sExpectedLevel, $ConfigReturnedObject, $bExceptionRaised=false)
+	{
+		$this->oMetaModelConfig
+			->method("Get")
+			->with('log_level_min')
+			->willReturn($ConfigReturnedObject);
+
+		\IssueLog::MockStaticObjects($this->mockFileLog, $this->oMetaModelConfig);
+
+		$this->mockFileLog->expects($this->exactly($expectedCallNb))
+			->method($sExpectedLevel)
+			->with("log msg", "GaBuZoMeuChannel");
+
+		try{
+			\IssueLog::Ok("log msg", "GaBuZoMeuChannel");
+			if ($bExceptionRaised)
+			{
+				$this->fail("raised should have been raised");
+			}
+		}
+		catch(\Exception $e)
+		{
+			if (!$bExceptionRaised)
+			{
+				$this->fail("raised should NOT have been raised");
+			}
+		}
+	}
+
+	public function LogOkWithASpecificChannel()
+	{
+		return [
+			"empty config" => [ 1, "Ok", ''],
+			"Empty array" => [ 1, "Ok", array()],
 		];
 	}
 


### PR DESCRIPTION
introduce the concept of channels,
enable log filtering per channel.

Also add a new log level "Debug" wich is not written with the default conf.

This leverage the possibility to 
 - write debug log for only a given channel
 - mute logs bellow a given level for specifics channels