### PR TITLE
N°2793 Log rotation

### DIFF
--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -2071,7 +2071,6 @@ class Config
 			$bReturn = fclose($hFile);
 
 			utils::SetConfig($this);
-			FileLog::RenameLegacyLogFiles();
 
 			return $bReturn;
 		}

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -161,7 +161,7 @@ abstract class RotatingLogFileNameBuilder implements iLogFileNameBuilder
 	 */
 	protected function GetRotatedFileName()
 	{
-		$sFileSuffix = $this->GetFileSuffix();
+		$sFileSuffix = $this->GetFileSuffix(static::$oLogFileLastModified);
 		return $this->sFilePath.DIRECTORY_SEPARATOR
 			.$this->sFileBaseName
 			.'.'.$sFileSuffix
@@ -177,10 +177,11 @@ abstract class RotatingLogFileNameBuilder implements iLogFileNameBuilder
 	abstract public function ShouldRotate($oLogDateLastModified, $oNow);
 
 	/**
+	 * @param DateTime $oDate log file last modification date
+	 *
 	 * @return string suffix for the rotated log file
-	 * @uses oLogDateLastModified
 	 */
-	abstract protected function GetFileSuffix();
+	abstract protected function GetFileSuffix($oDate);
 
 	/**
 	 * @see \LogFileRotationProcess
@@ -200,9 +201,9 @@ class DailyRotatingLogFileNameBuilder extends RotatingLogFileNameBuilder
 	/**
 	 * @inheritDoc
 	 */
-	protected function GetFileSuffix()
+	protected function GetFileSuffix($oDate)
 	{
-		return date('Y-m-d');
+		return $oDate->format('Y-m-d');
 	}
 
 	/**
@@ -236,10 +237,10 @@ class WeeklyRotatingLogFileNameBuilder extends RotatingLogFileNameBuilder
 	/**
 	 * @inheritDoc
 	 */
-	protected function GetFileSuffix()
+	protected function GetFileSuffix($oDate)
 	{
-		$sWeekYear = date('o');
-		$sWeekNumber = date('W');
+		$sWeekYear = $oDate->format('o');
+		$sWeekNumber = $oDate->format('W');
 
 		return $sWeekYear.'-week'.$sWeekNumber;
 	}
@@ -274,7 +275,7 @@ class WeeklyRotatingLogFileNameBuilder extends RotatingLogFileNameBuilder
 	{
 		$oOccurrence = clone $oNow;
 		$oOccurrence->modify('Monday next week');
-		$oOccurrence->setTime(0, 0, 0, 0);
+		$oOccurrence->setTime(0, 0, 0);
 
 		return $oOccurrence;
 	}

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -143,6 +143,8 @@ abstract class RotatingLogFileNameBuilder implements iLogFileNameBuilder
 	 *
 	 * @param DateTime $oLogFileLastModified date when the log file was last modified
 	 *
+	 * @throws \Exception
+	 *
 	 * @uses flock() instead of a mutex that would create a useless connection to the DB, using flock
 	 * @link https://www.php.net/manual/fr/function.flock.php
 	 * @uses GetRotatedFileName to get rotated file name
@@ -154,6 +156,7 @@ abstract class RotatingLogFileNameBuilder implements iLogFileNameBuilder
 			return;
 		}
 
+		static::$oLogFileLastModified = new DateTime();
 		$oLogFileHandle = fopen($this->sLogFileFullPath, 'r');
 		flock($oLogFileHandle, LOCK_EX);
 		$sNewLogFileName = $this->GetRotatedFileName($oLogFileLastModified);

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -18,9 +18,9 @@
 
 
 /**
- * @since 2.7.0 N°2518
+ * @since 2.7.0 N°2518 N°2793
  */
-interface ILogFileNameBuilder
+interface iLogFileNameBuilder
 {
 	/**
 	 * @param string $sFileFullPath full path name for the log file
@@ -33,7 +33,7 @@ interface ILogFileNameBuilder
 	public function GetLogFilePath();
 }
 
-class DefaultLogFileNameBuilder implements ILogFileNameBuilder
+class DefaultLogFileNameBuilder implements iLogFileNameBuilder
 {
 	private $sLogFileFullPath;
 
@@ -59,7 +59,7 @@ class DefaultLogFileNameBuilder implements ILogFileNameBuilder
  *
  * @since 2.7.0 N°2518 N°2793
  */
-abstract class RotatingLogFileNameBuilder implements ILogFileNameBuilder
+abstract class RotatingLogFileNameBuilder implements iLogFileNameBuilder
 {
 	/** @var DateTime */
 	protected static $oLogFileLastModified = null;
@@ -274,7 +274,7 @@ class LogFileNameBuilderFactory
 	 *
 	 * @param string $sFileFullPath
 	 *
-	 * @return \ILogFileNameBuilder
+	 * @return \iLogFileNameBuilder
 	 * @throws \ConfigException
 	 * @throws \CoreException
 	 */

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -349,7 +349,7 @@ class LogFileNameBuilderFactory
 	{
 		$oConfig = utils::GetConfig();
 		$sFileNameBuilderImpl = $oConfig->Get('log_filename_builder_impl');
-		if (empty($sFileNameBuilderImpl) || !class_exists($sFileNameBuilderImpl))
+		if (!is_a($sFileNameBuilderImpl, iLogFileNameBuilder::class, true))
 		{
 			$sFileNameBuilderImpl = 'DefaultLogFileNameBuilder';
 		}

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -22,8 +22,14 @@
  */
 interface ILogFileNameBuilder
 {
+	/**
+	 * @param string $sFileFullPath full path name for the log file
+	 */
 	public function __construct($sFileFullPath);
 
+	/**
+	 * @return string log file path we will write new log entry to
+	 */
 	public function GetLogFilePath();
 }
 
@@ -31,11 +37,17 @@ class DefaultLogFileNameBuilder implements ILogFileNameBuilder
 {
 	private $sLogFileFullPath;
 
+	/**
+	 * @inheritDoc
+	 */
 	public function __construct($sFileFullPath)
 	{
 		$this->sLogFileFullPath = $sFileFullPath;
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public function GetLogFilePath()
 	{
 		return $this->sLogFileFullPath;
@@ -60,6 +72,9 @@ abstract class RotatingLogFileNameBuilder implements ILogFileNameBuilder
 	/** @var string */
 	protected $sFileExtension;
 
+	/**
+	 * @inheritDoc
+	 */
 	public function __construct($sFileFullPath)
 	{
 		$this->sLogFileFullPath = $sFileFullPath;
@@ -71,12 +86,24 @@ abstract class RotatingLogFileNameBuilder implements ILogFileNameBuilder
 		$this->sFileExtension = $aPathParts['extension'];
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public function GetLogFilePath()
 	{
 		$this->CheckAndRotateLogFile();
 		return $this->sLogFileFullPath;
 	}
 
+	/**
+	 * Check log last date modified. If too old then rotate the log file (move it to a new name with a suffix)
+	 *
+	 * @uses \filemtime() to get log file date last modified
+	 * @uses \iTopMutex during the whole check
+	 * @uses ShouldRotate to check if we need to rotate
+	 * @uses GetFileSuffix if we need to rotate, the suffix in the target rotated log filename
+	 * @throws \Exception
+	 */
 	protected function CheckAndRotateLogFile()
 	{
 		if (static::$bFileCheckDone)
@@ -110,12 +137,16 @@ abstract class RotatingLogFileNameBuilder implements ILogFileNameBuilder
 	}
 
 	/**
-	 * @param DateTime $oLogDateLastModified
-	 * @param DateTime $oNow
+	 * @param DateTime $oLogDateLastModified date when the log file was last modified
+	 * @param DateTime $oNow date/time of the log we want to write
 	 *
-	 * @return bool
+	 * @return bool true if the file has older informations and we need to move it to an archive (rotate), false if we don't have to
 	 */
 	abstract public function ShouldRotate($oLogDateLastModified, $oNow);
+
+	/**
+	 * @return string suffix for the rotated log file
+	 */
 	abstract protected function GetFileSuffix();
 }
 
@@ -124,6 +155,9 @@ abstract class RotatingLogFileNameBuilder implements ILogFileNameBuilder
  */
 class DailyRotatingLogFileNameBuilder extends RotatingLogFileNameBuilder
 {
+	/**
+	 * @inheritDoc
+	 */
 	protected function GetFileSuffix()
 	{
 		return date('Y-m-d');
@@ -146,6 +180,9 @@ class DailyRotatingLogFileNameBuilder extends RotatingLogFileNameBuilder
  */
 class WeeklyRotatingLogFileNameBuilder extends RotatingLogFileNameBuilder
 {
+	/**
+	 * @inheritDoc
+	 */
 	protected function GetFileSuffix()
 	{
 		$sWeekYear = date('o');
@@ -154,6 +191,9 @@ class WeeklyRotatingLogFileNameBuilder extends RotatingLogFileNameBuilder
 		return $sWeekYear.'-week'.$sWeekNumber;
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public function ShouldRotate($oLogDateLastModified, $oNow)
 	{
 		$iLogYear = $oLogDateLastModified->format('Y');

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -91,13 +91,7 @@ abstract class RotatingLogFileNameBuilder implements ILogFileNameBuilder
 	 */
 	public function GetLogFilePath()
 	{
-		$iRandomInt = mt_rand(1,20);
-		if ($iRandomInt < 2)
-		{
-			// we don't want to do the check on each call !
-			// a background task is launched, but we have the check here anyway as cron can be disabled
-			$this->CheckAndRotateLogFile();
-		}
+		$this->CheckAndRotateLogFile();
 		return $this->sLogFileFullPath;
 	}
 

--- a/test/core/LogFileNameBuilderTest.php
+++ b/test/core/LogFileNameBuilderTest.php
@@ -11,61 +11,70 @@ use WeeklyRotatingLogFileNameBuilder;
 
 class LogFileNameBuilderTest extends ItopTestCase
 {
-	public function WeeklyRotationProvider()
+	public function ShouldRotateProvider()
 	{
 		return array(
-			'Same week' => array('2020-02-01', '2020-02-01', false),
-			'1 week diff, same month' => array('2020-02-01', '2020-02-08', true),
-			'2 weeks diff, same month' => array('2020-02-01', '2020-02-15', true),
-			'1 week diff, different month' => array('2020-01-27', '2020-02-03', true),
-			'same week, different month' => array('2020-01-27', '2020-02-02', false),
-			'1 week diff, different year' => array('2019-12-30', '2020-01-06', true),
-			'same week, different year' => array('2019-12-30', '2020-01-05', true),
+			'WEEKLY Same week' => array('WeeklyRotatingLogFileNameBuilder', '2020-02-01 00:00', '2020-02-01 00:00', false),
+			'WEEKLY 1 week diff, same month' => array('WeeklyRotatingLogFileNameBuilder', '2020-02-01 00:00', '2020-02-08 00:00', true),
+			'WEEKLY 2 weeks diff, same month' => array('WeeklyRotatingLogFileNameBuilder', '2020-02-01 00:00', '2020-02-15 00:00', true),
+			'WEEKLY 1 week diff, different month' => array('WeeklyRotatingLogFileNameBuilder', '2020-01-27 00:00', '2020-02-03 00:00', true),
+			'WEEKLY same week, different month' => array('WeeklyRotatingLogFileNameBuilder', '2020-01-27 00:00', '2020-02-02 00:00', false),
+			'WEEKLY 1 week diff, different year' => array('WeeklyRotatingLogFileNameBuilder', '2019-12-30 00:00', '2020-01-06 00:00', true),
+			'WEEKLY same week, different year' => array('WeeklyRotatingLogFileNameBuilder', '2019-12-30 00:00', '2020-01-05 00:00', true),
+			'DAILY Same day' => array('DailyRotatingLogFileNameBuilder', '2020-02-01 00:00', '2020-02-01 15:42', false),
+			'DAILY Same week, different day' => array('DailyRotatingLogFileNameBuilder', '2020-02-01 00:00', '2020-02-02 00:00', true),
+			'DAILY 1 week diff' => array('DailyRotatingLogFileNameBuilder', '2020-02-01 00:00', '2020-02-08 00:00', true),
 		);
 	}
 
 	/**
-	 * @param string $sDateModified format Y-m-d
-	 * @param string $sDateNow format Y-m-d
+	 * @param string $sFileNameBuilderClass RotatingLogFileNameBuilder impl
+	 * @param string $sDateModified format Y-m-d H:i
+	 * @param string $sDateNow format Y-m-d H:i
 	 * @param bool $bExpected
 	 *
-	 * @dataProvider WeeklyRotationProvider
+	 * @dataProvider ShouldRotateProvider
 	 */
-	public function testWeeklyRotation($sDateModified, $sDateNow, $bExpected)
+	public function testShouldRotate($sFileNameBuilderClass, $sDateModified, $sDateNow, $bExpected)
 	{
-		$oDateModified = DateTime::createFromFormat('Y-m-d', $sDateModified);
-		$oDateNow = DateTime::createFromFormat('Y-m-d', $sDateNow);
+		$oDateModified = DateTime::createFromFormat('Y-m-d H:i', $sDateModified);
+		$oDateNow = DateTime::createFromFormat('Y-m-d H:i', $sDateNow);
 
-		$oFileBuilder = new WeeklyRotatingLogFileNameBuilder('c:/this/is/just/a/stub.invalid');
+		/** @var \RotatingLogFileNameBuilder $oFileBuilder */
+		$oFileBuilder = new $sFileNameBuilderClass();
 		$bShouldRotate = $oFileBuilder->ShouldRotate($oDateModified, $oDateNow);
 
 		$this->assertEquals($bExpected, $bShouldRotate);
 	}
 
-	public function DailyRotationProvider()
+	public function CronNextOccurrenceProvider()
 	{
 		return array(
-			'Same day' => array('2020-02-01 00:00', '2020-02-01 15:42', false),
-			'Same week, different day' => array('2020-02-01 00:00', '2020-02-02 00:00', true),
-			'1 week diff' => array('2020-02-01 00:00', '2020-02-08 00:00', true),
+			'DAILY morning' => array('DailyRotatingLogFileNameBuilder', '2020-02-01 05:00', '2020-02-02 00:00'),
+			'DAILY midnight' => array('DailyRotatingLogFileNameBuilder', '2020-02-01 00:00', '2020-02-02 00:00'),
+			'WEEKLY monday 12:42' => array('WeeklyRotatingLogFileNameBuilder', '2020-02-03 12:42', '2020-02-10 00:00'),
+			'WEEKLY monday 00:00' => array('WeeklyRotatingLogFileNameBuilder', '2020-02-03 00:00', '2020-02-10 00:00'),
+			'WEEKLY tuesday 12:42' => array('WeeklyRotatingLogFileNameBuilder', '2020-02-04 12:42', '2020-02-10 00:00'),
+			'WEEKLY sunday 12:42' => array('WeeklyRotatingLogFileNameBuilder', '2020-02-02 12:42', '2020-02-03 00:00'),
 		);
 	}
 
 	/**
-	 * @param string $sDateModified format Y-m-d G:i
-	 * @param string $sDateNow format Y-m-d G:i
-	 * @param bool $bExpected
+	 * @param string $sFileNameBuilderClass RotatingLogFileNameBuilder impl
+	 * @param string $sDateNow format Y-m-d H:i
+	 * @param string $sExpectedOccurrence format Y-m-d H:i
 	 *
-	 * @dataProvider DailyRotationProvider
+	 * @dataProvider CronNextOccurrenceProvider
 	 */
-	public function testDailyRotation($sDateModified, $sDateNow, $bExpected)
+	public function testCronNextOccurrence($sFileNameBuilderClass, $sDateNow, $sExpectedOccurrence)
 	{
-		$oDateModified = DateTime::createFromFormat('Y-m-d G:i', $sDateModified);
-		$oDateNow = DateTime::createFromFormat('Y-m-d G:i', $sDateNow);
+		$oDateNow = DateTime::createFromFormat('Y-m-d H:i', $sDateNow);
 
-		$oFileBuilder = new DailyRotatingLogFileNameBuilder('c:/this/is/just/a/stub.invalid');
-		$bShouldRotate = $oFileBuilder->ShouldRotate($oDateModified, $oDateNow);
+		/** @var \RotatingLogFileNameBuilder $oFileBuilder */
+		$oFileBuilder = new $sFileNameBuilderClass();
+		$oActualOccurrence = $oFileBuilder->GetCronProcessNextOccurrence($oDateNow);
+		$sActualOccurrence = $oActualOccurrence->format('Y-m-d H:i');
 
-		$this->assertEquals($bExpected, $bShouldRotate);
+		$this->assertEquals($sExpectedOccurrence, $sActualOccurrence);
 	}
 }

--- a/test/core/LogFileNameBuilderTest.php
+++ b/test/core/LogFileNameBuilderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+
+namespace Combodo\iTop\Test\UnitTest\Core;
+
+
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+use DailyRotatingLogFileNameBuilder;
+use DateTime;
+use WeeklyRotatingLogFileNameBuilder;
+
+class LogFileNameBuilderTest extends ItopTestCase
+{
+	public function WeeklyRotationProvider()
+	{
+		return array(
+			'Same week' => array('2020-02-01', '2020-02-01', false),
+			'1 week diff, same month' => array('2020-02-01', '2020-02-08', true),
+			'2 weeks diff, same month' => array('2020-02-01', '2020-02-15', true),
+			'1 week diff, different month' => array('2020-01-27', '2020-02-03', true),
+			'same week, different month' => array('2020-01-27', '2020-02-02', false),
+			'1 week diff, different year' => array('2019-12-30', '2020-01-06', true),
+			'same week, different year' => array('2019-12-30', '2020-01-05', true),
+		);
+	}
+
+	/**
+	 * @param string $sDateModified format Y-m-d
+	 * @param string $sDateNow format Y-m-d
+	 * @param bool $bExpected
+	 *
+	 * @dataProvider WeeklyRotationProvider
+	 */
+	public function testWeeklyRotation($sDateModified, $sDateNow, $bExpected)
+	{
+		$oDateModified = DateTime::createFromFormat('Y-m-d', $sDateModified);
+		$oDateNow = DateTime::createFromFormat('Y-m-d', $sDateNow);
+
+		$oFileBuilder = new WeeklyRotatingLogFileNameBuilder('c:/this/is/just/a/stub.invalid');
+		$bShouldRotate = $oFileBuilder->ShouldRotate($oDateModified, $oDateNow);
+
+		$this->assertEquals($bExpected, $bShouldRotate);
+	}
+
+	public function DailyRotationProvider()
+	{
+		return array(
+			'Same day' => array('2020-02-01 00:00', '2020-02-01 15:42', false),
+			'Same week, different day' => array('2020-02-01 00:00', '2020-02-02 00:00', true),
+			'1 week diff' => array('2020-02-01 00:00', '2020-02-08 00:00', true),
+		);
+	}
+
+	/**
+	 * @param string $sDateModified format Y-m-d G:i
+	 * @param string $sDateNow format Y-m-d G:i
+	 * @param bool $bExpected
+	 *
+	 * @dataProvider DailyRotationProvider
+	 */
+	public function testDailyRotation($sDateModified, $sDateNow, $bExpected)
+	{
+		$oDateModified = DateTime::createFromFormat('Y-m-d G:i', $sDateModified);
+		$oDateNow = DateTime::createFromFormat('Y-m-d G:i', $sDateNow);
+
+		$oFileBuilder = new DailyRotatingLogFileNameBuilder('c:/this/is/just/a/stub.invalid');
+		$bShouldRotate = $oFileBuilder->ShouldRotate($oDateModified, $oDateNow);
+
+		$this->assertEquals($bExpected, $bShouldRotate);
+	}
+}


### PR DESCRIPTION
With N°2518 I implemented a simple system where the log file name was calculated each time we want to open it. This was not cool as usual error.log or setup.log were no longer present, the current log file name was not deterministic anymore (have to guess which policy, and which name based on current date)

Those modifications get back to the old system : we are still writing to usual file names.
But a check is done  before writing to see if we need to rotate the file.