### PR TITLE
:globe_with_meridians: Config Menu title should be uppercase

### DIFF
--- a/datamodels/2.x/itop-welcome-itil/es_cr.dict.itop-welcome-itil.php
+++ b/datamodels/2.x/itop-welcome-itil/es_cr.dict.itop-welcome-itil.php
@@ -55,7 +55,7 @@ Dict::Add('ES CR', 'Spanish', 'Español, Castellaño', array(
 	'Menu:MyShortcuts' => 'Mis Accesos Rápidos',
 	'Menu:UserManagement' => 'Gestión de usuarios',
 	'Menu:Queries' => 'Consultas',
-	'Menu:ConfigurationTools' => 'configuración',
+	'Menu:ConfigurationTools' => 'Configuración',
 ));
 
 //


### PR DESCRIPTION
Changed "configuración" to "Configuración". 

I think this should be ported to release/2.7.0