### PR TITLE
REST API : new array syntax for json_data parameter

### DIFF
--- a/webservices/rest.php
+++ b/webservices/rest.php
@@ -70,6 +70,8 @@ $oCtx = new ContextTag(ContextTag::TAG_REST);
 
 $sVersion = utils::ReadParam('version', null, false, 'raw_data');
 $sOperation = utils::ReadParam('operation', null);
+
+// Can be a either a string or an array
 $sJsonString = utils::ReadParam('json_data', null, false, 'raw_data');
 $sProvider = '';
 

--- a/webservices/rest.php
+++ b/webservices/rest.php
@@ -128,7 +128,17 @@ try
 		throw new Exception("Missing parameter 'version' (e.g. '1.0')", RestResult::MISSING_VERSION);
 	}
 	
-	if ($sJsonString == null)
+	if ($sJsonString === null)
+	{
+		$aNonJsonDataKeysList = array('auth_user', 'auth_pwd');
+		$sJsonString = $_REQUEST;
+		foreach ($aNonJsonDataKeysList as $sNonJsonDataKey)
+		{
+			unset($sJsonString[$sNonJsonDataKey]);
+		}
+	}
+
+	if ($sJsonString === null)
 	{
 		throw new Exception("Missing parameter 'json_data'", RestResult::MISSING_JSON);
 	}

--- a/webservices/rest.php
+++ b/webservices/rest.php
@@ -130,7 +130,7 @@ try
 	
 	if ($sJsonString === null)
 	{
-		$aNonJsonDataKeysList = array('auth_user', 'auth_pwd');
+		$aNonJsonDataKeysList = array('version', 'auth_user', 'auth_pwd', 'callback');
 		$sJsonString = $_REQUEST;
 		foreach ($aNonJsonDataKeysList as $sNonJsonDataKey)
 		{


### PR DESCRIPTION
Before iTop 2.8.0, REST API json_data param needed a JSON value. So you would call the API like this :

```php
CURLOPT_POSTFIELDS => array(
	'auth_user' => 'admin',
	'auth_pwd' => 'admin',
	'json_data' => '{
	   "operation": "core/get",
	   "class": "Person",
	   "key": "SELECT Person", "limit": "10", "page": "1"
	}'
)
```

With #99, it became possible to use this syntax :

```php
CURLOPT_POSTFIELDS => array(
	'auth_user' => 'admin',
	'auth_pwd' => 'admin',
	"json_data[operation]" => "core/get",
	"json_data[class]" => "Person",
	"json_data[key]" => "SELECT Person",
	"json_data[limit]" => 10,
	"json_data[page]" => 1
)
```

Now with this modification we can use :

```php
CURLOPT_POSTFIELDS => array(
	'auth_user' => 'admin',
	'auth_pwd' => 'admin',
	"operation" => "core/get",
	"class" => "Person",
	"key" => "SELECT Person",
	"limit" => 10,
	"page" => 1
)
```