### PR TITLE
N°2901 - Add inline images trace logs

### DIFF
--- a/core/inlineimage.class.inc.php
+++ b/core/inlineimage.class.inc.php
@@ -191,7 +191,7 @@ class InlineImage extends DBObject
 				'$sTempId' => $sTempId,
 				'$aInlineImagesId' => $aInlineImagesId,
 				'$sUser' => UserRights::GetUser(),
-				'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+				'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 			));
 		}
 		else
@@ -200,7 +200,7 @@ class InlineImage extends DBObject
 				'$sObjectClass' => get_class($oObject),
 				'$sTransactionId' => $iTransactionId,
 				'$sUser' => UserRights::GetUser(),
-				'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+				'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 			));
 		}
 
@@ -242,7 +242,7 @@ class InlineImage extends DBObject
 			'$sTempId' => $sTempId,
 			'$aInlineImagesId' => $aInlineImagesId,
 			'$sUser' => UserRights::GetUser(),
-			'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+			'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 		));
 	}
 	
@@ -658,7 +658,7 @@ class InlineImageGC implements iBackgroundProcess
 				'item_id' => $oResult->Get('item_id'),
 				'item_class' => $oResult->Get('item_class'),
 				'$sUser' => UserRights::GetUser(),
-				'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+				'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 			));
 
 			$oResult->DBDelete();

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -914,7 +914,7 @@ HTML
 					'$id' => $id,
 					'$sTransactionId' => $sTransactionId,
 					'$sUser' => UserRights::GetUser(),
-					'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+					'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 				));
 
 				throw new ApplicationException(Dict::Format('UI:Error:2ParametersMissing', 'class', 'id'));
@@ -932,7 +932,7 @@ HTML
 					'$id' => $id,
 					'$sTransactionId' => $sTransactionId,
 					'$sUser' => UserRights::GetUser(),
-					'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+					'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 				));
 			}
 			elseif (!utils::IsTransactionValid($sTransactionId, false))
@@ -947,7 +947,7 @@ HTML
 					'$id' => $id,
 					'$sTransactionId' => $sTransactionId,
 					'$sUser' => UserRights::GetUser(),
-					'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+					'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 				));
 			}
 			else
@@ -971,7 +971,7 @@ HTML
 						'$aErrors' => $aErrors,
 						'IsModified' => $oObj->IsModified(),
 						'$sUser' => UserRights::GetUser(),
-						'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+						'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 					));
 				}
 				else
@@ -984,7 +984,7 @@ HTML
 						'$aErrors' => $aErrors,
 						'IsModified' => $oObj->IsModified(),
 						'$sUser' => UserRights::GetUser(),
-						'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+						'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 					));
 
 					try
@@ -1153,7 +1153,7 @@ HTML
 				'$operation' => $operation,
 				'$sTransactionId' => $sTransactionId,
 				'$sUser' => UserRights::GetUser(),
-				'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+				'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 			));
 
 			throw new ApplicationException(Dict::Format('UI:Error:1ParametersMissing', 'class'));
@@ -1169,7 +1169,7 @@ HTML
 				'$id' => $id,
 				'$sTransactionId' => $sTransactionId,
 				'$sUser' => UserRights::GetUser(),
-				'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+				'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 			));
 		}
 		else
@@ -1208,7 +1208,7 @@ HTML
 						'$aErrors' => $aErrors,
 						'$aWarnings' => $aWarnings,
 						'$sUser' => UserRights::GetUser(),
-						'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+						'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 					));
 
 					throw new CoreCannotSaveObjectException(array('id' => $oObj->GetKey(), 'class' => $sClass, 'issues' => $aErrors));

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -909,6 +909,14 @@ HTML
 			$sTransactionId = utils::ReadPostedParam('transaction_id', '', 'transaction_id');
 			if ( empty($sClass) || empty($id)) // TO DO: check that the class name is valid !
 			{
+				IssueLog::Trace('Object not updated (empty class or id)', $sClass, array(
+					'$operation' => $operation,
+					'$id' => $id,
+					'$sTransactionId' => $sTransactionId,
+					'$sUser' => UserRights::GetUser(),
+					'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+				));
+
 				throw new ApplicationException(Dict::Format('UI:Error:2ParametersMissing', 'class', 'id'));
 			}
 			$bDisplayDetails = true;
@@ -918,6 +926,14 @@ HTML
 				$bDisplayDetails = false;
 				$oP->set_title(Dict::S('UI:ErrorPageTitle'));
 				$oP->P(Dict::S('UI:ObjectDoesNotExist'));
+
+				IssueLog::Trace('Object not updated (id not found)', $sClass, array(
+					'$operation' => $operation,
+					'$id' => $id,
+					'$sTransactionId' => $sTransactionId,
+					'$sUser' => UserRights::GetUser(),
+					'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+				));
 			}
 			elseif (!utils::IsTransactionValid($sTransactionId, false))
 			{
@@ -925,6 +941,14 @@ HTML
 				IssueLog::Error("UI.php '$operation' : invalid transaction_id ! data: user='$sUser', class='$sClass'");
 				$oP->set_title(Dict::Format('UI:ModificationPageTitle_Object_Class', $oObj->GetRawName(), $sClassLabel)); // Set title will take care of the encoding
 				$oP->p("<strong>".Dict::S('UI:Error:ObjectAlreadyUpdated')."</strong>\n");
+
+				IssueLog::Trace('Object not updated (invalid transaction_id)', $sClass, array(
+					'$operation' => $operation,
+					'$id' => $id,
+					'$sTransactionId' => $sTransactionId,
+					'$sUser' => UserRights::GetUser(),
+					'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+				));
 			}
 			else
 			{
@@ -932,14 +956,37 @@ HTML
 				$sMessage = '';
 				$sSeverity = 'ok';
 
+
 				if (!$oObj->IsModified() && empty($aErrors))
 				{
 					$oP->set_title(Dict::Format('UI:ModificationPageTitle_Object_Class', $oObj->GetRawName(), $sClassLabel)); // Set title will take care of the encoding
 					$sMessage = Dict::Format('UI:Class_Object_NotUpdated', MetaModel::GetName(get_class($oObj)), $oObj->GetName());
 					$sSeverity = 'info';
+
+
+					IssueLog::Trace('Object updated', $sClass, array(
+						'$operation' => $operation,
+						'$id' => $id,
+						'$sTransactionId' => $sTransactionId,
+						'$aErrors' => $aErrors,
+						'IsModified' => $oObj->IsModified(),
+						'$sUser' => UserRights::GetUser(),
+						'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+					));
 				}
 				else
 				{
+
+					IssueLog::Trace('Object not updated (see either $aErrors or IsModified)', $sClass, array(
+						'$operation' => $operation,
+						'$id' => $id,
+						'$sTransactionId' => $sTransactionId,
+						'$aErrors' => $aErrors,
+						'IsModified' => $oObj->IsModified(),
+						'$sUser' => UserRights::GetUser(),
+						'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+					));
+
 					try
 					{
 						if (!empty($aErrors))
@@ -1102,6 +1149,13 @@ HTML
 		$aWarnings = array();
 		if ( empty($sClass) ) // TO DO: check that the class name is valid !
 		{
+			IssueLog::Trace('Object not created (empty class)', $sClass, array(
+				'$operation' => $operation,
+				'$sTransactionId' => $sTransactionId,
+				'$sUser' => UserRights::GetUser(),
+				'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+			));
+
 			throw new ApplicationException(Dict::Format('UI:Error:1ParametersMissing', 'class'));
 		}
 		if (!utils::IsTransactionValid($sTransactionId, false))
@@ -1109,6 +1163,14 @@ HTML
 			$sUser = UserRights::GetUser();
 			IssueLog::Error("UI.php '$operation' : invalid transaction_id ! data: user='$sUser', class='$sClass'");
 			$oP->p("<strong>".Dict::S('UI:Error:ObjectAlreadyCreated')."</strong>\n");
+
+			IssueLog::Trace('Object not created (invalid transaction_id)', $sClass, array(
+				'$operation' => $operation,
+				'$id' => $id,
+				'$sTransactionId' => $sTransactionId,
+				'$sUser' => UserRights::GetUser(),
+				'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+			));
 		}
 		else
 		{
@@ -1139,6 +1201,16 @@ HTML
 			{
 				if (!empty($aErrors) || !empty($aWarnings))
 				{
+					IssueLog::Trace('Object not created (see either $aErrors or $aWarnings)', $sClass, array(
+						'$operation' => $operation,
+						'$id' => $id,
+						'$sTransactionId' => $sTransactionId,
+						'$aErrors' => $aErrors,
+						'$aWarnings' => $aWarnings,
+						'$sUser' => UserRights::GetUser(),
+						'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+					));
+
 					throw new CoreCannotSaveObjectException(array('id' => $oObj->GetKey(), 'class' => $sClass, 'issues' => $aErrors));
 				}
 

--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -1021,6 +1021,16 @@ try
 			{
 				$bReleaseLock = iTopOwnershipLock::ReleaseLock($sObjClass, $iObjKey, $sToken);
 			}
+
+			IssueLog::Trace('on_form_cancel', $sObjClass, array(
+				'$iObjKey' => $iObjKey,
+				'$sTransactionId' => $iTransactionId,
+				'$sTempId' => $sTempId,
+				'$sToken' => $sToken,
+				'$sUser' => UserRights::GetUser(),
+				'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+			));
+
 			break;
 
 		case 'dashboard':
@@ -2650,6 +2660,16 @@ EOF
 							$aResult['width'] = $aDimensions['width'];
 							$aResult['height'] = $aDimensions['height'];
 						}
+
+						IssueLog::Trace('InlineImage created', 'InlineImage', array(
+							'$operation' => $operation,
+							'$aResult' => $aResult,
+							'secret' => $oAttachment->Get('secret'),
+							'temp_id' => $sTempId,
+							'item_class' => $sObjClass,
+							'user' => $sUser = UserRights::GetUser(),
+							'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+						));
 					}
 					else
 					{
@@ -2690,6 +2710,15 @@ EOF
 					$oAttachment->Set('contents', $oDoc);
 					$oAttachment->Set('secret', sprintf('%06x', mt_rand(0, 0xFFFFFF))); // something not easy to guess
 					$iAttId = $oAttachment->DBInsert();
+
+					IssueLog::Trace('InlineImage created', 'InlineImage', array(
+						'$operation' => $operation,
+						'secret' => $oAttachment->Get('secret'),
+						'temp_id' => $sTempId,
+						'item_class' => $sObjClass,
+						'user' => $sUser = UserRights::GetUser(),
+						'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+					));
 				}
 
 			} catch (FileUploadException $e)

--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -1028,7 +1028,7 @@ try
 				'$sTempId' => $sTempId,
 				'$sToken' => $sToken,
 				'$sUser' => UserRights::GetUser(),
-				'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+				'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 			));
 
 			break;
@@ -2668,7 +2668,7 @@ EOF
 							'temp_id' => $sTempId,
 							'item_class' => $sObjClass,
 							'user' => $sUser = UserRights::GetUser(),
-							'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+							'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 						));
 					}
 					else
@@ -2717,7 +2717,7 @@ EOF
 						'temp_id' => $sTempId,
 						'item_class' => $sObjClass,
 						'user' => $sUser = UserRights::GetUser(),
-						'HTTP_REFERER' => $_SERVER['HTTP_REFERER'],
+						'HTTP_REFERER' => @$_SERVER['HTTP_REFERER'],
 					));
 				}
 


### PR DESCRIPTION
This PR propose new log entries (cf N°2901 / R-024611).

they are written only if
```php
	'log_level_min' => array(
		'InlineImage' => LogAPI::LEVEL_TRACE,
		'UserRequest' => LogAPI::LEVEL_TRACE,
	),
```
You can then monitor the logs using something like : `tail -f log/error.log | grep "| InlineImage\|| UserRequest" -A 20`

One drawback of the log I've written are that the UserRequest logs are only written for some operations of UI.php, maybe I should add less detailed information within DBObject, What do you think?

For iTop <2.7, the code must be altered in order to remove the channel & move the extra info within the message string. (thus, it is not filterable, and must be used as a separate temporary build activating more functionalities 😭 