### PR TITLE
Enable external classes to use bypass function as well

### DIFF
--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -4091,6 +4091,16 @@ EOF
 	}
 
 	/**
+	 * Whether to bypass the checks of user rights when writing this object, could be used in {@link \iApplicationObjectExtension::OnCheckToWrite()}
+	 *
+	 * @return bool
+	 */
+	public function GetAllowWrite()
+	{
+		return $this->bAllowWrite;
+	}
+
+	/**
 	 * Bypass the check of the user rights when deleting this object
 	 *
 	 * @param bool $bAllow True to bypass the checks, false to restore the default behavior


### PR DESCRIPTION
Hey there,
with this PR I would like to add the possibility that implementations iApplicationObjectExtension interface could ask the given object whether to bypass user right checks or not. This offers the possibility to bypass some additional checks in an extension as well.
Hope it was okay, that I did not create a ticket before, like you wrote in CONTRIBUTING.md.
From my point of view this change was such small, that it was easier to touch it in the code than explaining it in a ticket.
Best
Lars