### PR TITLE
Check changes attributes in TriggerOnPortalUpdate

### DIFF
--- a/dictionaries/cs.dictionary.itop.core.php
+++ b/dictionaries/cs.dictionary.itop.core.php
@@ -570,6 +570,8 @@ Dict::Add('CS CZ', 'Czech', 'Čeština', array(
 Dict::Add('CS CZ', 'Czech', 'Čeština', array(
 	'Class:TriggerOnPortalUpdate' => 'Trigger \'aktualizace přes portál\'',
 	'Class:TriggerOnPortalUpdate+' => 'Trigger při aktualizaci koncovým uživatelem přes portál',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => 'Target fields~~',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => '~~',
 ));
 
 //

--- a/dictionaries/da.dictionary.itop.core.php
+++ b/dictionaries/da.dictionary.itop.core.php
@@ -568,6 +568,8 @@ Dict::Add('DA DA', 'Danish', 'Dansk', array(
 Dict::Add('DA DA', 'Danish', 'Dansk', array(
 	'Class:TriggerOnPortalUpdate' => 'Trigger (Når opdateret fra portalen)',
 	'Class:TriggerOnPortalUpdate+' => '',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => 'Target fields~~',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => '~~',
 ));
 
 //

--- a/dictionaries/de.dictionary.itop.core.php
+++ b/dictionaries/de.dictionary.itop.core.php
@@ -567,6 +567,8 @@ Dict::Add('DE DE', 'German', 'Deutsch', array(
 Dict::Add('DE DE', 'German', 'Deutsch', array(
 	'Class:TriggerOnPortalUpdate' => 'Trigger (bei Update aus dem Portal)',
 	'Class:TriggerOnPortalUpdate+' => '',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => 'Ziel-Felder',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => '',
 ));
 
 //

--- a/dictionaries/en.dictionary.itop.core.php
+++ b/dictionaries/en.dictionary.itop.core.php
@@ -568,6 +568,8 @@ Dict::Add('EN US', 'English', 'English', array(
 Dict::Add('EN US', 'English', 'English', array(
 	'Class:TriggerOnPortalUpdate' => 'Trigger (when updated from the portal)',
 	'Class:TriggerOnPortalUpdate+' => 'Trigger on a end-user\'s update from the portal',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => 'Target fields',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => '',
 ));
 
 //

--- a/dictionaries/es_cr.dictionary.itop.core.php
+++ b/dictionaries/es_cr.dictionary.itop.core.php
@@ -568,6 +568,8 @@ Dict::Add('ES CR', 'Spanish', 'Español, Castellaño', array(
 Dict::Add('ES CR', 'Spanish', 'Español, Castellaño', array(
 	'Class:TriggerOnPortalUpdate' => 'Disparador (cuando se actualiza desde el portal)',
 	'Class:TriggerOnPortalUpdate+' => 'Disparador cuando un usuario actualiza desde el portal',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => 'Campos objetivo',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => 'Campos que serán monitorizados',
 ));
 
 //

--- a/dictionaries/fr.dictionary.itop.core.php
+++ b/dictionaries/fr.dictionary.itop.core.php
@@ -566,6 +566,8 @@ Dict::Add('FR FR', 'French', 'Français', array(
 Dict::Add('FR FR', 'French', 'Français', array(
 	'Class:TriggerOnPortalUpdate' => 'Déclencheur sur mise à jour depuis le portail',
 	'Class:TriggerOnPortalUpdate+' => '',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => 'Attributs cible',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => '',
 ));
 
 //

--- a/dictionaries/hu.dictionary.itop.core.php
+++ b/dictionaries/hu.dictionary.itop.core.php
@@ -566,6 +566,8 @@ Dict::Add('HU HU', 'Hungarian', 'Magyar', array(
 Dict::Add('HU HU', 'Hungarian', 'Magyar', array(
 	'Class:TriggerOnPortalUpdate' => 'Trigger (when updated from the portal)~~',
 	'Class:TriggerOnPortalUpdate+' => 'Trigger on a end-user\'s update from the portal~~',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => 'Target fields~~',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => '~~',
 ));
 
 //

--- a/dictionaries/it.dictionary.itop.core.php
+++ b/dictionaries/it.dictionary.itop.core.php
@@ -568,6 +568,8 @@ Dict::Add('IT IT', 'Italian', 'Italiano', array(
 Dict::Add('IT IT', 'Italian', 'Italiano', array(
 	'Class:TriggerOnPortalUpdate' => 'Trigger (dopo l\'aggiornamento dal portale )',
 	'Class:TriggerOnPortalUpdate+' => 'Trigger sull\'aggiornamento dell\'utente dal portale',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => 'Target fields~~',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => '~~',
 ));
 
 //

--- a/dictionaries/ja.dictionary.itop.core.php
+++ b/dictionaries/ja.dictionary.itop.core.php
@@ -566,6 +566,8 @@ Dict::Add('JA JP', 'Japanese', '日本語', array(
 Dict::Add('JA JP', 'Japanese', '日本語', array(
 	'Class:TriggerOnPortalUpdate' => 'トリガー（ポータルから更新された時）',
 	'Class:TriggerOnPortalUpdate+' => 'エンドユーザがポータルから更新した場合のトリガー',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => 'Target fields~~',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => '~~',
 ));
 
 //

--- a/dictionaries/nl.dictionary.itop.core.php
+++ b/dictionaries/nl.dictionary.itop.core.php
@@ -574,6 +574,8 @@ Dict::Add('NL NL', 'Dutch', 'Nederlands', array(
 Dict::Add('NL NL', 'Dutch', 'Nederlands', array(
 	'Class:TriggerOnPortalUpdate' => 'Trigger (als er vanuit het portaal geüpdatet wordt)',
 	'Class:TriggerOnPortalUpdate+' => 'Trigger op de update van de eindgebruiker van het portaal',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => 'Doelvelden',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => '',
 ));
 
 //

--- a/dictionaries/pt_br.dictionary.itop.core.php
+++ b/dictionaries/pt_br.dictionary.itop.core.php
@@ -568,6 +568,8 @@ Dict::Add('PT BR', 'Brazilian', 'Brazilian', array(
 Dict::Add('PT BR', 'Brazilian', 'Brazilian', array(
 	'Class:TriggerOnPortalUpdate' => 'Gatilho (quando atualizado a partir do portal)',
 	'Class:TriggerOnPortalUpdate+' => 'Gatilho de uma atualização do usuário final a partir do portal',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => 'Campos de destino',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => '',
 ));
 
 //

--- a/dictionaries/ru.dictionary.itop.core.php
+++ b/dictionaries/ru.dictionary.itop.core.php
@@ -555,6 +555,8 @@ Dict::Add('RU RU', 'Russian', 'Русский', array(
 Dict::Add('RU RU', 'Russian', 'Русский', array(
 	'Class:TriggerOnPortalUpdate' => 'Триггер на обновление из портала',
 	'Class:TriggerOnPortalUpdate+' => 'Триггер на обновление объекта пользователем портала',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => 'Отслеживаемые поля',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => 'Поля объекта, при обновлении которых сработает триггер',
 ));
 
 //

--- a/dictionaries/sk.dictionary.itop.core.php
+++ b/dictionaries/sk.dictionary.itop.core.php
@@ -565,6 +565,8 @@ Dict::Add('SK SK', 'Slovak', 'Slovenčina', array(
 Dict::Add('SK SK', 'Slovak', 'Slovenčina', array(
 	'Class:TriggerOnPortalUpdate' => 'Spúštač (pri aktualizácií z portálu)',
 	'Class:TriggerOnPortalUpdate+' => '',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => 'Target fields~~',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => '~~',
 ));
 
 //

--- a/dictionaries/tr.dictionary.itop.core.php
+++ b/dictionaries/tr.dictionary.itop.core.php
@@ -576,6 +576,8 @@ Dict::Add('TR TR', 'Turkish', 'Türkçe', array(
 Dict::Add('TR TR', 'Turkish', 'Türkçe', array(
 	'Class:TriggerOnPortalUpdate' => 'Trigger (when updated from the portal)~~',
 	'Class:TriggerOnPortalUpdate+' => 'Trigger on a end-user\'s update from the portal~~',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => 'Target fields~~',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => '~~',
 ));
 
 //

--- a/dictionaries/zh_cn.dictionary.itop.core.php
+++ b/dictionaries/zh_cn.dictionary.itop.core.php
@@ -567,6 +567,8 @@ Dict::Add('ZH CN', 'Chinese', '简体中文', array(
 Dict::Add('ZH CN', 'Chinese', '简体中文', array(
 	'Class:TriggerOnPortalUpdate' => '触发器 (工单更新时)',
 	'Class:TriggerOnPortalUpdate+' => '终端用户更新工单时触发',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes' => '目标字段',
+	'Class:TriggerOnPortalUpdate/Attribute:target_attcodes+' => '',
 ));
 
 //


### PR DESCRIPTION
This PR adds a feature in TriggerOnPortalUpdate to check for changes attributes (similar to TriggerOnObjectUpdate) using the new method ListPreviousValuesForUpdatedAttributes

Previously I implemented my own Trigger with this feature via an extension, but I though it might be interesting to integrate this in the core and make it available to all iTop users.

Best
Lars