### PR TITLE
Deadlock log : log inside a dedicated log file instead of creating an EventIssue object

### DIFF
--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -683,6 +683,10 @@ class CMDBSource
 		return $oResult;
 	}
 
+	/**
+	 * @param \Exception $e
+	 * @since 2.7.1
+	 */
 	private static function LogDeadLock(Exception $e)
 	{
 		// Deadlock detection

--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -124,12 +124,12 @@ class CMDBSource
 	 * Error: 1205 SQLSTATE: HY000 (ER_LOCK_WAIT_TIMEOUT)
 	 *   Message: Lock wait timeout exceeded; try restarting transaction
 	 */
-	const ERRNO_1205 = 1205;
+	const MYSQL_ERRNO_WAIT_TIMEOUT = 1205;
 	/**
 	 * Error: 1213 SQLSTATE: 40001 (ER_LOCK_DEADLOCK)
 	 *   Message: Deadlock found when trying to get lock; try restarting transaction
 	 */
-	const ERRNO_1213 = 1213;
+	const MYSQL_ERRNO_DEADLOCK = 1213;
 
 	protected static $m_sDBHost;
 	protected static $m_sDBUser;
@@ -703,7 +703,7 @@ class CMDBSource
 	{
 		// checks MySQL error code
 		$iMySqlErrorNo = self::$m_oMysqli->errno;
-		if (!in_array($iMySqlErrorNo, array(self::ERRNO_1205, self::ERRNO_1213)))
+		if (!in_array($iMySqlErrorNo, array(self::MYSQL_ERRNO_WAIT_TIMEOUT, self::MYSQL_ERRNO_DEADLOCK)))
 		{
 			return;
 		}

--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -706,11 +706,15 @@ class CMDBSource
 
 		// Get error info
 		$sUser = UserRights::GetUser();
-		$oError = self::$m_oMysqli->query("SHOW ENGINE INNODB STATUS");
-		$aData = array();
+		$oError = self::$m_oMysqli->query('SHOW ENGINE INNODB STATUS');
 		if ($oError !== false)
 		{
 			$aData = $oError->fetch_all(MYSQLI_ASSOC);
+			$sInnodbStatus = $aData[0];
+		}
+		else
+		{
+			$sInnodbStatus = 'Get status query cannot execute';
 		}
 
 		// log !
@@ -720,7 +724,7 @@ class CMDBSource
 			'errno' => $iMySqlErrorNo,
 			'ex_msg' => $e->getMessage(),
 			'callstack' => $e->getTrace(),
-			'data' => $aData[0],
+			'data' => $sInnodbStatus,
 		);
 		DeadLockLog::Info($sMessage, $iMySqlErrorNo, $aLogContext);
 

--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -727,7 +727,7 @@ class CMDBSource
 			'userinfo' => $sUser,
 			'errno' => $iMySqlErrorNo,
 			'ex_msg' => $e->getMessage(),
-			'callstack' => $e->getTrace(), //TODO replace by https://www.php.net/manual/en/exception.gettraceasstring.php
+			'callstack' => $e->getTraceAsString(),
 			'data' => $sInnodbStatus,
 		);
 		DeadLockLog::Info($sMessage, $iMySqlErrorNo, $aLogContext);

--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -119,7 +119,18 @@ class CMDBSource
 	const ENUM_DB_VENDOR_MYSQL = 'MySQL';
 	const ENUM_DB_VENDOR_MARIADB = 'MariaDB';
 	const ENUM_DB_VENDOR_PERCONA = 'Percona';
-	
+
+	/**
+	 * Error: 1205 SQLSTATE: HY000 (ER_LOCK_WAIT_TIMEOUT)
+	 *   Message: Lock wait timeout exceeded; try restarting transaction
+	 */
+	const ERRNO_1205 = 1205;
+	/**
+	 * Error: 1213 SQLSTATE: 40001 (ER_LOCK_DEADLOCK)
+	 *   Message: Deadlock found when trying to get lock; try restarting transaction
+	 */
+	const ERRNO_1213 = 1213;
+
 	protected static $m_sDBHost;
 	protected static $m_sDBUser;
 	protected static $m_sDBPwd;
@@ -684,13 +695,6 @@ class CMDBSource
 	}
 
 	/**
-	 * Will log if MySQL error if one of the following :
-	 *
-	 * * Error: 1205 SQLSTATE: HY000 (ER_LOCK_WAIT_TIMEOUT)
-	 *   Message: Lock wait timeout exceeded; try restarting transaction
-	 * * Error: 1213 SQLSTATE: 40001 (ER_LOCK_DEADLOCK)
-	 *   Message: Deadlock found when trying to get lock; try restarting transaction
-	 *
 	 * @param \Exception $e
 	 *
 	 * @since 2.7.1
@@ -699,7 +703,7 @@ class CMDBSource
 	{
 		// checks MySQL error code
 		$iMySqlErrorNo = self::$m_oMysqli->errno;
-		if (!in_array($iMySqlErrorNo, array(1205, 1213)))
+		if (!in_array($iMySqlErrorNo, array(self::ERRNO_1205, self::ERRNO_1213)))
 		{
 			return;
 		}

--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -705,6 +705,7 @@ class CMDBSource
 		}
 
 		// Get error info
+		$sUser = UserRights::GetUser();
 		$oError = self::$m_oMysqli->query("SHOW ENGINE INNODB STATUS");
 		$aData = array();
 		if ($oError !== false)
@@ -713,16 +714,17 @@ class CMDBSource
 		}
 
 		// log !
+		$sMessage = "deadlock detected: user= $sUser; errno=$iMySqlErrorNo";
 		$aLogContext = array(
-			'userinfo' => UserRights::GetUser(),
-			'issue' => 'Database DeadLock',
-			'impact' => 'Request execution failed',
+			'userinfo' => $sUser,
+			'errno' => $iMySqlErrorNo,
+			'ex_msg' => $e->getMessage(),
 			'callstack' => $e->getTrace(),
 			'data' => $aData[0],
 		);
-		DeadLockLog::Info($e->getMessage(), $iMySqlErrorNo, $aLogContext);
+		DeadLockLog::Info($sMessage, $iMySqlErrorNo, $aLogContext);
 
-		IssueLog::Error($e->getMessage(), 'DeadLock', $aLogContext['data']);
+		IssueLog::Error($sMessage, 'DeadLock', $e->getMessage());
 	}
 
 	/**

--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -727,7 +727,7 @@ class CMDBSource
 			'userinfo' => $sUser,
 			'errno' => $iMySqlErrorNo,
 			'ex_msg' => $e->getMessage(),
-			'callstack' => $e->getTrace(),
+			'callstack' => $e->getTrace(), //TODO replace by https://www.php.net/manual/en/exception.gettraceasstring.php
 			'data' => $sInnodbStatus,
 		);
 		DeadLockLog::Info($sMessage, $iMySqlErrorNo, $aLogContext);

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -716,7 +716,7 @@ class DeadLockLog extends LogAPI
 	{
 		if (empty($sTargetFile))
 		{
-			$sTargetFile = APPROOT.'log/itop-deadlocks.log';
+			$sTargetFile = APPROOT.'log/deadlocks.log';
 		}
 		parent::Enable($sTargetFile);
 	}

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -705,8 +705,8 @@ class ToolsLog extends LogAPI
  */
 class DeadLockLog extends LogAPI
 {
-	const CHANNEL_WAIT_TIMEOUT = 'iTopDeadlLock_1205WaitTimeout';
-	const CHANNEL_DEADLOCK_FOUND = 'iTopDeadlock_1213DeadlockFound';
+	const CHANNEL_WAIT_TIMEOUT = 'Deadlock-WaitTimeout';
+	const CHANNEL_DEADLOCK_FOUND = 'Deadlock-Found';
 	const CHANNEL_DEFAULT = self::CHANNEL_WAIT_TIMEOUT;
 
 	/** @var \FileLog we want our own instance ! */

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -699,6 +699,27 @@ class ToolsLog extends LogAPI
 	protected static $m_oFileLog = null;
 }
 
+/**
+ * @see \CMDBSource::LogDeadLock()
+ * @since 2.7.1
+ */
+class DeadLockLog extends LogAPI
+{
+	const CHANNEL_DEFAULT   = 'iTopDeadlocks';
+
+	/** @var \FileLog we want our own instance ! */
+	protected static $m_oFileLog = null;
+
+	public static function Enable($sTargetFile = null)
+	{
+		if (empty($sTargetFile))
+		{
+			$sTargetFile = APPROOT.'log/itop-deadlocks.log';
+		}
+		parent::Enable($sTargetFile);
+	}
+}
+
 
 class LogFileRotationProcess implements iScheduledProcess
 {

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -705,7 +705,9 @@ class ToolsLog extends LogAPI
  */
 class DeadLockLog extends LogAPI
 {
-	const CHANNEL_DEFAULT   = 'iTopDeadlocks';
+	const CHANNEL_WAIT_TIMEOUT = 'iTopDeadlLock_1205WaitTimeout';
+	const CHANNEL_DEADLOCK_FOUND = 'iTopDeadlock_1213DeadlockFound';
+	const CHANNEL_DEFAULT = self::CHANNEL_WAIT_TIMEOUT;
 
 	/** @var \FileLog we want our own instance ! */
 	protected static $m_oFileLog = null;
@@ -717,6 +719,36 @@ class DeadLockLog extends LogAPI
 			$sTargetFile = APPROOT.'log/itop-deadlocks.log';
 		}
 		parent::Enable($sTargetFile);
+	}
+
+	private static function GetChannelFromMysqlErrorNo($iMysqlErrorNo)
+	{
+		switch ($iMysqlErrorNo)
+		{
+			case 1205:
+				return self::CHANNEL_WAIT_TIMEOUT;
+				break;
+			case 1213:
+				return  self::CHANNEL_DEADLOCK_FOUND;
+				break;
+			default:
+				return self::CHANNEL_DEFAULT;
+				break;
+		}
+	}
+
+	/**
+	 * @param int $iMySQLErrNo will be converted to channel using {@link GetChannelFromMysqlErrorNo}
+	 * @param string $sMessage
+	 * @param null $iMysqlErroNo
+	 * @param array $aContext
+	 *
+	 * @throws \Exception
+	 */
+	public static function Log($iMySQLErrNo, $sMessage, $iMysqlErroNo = null, $aContext = array())
+	{
+		$sChannel = self::GetChannelFromMysqlErrorNo($iMysqlErroNo);
+		parent::Log($iMySQLErrNo, $sMessage, $sChannel, $aContext);
 	}
 }
 

--- a/core/metamodel.class.php
+++ b/core/metamodel.class.php
@@ -6316,6 +6316,7 @@ abstract class MetaModel
 			self::$m_bLogWebService = self::$m_oConfig->GetLogWebService();
 
 			ToolsLog::Enable(APPROOT.'log/tools.log');
+			DeadLockLog::Enable();
 		}
 		else
 		{


### PR DESCRIPTION
With 75730eee a log was added to trace for deadlocks. This was creating EventIssue objects.
My proposal is to log directly to a dedicated log file instead.