### PR TITLE
the event names has now a reflection

### DIFF
--- a/.make/release/list-events.php
+++ b/.make/release/list-events.php
@@ -1,0 +1,14 @@
+<?php
+
+/*******************************************************************************
+ * Tool to automate events list retrieval before release
+ ******************************************************************************/
+
+
+
+require_once (__DIR__.'/../../approot.inc.php');
+require_once APPROOT.'application/startup.inc.php';
+
+$aList = \Combodo\iTop\Service\Event::GetEventNameList();
+
+var_dump($aList);

--- a/application/startup.inc.php
+++ b/application/startup.inc.php
@@ -18,7 +18,7 @@
 require_once(APPROOT.'/core/cmdbobject.class.inc.php');
 require_once(APPROOT.'/application/utils.inc.php');
 require_once(APPROOT.'/core/contexttag.class.inc.php');
-
+require_once(APPROOT.'/sources/application/Service/EventName.php');
 
 /**
  * File to include to initialize the datamodel in memory

--- a/lib/composer/autoload_classmap.php
+++ b/lib/composer/autoload_classmap.php
@@ -153,6 +153,8 @@ return array(
     'Combodo\\iTop\\Service\\Event' => $baseDir . '/sources/application/Service/Event.php',
     'Combodo\\iTop\\Service\\EventData' => $baseDir . '/sources/application/Service/EventData.php',
     'Combodo\\iTop\\Service\\EventName' => $baseDir . '/sources/application/Service/EventName.php',
+    'Combodo\\iTop\\Service\\EventNameAbstract' => $baseDir . '/sources/application/Service/EventNameAbstract.php',
+    'Combodo\\iTop\\Service\\iEventName' => $baseDir . '/sources/application/Service/iEventName.php',
     'Combodo\\iTop\\TwigExtension' => $baseDir . '/application/twigextension.class.inc.php',
     'Config' => $baseDir . '/core/config.class.inc.php',
     'ConfigException' => $baseDir . '/core/config.class.inc.php',

--- a/lib/composer/autoload_static.php
+++ b/lib/composer/autoload_static.php
@@ -383,6 +383,8 @@ class ComposerStaticInit0018331147de7601e7552f7da8e3bb8b
         'Combodo\\iTop\\Service\\Event' => __DIR__ . '/../..' . '/sources/application/Service/Event.php',
         'Combodo\\iTop\\Service\\EventData' => __DIR__ . '/../..' . '/sources/application/Service/EventData.php',
         'Combodo\\iTop\\Service\\EventName' => __DIR__ . '/../..' . '/sources/application/Service/EventName.php',
+        'Combodo\\iTop\\Service\\EventNameAbstract' => __DIR__ . '/../..' . '/sources/application/Service/EventNameAbstract.php',
+        'Combodo\\iTop\\Service\\iEventName' => __DIR__ . '/../..' . '/sources/application/Service/iEventName.php',
         'Combodo\\iTop\\TwigExtension' => __DIR__ . '/../..' . '/application/twigextension.class.inc.php',
         'Config' => __DIR__ . '/../..' . '/core/config.class.inc.php',
         'ConfigException' => __DIR__ . '/../..' . '/core/config.class.inc.php',

--- a/sources/application/Service/Event.php
+++ b/sources/application/Service/Event.php
@@ -260,4 +260,41 @@ class Event
 		}
 		return false;
 	}
+
+	public static function GetEventNameList()
+	{
+
+		$aEventNameInstances = \MetaModel::EnumPlugins('iModuleExtension', iEventName::class);
+		$aEventNameList = self::MergeEventNameLists($aEventNameInstances);
+
+		return $aEventNameList;
+	}
+
+	/**
+	 * @param \Combodo\iTop\Service\iEventName[] $aEventNameInstances
+	 *
+	 * @return array
+	 */
+	private static function MergeEventNameLists(array $aEventNameInstances)
+	{
+		$aEventNameList = array();
+
+		foreach ($aEventNameInstances as $oEventName)
+		{
+			$aList = $oEventName->GetEventNameList();
+			$sModule = $aList['module'];
+			$aEvents = $aList['events'];
+
+			if (empty($aEventNameList[$sModule]))
+			{
+				$aEventNameList[$sModule] = $aEvents;
+			}
+			else
+			{
+				$aEventNameList[$sModule] = array_merge($aEventNameList[$sModule], $aEvents);
+			}
+		}
+
+		return $aEventNameList;
+	}
 }

--- a/sources/application/Service/EventName.php
+++ b/sources/application/Service/EventName.php
@@ -8,8 +8,11 @@
 namespace Combodo\iTop\Service;
 
 
-class EventName
+class EventName extends EventNameAbstract
 {
+	//not an event
+	const MODULE_CODE = 'core';
+
 	// OrmDocument
 	const DOWNLOAD_DOCUMENT = 'DownloadDocument';
 
@@ -26,4 +29,5 @@ class EventName
 	const AFTER_DELETE = 'AfterDelete';
 	const BEFORE_APPLY_STIMULUS = 'BeforeApplyStimulus';
 	const AFTER_APPLY_STIMULUS = 'AfterApplyStimulus';
+
 }

--- a/sources/application/Service/EventNameAbstract.php
+++ b/sources/application/Service/EventNameAbstract.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright   Copyright (C) 2010-2020 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+
+namespace Combodo\iTop\Service;
+
+
+abstract class EventNameAbstract implements iEventName
+{
+	const MODULE_CODE = '';
+
+	public function __construct()
+	{
+//		The interface force an empty & public constructor... let's make it useful:
+//
+//               __
+//             <(o )___             _      _      _
+//              ( ._> /           >(.)__ <(.)__ =(.)__
+//               `---'             (___/  (___/  (___/              quack !
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function GetEventNameList()
+	{
+		$oReflectionClass = new \ReflectionClass(static::class);
+		$aRawEventNameList = $oReflectionClass->getConstants();
+
+		unset($aRawEventNameList['MODULE_CODE']);
+
+		$aEventNameList = array();
+		foreach ($aRawEventNameList as $sConstName => $sConstValue)
+		{
+			$sConstName = static::class.'::'.$sConstName;
+			$aEventNameList[$sConstName] = $sConstValue;
+		}
+
+		return array(
+			'module' => static::MODULE_CODE,
+			'events' => $aEventNameList,
+		);
+	}
+}

--- a/sources/application/Service/iEventName.php
+++ b/sources/application/Service/iEventName.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright (C) 2010-2020 Combodo SARL
+ *
+ *   This file is part of iTop.
+ *
+ *   iTop is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Affero General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   iTop is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public License
+ *   along with iTop. If not, see <http: *www.gnu.org/licenses/>
+ *
+ */
+
+namespace Combodo\iTop\Service;
+
+interface iEventName extends \iModuleExtension
+{
+	/**
+	 * @return array{module: string, events: string[]}
+	 */
+    public function GetEventNameList();
+}


### PR DESCRIPTION
the event names has now a reflection 

## usage
You can expose the events names by choosing one of those two methods:

### using the abstract class
 - extends `EventNameAbstract`
 - define the class constant `MODULE_CODE`
=> all constants but `MODULE_CODE` will be returned by `GetEventNameList()`

### using the interface
 - just implement `iEventName`

## test

 - I only tested the private static method.
 - I should also had test several implementations of `EventNameAbstract` but hey, it's past midnight!


## how to query it:
```php
 php .make/release/list-events.php 
```
>  array(1) {
>   'core' =>
>   array(13) {
>     'Combodo\iTop\Service\EventName::DOWNLOAD_DOCUMENT' =>
>     string(16) "DownloadDocument"
>     'Combodo\iTop\Service\EventName::DB_OBJECT_LOADED' =>
>     string(14) "DBObjectLoaded"
>     'Combodo\iTop\Service\EventName::DB_OBJECT_RELOAD' =>
>     string(14) "DBObjectReload"
>     'Combodo\iTop\Service\EventName::DB_OBJECT_NEW' =>
>     string(11) "DBObjectNew"
>     'Combodo\iTop\Service\EventName::BEFORE_INSERT' =>
>     string(12) "BeforeInsert"
>     'Combodo\iTop\Service\EventName::DB_OBJECT_KEY_READY' =>
>     string(16) "DBObjectKeyReady"
>     'Combodo\iTop\Service\EventName::AFTER_INSERT' =>
>     string(11) "AfterInsert"
>     'Combodo\iTop\Service\EventName::BEFORE_UPDATE' =>
>     string(12) "BeforeUpdate"
>     'Combodo\iTop\Service\EventName::AFTER_UPDATE' =>
>     string(11) "AfterUpdate"
>     'Combodo\iTop\Service\EventName::BEFORE_DELETE' =>
>     string(12) "BeforeDelete"
>     'Combodo\iTop\Service\EventName::AFTER_DELETE' =>
>     string(11) "AfterDelete"
>     'Combodo\iTop\Service\EventName::BEFORE_APPLY_STIMULUS' =>
>     string(19) "BeforeApplyStimulus"
>     'Combodo\iTop\Service\EventName::AFTER_APPLY_STIMULUS' =>
>     string(18) "AfterApplyStimulus"
>   }
> }
> 

@eespie I let you see if you like it :)

## notes :
 -  I'm not fond of the new line into `application/startup.inc.php`
 - The interface does return an array since I know you prefer arrays over DTO, if it where me, I would had use a DTO (because the expected structure is not documented enough with arrays)
