### PR TITLE
Add "software requirements" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,18 @@ iTop also offers mass import tools and web services to integrate with your IT
  - [iTop Forums][1]: community support
  - [iTop Tickets][2]: for feature requests and bug reports
  - [Releases download][3]
- - [Documentation][4] covering both iTop and its official extensions
- - [iTop Hub][5] : discover and install extensions !
+ - [Software requirements][4]
+ - [Documentation][5] covering both iTop and its official extensions
+ - [iTop Hub][6] : discover and install extensions !
 
 
 
 [1]: https://sourceforge.net/p/itop/discussion/
 [2]: https://sourceforge.net/p/itop/tickets/
 [3]: https://sourceforge.net/projects/itop/files/itop/
-[4]: https://www.itophub.io/wiki
-[5]: https://store.itophub.io/en_US/
+[4]: https://www.itophub.io/wiki/page?id=2_7_0%3Ainstall%3Aupgrading_itop
+[5]: https://www.itophub.io/wiki
+[6]: https://store.itophub.io/en_US/
 
 [10]: https://www.itophub.io/wiki/page?id=latest%3Adatamodel%3Astart#configuration_management_cmdb
 [11]: https://www.itophub.io/wiki/page?id=latest%3Adatamodel%3Astart#ticketing


### PR DESCRIPTION
At first I added a complete section with a table and all currently supported versions of iTop, then @bruno-ds pointed out that it would only be redundant with the wiki page and just another source of information to maintain (which is totally true, thanks!). So instead it's just a simple link in the "resources" section.

Below is the original table, just because I learned how to make them in GitHub 😁

## Software requirements
| iTop version | PHP versions | MySQL versions | MariaDB versions | Chrome support | Firefox support | Edge support | IE support | Limitations |
|:------------:|:-------------|:---------------|:-----------------|:--------------:|:---------------:|:------------:|:----------:|:---|
| 2.8.x | **7.1-7.4** | **5.7**-8.0 | **10.3+** | ✔ | ✔ | ✔ | ❌       | - |
| 2.7.x | 5.6-7.3     | 5.6-**8.0** | 10.1+     | ✔ | ✔ | ✔ | **IE10+** | Add MySQL 8 support, but not recommended for large database |
| 2.6.1 | 5.6-**7.3** | 5.6-5.7     | 10.1+     | ✔ | ✔ | ✔ | IE9+      | Add PHP 7.3 support |
| 2.6.0 | 5.6-7.2     | 5.6-5.7     | 10.1+     | ✔ | ✔ | ✔ | IE9+      | - |