### PR TITLE
fix: DB schema check, MySQL 8 int and tinyint ignore length

### DIFF
--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -605,7 +605,7 @@ class CMDBSource
 	 */
 	private static function RemoveSurroundingQuotes($sValue)
 	{
-		if (utils::StartsWith($sValue, '\'') && utils::EndsWith($sValue, '\''))
+		if ($sValue != "'" && utils::StartsWith($sValue, '\'') && utils::EndsWith($sValue, '\''))
 		{
 			$sValue = substr($sValue, 1, -1);
 		}
@@ -1187,8 +1187,12 @@ class CMDBSource
 
 		if (strcmp($sItopFieldTypeOptions, $sDbFieldTypeOptions) !== 0)
 		{
+			// in MySQL 8, will ignore int and tinyint length
+			$aIgnoreOptions = array("int", "tinyint");
 			// case sensitive comp as we need to check case for enum possible values for example
-			return false;
+			if(!in_array($sDbFieldDataType, $aIgnoreOptions)) {
+				return false;
+			}
 		}
 
 		// remove the default value NULL added by MariadDB


### PR DESCRIPTION
If use MySQL 8，toolkit db schema check will report:

- `found int DEFAULT 0 while expecting INT(11) DEFAULT 0`
- `found tinyint DEFAULT 0 while expecting TINYINT(1) DEFAULT 0`
- `varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT while expecting VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT '\''`

this pr try to fix it.