### PR TITLE
Generate lifecycle as SVG

### DIFF
--- a/pages/graphviz.php
+++ b/pages/graphviz.php
@@ -143,6 +143,7 @@ if (file_exists($sDotExecutable))
 	else
 	{
 		header('Content-type: image/svg+xml');
+		header('Content-Disposition: inline; filename="'.$sClass.'.svg"');
 		readfile($sImageFilePath);
 	}
 	@unlink($sDotFilePath);
@@ -150,6 +151,7 @@ if (file_exists($sDotExecutable))
 else
 {
 	header('Content-type: image/png');
+	header('Content-Disposition: inline; filename="'.$sClass.'.png"');
 	readfile($sImageFilePath);
 }
 

--- a/pages/graphviz.php
+++ b/pages/graphviz.php
@@ -143,14 +143,14 @@ if (file_exists($sDotExecutable))
 	else
 	{
 		header('Content-type: image/png');
-		echo file_get_contents($sImageFilePath);
+		readfile($sImageFilePath);
 	}
 	@unlink($sDotFilePath);
 }
 else
 {
 	header('Content-type: image/png');
-	echo file_get_contents($sImageFilePath);
+	readfile($sImageFilePath);
 }
 
 ?>

--- a/pages/graphviz.php
+++ b/pages/graphviz.php
@@ -112,7 +112,7 @@ $sDotExecutable = MetaModel::GetConfig()->Get('graphviz_path');
 if (file_exists($sDotExecutable))
 {
 	// create the file with Graphviz
-	$sImageFilePath = APPROOT."data/lifecycle/".$sClass.".png";
+	$sImageFilePath = APPROOT."data/lifecycle/".$sClass.".svg";
 	if (!is_dir(APPROOT."data"))
 	{
 		@mkdir(APPROOT."data");
@@ -128,7 +128,7 @@ if (file_exists($sDotExecutable))
 	@fwrite($rFile, $sDotDescription);
 	@fclose($rFile);
 	$aOutput = array();
-	$CommandLine = "\"$sDotExecutable\" -v -Tpng < \"$sDotFilePath\" -o \"$sImageFilePath\" 2>&1";
+	$CommandLine = "\"$sDotExecutable\" -v -Tsvg < \"$sDotFilePath\" -o \"$sImageFilePath\" 2>&1";
 	
 	exec($CommandLine, $aOutput, $iRetCode);
 	if ($iRetCode != 0)
@@ -142,7 +142,7 @@ if (file_exists($sDotExecutable))
 	}
 	else
 	{
-		header('Content-type: image/png');
+		header('Content-type: image/svg+xml');
 		readfile($sImageFilePath);
 	}
 	@unlink($sDotFilePath);


### PR DESCRIPTION
Here a request to change the Graphviz generation of a lifecycle to output SVG instead of PNG.

Pro:
- Smaller image size (Roughly 10x smaller files)
- Easier readable when there are a lot of transitions
- Reduced php memory consumption by using `readfile` instead of `echo file_get_contents`.

Con:
- Might not be supported by old browsers