### PR TITLE
Fix AttributeDecimal to be empty in synchro

### DIFF
--- a/synchro/synchro_import.php
+++ b/synchro/synchro_import.php
@@ -534,7 +534,7 @@ try
 				$aValues = array(); // Used to build the insert query
 				foreach ($aRow as $iCol => $value)
 				{
-					if ($value === null)
+					if (!strlen($value))
 					{
 						$aValues[] = 'NULL';
 					}
@@ -604,7 +604,11 @@ try
 					}
 
 					$sCol = $aInputColumns[$iCol];
-					if ($aIsDateToTransform[$iCol] !== false)
+					if(!strlen($value))
+					{
+						$aValuePairs[] = "`$sCol` = NULL";
+					}
+					elseif ($aIsDateToTransform[$iCol] !== false)
 					{
 						$bDateOnly = false;
 						$sFormat = $sDateTimeFormat;


### PR DESCRIPTION
### Problem
When having fields of type AttributeDecimal (or AttributeInteger, ..) and you want to do a data synchronisation with them, it is not possible to synchronise when there is no value. MySQL will complain with:
> Incorrect decimal value: '' for column 'decimal_field' at row 1
### Solution
Fix the query building process to not generate `''` as value for these fields, but use `NULL` instead. There was an `if` clause intending to do that, but never got used.