### PR TITLE
Fix filename headers when downloading

### DIFF
--- a/sources/application/TwigBase/Controller/Controller.php
+++ b/sources/application/TwigBase/Controller/Controller.php
@@ -437,7 +437,7 @@ abstract class Controller
 
 		if ($bFileTransfer)
 		{
-			header('Content-Disposition: attachment; filename="'.$sDownloadArchiveName);
+			header('Content-Disposition: attachment; filename="'.$sDownloadArchiveName.'"');
 		}
 
 		header('Expires: 0');

--- a/sources/application/TwigBase/Controller/Controller.php
+++ b/sources/application/TwigBase/Controller/Controller.php
@@ -437,8 +437,7 @@ abstract class Controller
 
 		if ($bFileTransfer)
 		{
-			header('Content-Description: File Transfer');
-			header('Content-Disposition: inline; filename="'.$sDownloadArchiveName);
+			header('Content-Disposition: attachment; filename="'.$sDownloadArchiveName);
 		}
 
 		header('Expires: 0');


### PR DESCRIPTION
The [Content-Disposition](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) is either `inline` or `attachment` with optional filename.

The wrong combination resulted in (some?) browser not to use the correct name for the downloaded file.

Also, the `Content-Description` header is not a HTTP header, but a MIME header, so I removed that as well.