### PR TITLE
Correctly detect if connection to client is secure

### DIFF
--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -925,10 +925,19 @@ class utils
 	{
 		$bSecured = false;
 
-		if (!empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+		if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']))
 		{
-			$bSecured = true;
+			$bSecured = ($_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https');
 		}
+		elseif (!empty($_SERVER['HTTP_X_FORWARDED_PROTOCOL']))
+		{
+			$bSecured = ($_SERVER['HTTP_X_FORWARDED_PROTOCOL'] === 'https');
+		}
+		elseif (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']))
+		{
+			$bSecured = (strcasecmp($_SERVER['HTTPS'], 'off') !== 0);
+		}
+
 		return $bSecured;
 	}
 

--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -834,7 +834,7 @@ class utils
 	{
 		// Build an absolute URL to this page on this server/port
 		$sServerName = isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : '';
-		$sProtocol = self::IsConnectionSecure() ? 'https' : 'http';
+		$sProtocol = self::IsConnectionSecure(true) ? 'https' : 'http';
 		$iPort = isset($_SERVER['SERVER_PORT']) ? $_SERVER['SERVER_PORT'] : 80;
 		if ($sProtocol == 'http')
 		{
@@ -920,16 +920,20 @@ class utils
 	 * Though the official specs says 'a non empty string', some servers like IIS do set it to 'off' !
 	 * nginx set it to an empty string
 	 * Others might leave it unset (no array entry)	 
+	 *
+	 * @param bool $bTrustProxy
+	 *
+	 * @return bool
 	 */	 	
-	public static function IsConnectionSecure()
+	public static function IsConnectionSecure($bTrustProxy=false)
 	{
 		$bSecured = false;
 
-		if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']))
+		if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $bTrustProxy)
 		{
 			$bSecured = ($_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https');
 		}
-		elseif (!empty($_SERVER['HTTP_X_FORWARDED_PROTOCOL']))
+		elseif (!empty($_SERVER['HTTP_X_FORWARDED_PROTOCOL']) && $bTrustProxy)
 		{
 			$bSecured = ($_SERVER['HTTP_X_FORWARDED_PROTOCOL'] === 'https');
 		}

--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -790,11 +790,13 @@ class utils
     /**
      * Returns the absolute URL to the application root path
      *
+     * @param bool $bTrustProxy
+     *
      * @return string The absolute URL to the application root, without the first slash
      *
      * @throws \Exception
      */
-	public static function GetAbsoluteUrlAppRoot()
+	public static function GetAbsoluteUrlAppRoot($bTrustProxy=false)
 	{
 		static $sUrl = null;
 		if ($sUrl === null)
@@ -802,7 +804,7 @@ class utils
 			$sUrl = self::GetConfig()->Get('app_root_url');
 			if ($sUrl == '')
 			{
-				$sUrl = self::GetDefaultUrlAppRoot();
+				$sUrl = self::GetDefaultUrlAppRoot($bTrustProxy);
 			}
 			elseif (strpos($sUrl, SERVER_NAME_PLACEHOLDER) > -1)
 			{
@@ -826,15 +828,17 @@ class utils
 	 * For most usages, when an root url is needed, use utils::GetAbsoluteUrlAppRoot() instead as uses this only as a fallback when the
 	 * app_root_url conf parameter is not defined.
 	 *
+	 * @param bool $bTrustProxy
+	 * 
 	 * @return string
 	 *
 	 * @throws \Exception
      */
-    public static function GetDefaultUrlAppRoot()
+    public static function GetDefaultUrlAppRoot($bTrustProxy=false)
 	{
 		// Build an absolute URL to this page on this server/port
 		$sServerName = isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : '';
-		$sProtocol = self::IsConnectionSecure(true) ? 'https' : 'http';
+		$sProtocol = self::IsConnectionSecure($bTrustProxy) ? 'https' : 'http';
 		$iPort = isset($_SERVER['SERVER_PORT']) ? $_SERVER['SERVER_PORT'] : 80;
 		if ($sProtocol == 'http')
 		{

--- a/setup/setuppage.class.inc.php
+++ b/setup/setuppage.class.inc.php
@@ -144,7 +144,7 @@ class SetupPage extends NiceWebPage
 
 	public function output()
 	{
-		$sLogo = utils::GetAbsoluteUrlAppRoot().'/images/itop-logo.png';
+		$sLogo = utils::GetAbsoluteUrlAppRoot(true).'/images/itop-logo.png';
 		$this->s_content = "<div id=\"header\"><h1><a href=\"http://www.combodo.com/itop\" target=\"_blank\"><img title=\"iTop by Combodo\" alt=\" \" src=\"{$sLogo}?t=".utils::GetCacheBusterTimestamp()."\"></a>&nbsp;".htmlentities($this->s_title,
 				ENT_QUOTES, self::PAGES_CHARSET)."</h1>\n</div><div id=\"setup\">{$this->s_content}\n</div>\n";
 

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -978,7 +978,7 @@ class WizStepMiscParams extends WizardStep
 	public function Display(WebPage $oPage)
 	{
 		$sDefaultLanguage = $this->oWizard->GetParameter('default_language', $this->oWizard->GetParameter('admin_language'));
-		$sApplicationURL = $this->oWizard->GetParameter('application_url', utils::GetDefaultUrlAppRoot());
+		$sApplicationURL = $this->oWizard->GetParameter('application_url', utils::GetDefaultUrlAppRoot(true));
 		$sDefaultGraphvizPath = (strtolower(substr(PHP_OS, 0, 3)) === 'win') ? 'C:\\Program Files\\Graphviz\\bin\\dot.exe' : '/usr/bin/dot';
 		$sGraphvizPath = $this->oWizard->GetParameter('graphviz_path', $sDefaultGraphvizPath);
 		$sSampleData = $this->oWizard->GetParameter('sample_data', 'yes');
@@ -1125,7 +1125,7 @@ class WizStepUpgradeMiscParams extends WizardStep
 
 	public function Display(WebPage $oPage)
 	{
-		$sApplicationURL = $this->oWizard->GetParameter('application_url', utils::GetDefaultUrlAppRoot());
+		$sApplicationURL = $this->oWizard->GetParameter('application_url', utils::GetDefaultUrlAppRoot(true));
 		$sDefaultGraphvizPath = (strtolower(substr(PHP_OS, 0, 3)) === 'win') ? 'C:\\Program Files\\Graphviz\\bin\\dot.exe' : '/usr/bin/dot';
 		$sGraphvizPath = $this->oWizard->GetParameter('graphviz_path', $sDefaultGraphvizPath);
 		$oPage->add('<h2>Additional parameters</h2>');
@@ -1376,14 +1376,14 @@ class WizStepModulesChoice extends WizardStep
 			if (substr($sBannerPath, 0, 1) == '/')
 			{
 				// absolute path, means relative to APPROOT
-				$sBannerUrl = utils::GetDefaultUrlAppRoot().$sBannerPath;
+				$sBannerUrl = utils::GetDefaultUrlAppRoot(true).$sBannerPath;
 			}
 			else
 			{
 				// relative path: i.e. relative to the directory containing the XML file
 				$sFullPath = dirname($this->GetSourceFilePath()).'/'.$sBannerPath;
 				$sRealPath = realpath($sFullPath);
-				$sBannerUrl = utils::GetDefaultUrlAppRoot().str_replace(realpath(APPROOT), '', $sRealPath);
+				$sBannerUrl = utils::GetDefaultUrlAppRoot(true).str_replace(realpath(APPROOT), '', $sRealPath);
 			}
 			$oPage->add('<td><img src="'.$sBannerUrl.'"/><td>');
 		}
@@ -2494,7 +2494,7 @@ class WizStepDone extends WizardStep
 		$aManualSteps = array();
 		$aAvailableModules = SetupUtils::AnalyzeInstallation($this->oWizard);
 
-		$sRootUrl = utils::GetAbsoluteUrlAppRoot();
+		$sRootUrl = utils::GetAbsoluteUrlAppRoot(true);
 		$aSelectedModules = json_decode($this->oWizard->GetParameter('selected_modules'), true);
 		foreach($aSelectedModules as $sModuleId)
 		{
@@ -2526,7 +2526,7 @@ class WizStepDone extends WizardStep
 			{
 				// To mitigate security risks: pass only the filename without the extension, the download will add the extension itself
 				$oPage->p('Your backup is ready');
-				$oPage->p('<a style="background:transparent;" href="'.utils::GetAbsoluteUrlAppRoot().'setup/ajax.dataloader.php?operation=async_action&step_class=WizStepDone&params[backup]='.urlencode($sBackupDestination).'&authent='.$this->oWizard->GetParameter('authent','').'" target="_blank"><img src="../images/tar.png" style="border:0;vertical-align:middle;">&nbsp;Download '.basename($sBackupDestination).'</a>');
+				$oPage->p('<a style="background:transparent;" href="'.utils::GetAbsoluteUrlAppRoot(true).'setup/ajax.dataloader.php?operation=async_action&step_class=WizStepDone&params[backup]='.urlencode($sBackupDestination).'&authent='.$this->oWizard->GetParameter('authent','').'" target="_blank"><img src="../images/tar.png" style="border:0;vertical-align:middle;">&nbsp;Download '.basename($sBackupDestination).'</a>');
 			}
 			else
 			{


### PR DESCRIPTION
The current code breaks the setup page when the iTop server is behind a proxy that handles [SSL termination](https://en.wikipedia.org/wiki/TLS_termination_proxy).

I have applied a better way to detect if iTop has been reached over HTTPS based on code already present in the project:
https://github.com/Combodo/iTop/blob/97e58c2d79355c71b91e44071d24796fe6449e67/datamodels/2.x/authent-cas/vendor/apereo/phpcas/source/CAS/Client.php#L3591-L3610