### PR TITLE
fix error: Invalid uniqueness rule declaration : class=FunctionalCI, …

### DIFF
--- a/core/metamodel.class.php
+++ b/core/metamodel.class.php
@@ -2889,6 +2889,7 @@ abstract class MetaModel
 					if (!empty($aCurrentClassUniquenessRules))
 					{
 						$aClassFields = self::GetAttributesList($sPHPClass);
+						$aClassFields[] = "finalclass";
 						foreach ($aCurrentClassUniquenessRules as $sUniquenessRuleId => $aUniquenessRuleProperties)
 						{
 							$bIsRuleOverride = self::HasSameUniquenessRuleInParent($sPHPClass, $sUniquenessRuleId);


### PR DESCRIPTION
follow the wiki：https://www.itophub.io/wiki/page?id=2_7_0%3Acustomization%3Auniqueness-rules

define  **Unique name within sub-classes**

```xml
        <uniqueness_rules>
          <rule id="functionalci_name" _delta="define">
            <!-- field or combination of "FunctionalCI" fields which must be unique -->
            <attributes>
              <attribute id="name"/>
              <attribute id="finalclass"/>
            </attributes>
          <!-- ... -->
```

will report error:

> Invalid uniqueness rule declaration : class=FunctionalCI, rule=functionalci_name, reason=Uniqueness rule : non existing field 'finalclass'

This pr try to fix the error. This may not be the right fix, I just want to point out the issue.