### PR TITLE
Advanced search: only list AttributeExternalKey items which is used by the objects

### DIFF
--- a/sources/application/search/searchform.class.inc.php
+++ b/sources/application/search/searchform.class.inc.php
@@ -48,6 +48,8 @@ use UserRights;
 
 class SearchForm
 {
+	private $sClass;
+
 	/**
 	 * @param \WebPage $oPage
 	 * @param \CMDBObjectSet $oSet
@@ -63,6 +65,7 @@ class SearchForm
 		$sHtml = '';
 		$oAppContext = new ApplicationContext();
 		$sClassName = $oSet->GetFilter()->GetClass();
+		$this->sClass = $sClassName;
 		$aListParams = array();
 
 		foreach($aExtraParams as $key => $value)
@@ -437,7 +440,7 @@ class SearchForm
      * @throws \MySQLException
      * @throws \MySQLHasGoneAwayException
      */
-	public static function GetFieldAllowedValues($oAttrDef)
+	public static function GetFieldAllowedValues($oAttrDef, $sClass = '')
 	{
 		$iMaxComboLength = MetaModel::GetConfig()->Get('max_combo_length');
 		if ($oAttrDef->IsExternalKey(EXTKEY_ABSOLUTE))
@@ -509,7 +512,11 @@ class SearchForm
 			}
 		}
 
-		$aAllowedValues = $oAttrDef->GetAllowedValues();
+		$aArgs = array(
+			"this->finalclass" => $sClass
+		);
+
+		$aAllowedValues = $oAttrDef->GetAllowedValues($aArgs);
 
 		return array('values' => $aAllowedValues);
 	}
@@ -719,7 +726,7 @@ class SearchForm
 			$aField['target_class'] = $sTargetClass;
 			$aField['label'] = $sLabel;
 			$aField['widget'] = $oAttDef->GetSearchType();
-			$aField['allowed_values'] = self::GetFieldAllowedValues($oAttDef);
+			$aField['allowed_values'] = self::GetFieldAllowedValues($oAttDef, $this->sClass);
 			$aField['is_null_allowed'] = $oAttDef->IsNullAllowed();
 			$aField['has_index'] = $bHasIndex;
 			$aFields[$sClassAlias.'.'.$sAttCode] = $aField;


### PR DESCRIPTION
Update 2020/10/26
Latest commit use a new method, only list AttributeExternalKey items which is used by the objects. No need to define `<filter>` any more. 

--------
Assuming such a scenario, we manage a variety of devices, they have different brand models, there may be dozens of them. At this time, when the user views the server or network device list, many items can be seen in the brand search box. 
![image](https://user-images.githubusercontent.com/4145852/93483296-4422c880-f933-11ea-8237-b2cbf8200c82.png)

The system administrator may not want to see the brand of the router, and the network administrator does not want to see the brand of the server. Therefore, I hope to reduce the number of brands listed through filter. Through the following OQL statement: `SELECT Brand AS b JOIN Model AS m ON m.brand_id=b.id WHERE m.type=:this->finalclass`. 

```xml
<class id="PhysicalDevice">
	<fields>
		<field id="brand_id" xsi:type="AttributeExternalKey"  _delta="redefine">
			<sql>brand_id</sql>
			<target_class>Brand</target_class>
			<is_null_allowed>true</is_null_allowed>
			<on_target_delete>DEL_MANUAL</on_target_delete>
			<filter>SELECT Brand AS b JOIN Model AS m ON m.brand_id=b.id WHERE m.type=:this->finalclass</filter>
		</field>
	</fields>
</class>
```
It works fine when edit an object, but has no effect in the list interface. Looking at the code, I found that the search form does not support OQL statements with variables. This is normal, after all, lists is objectset, and variables for a single object, like `:this->org_id`, `:this->location_id`,  are almost useless. But `:this->finalclass` is not for a single object, I think it is worth supporting, to improve the user experience in this scenario. .
![image](https://user-images.githubusercontent.com/4145852/93483335-4be26d00-f933-11ea-88f0-7b870f3386ba.png)

This pr try to resolve the issue. This may not be the right fix, I just want to point out the issue.
