### PR TITLE
Use filter of external key on csv import

### DIFF
--- a/core/bulkchange.class.inc.php
+++ b/core/bulkchange.class.inc.php
@@ -378,7 +378,7 @@ class BulkChange
 			}
 			else
 			{
-				$oReconFilter = new DBObjectSearch($oExtKey->GetTargetClass());
+				$oReconFilter = $oExtKey->GetAllowedValuesAsFilter();
 
 				$aCacheKeys = array();
 				foreach ($aKeyConfig as $sForeignAttCode => $iCol)
@@ -417,7 +417,7 @@ class BulkChange
 				else
 				{
 					// Cache miss, let's initialize it
-					$oExtObjects = new CMDBObjectSet($oReconFilter);
+					$oExtObjects = new CMDBObjectSet($oReconFilter, array(), $oTargetObj->ToArgs());
 					$iCount = $oExtObjects->Count();
 					if ($iCount == 1)
 					{


### PR DESCRIPTION
This allows an extra check to see if the provided values are compliant with the specified filter. Example `model_id` on `PhysicalDevice`.

It also reduces the need of adding `Model->Brand name` field in csv next to `Model->Name` when importing a device. If you have duplicate model names (for different brands or different device types), the import tool is unable to pick the correct one without the addition of brand name. In some cases we are importing devices with a brand name, but without model, then this is also not working because the import tool searches for a Model with empty name and a brand name.

I didn't test this with any object that has a hierarchical key.