### PR TITLE
Advanced search: Fix string criterion contains '0' returning all results

### DIFF
--- a/sources/application/search/criterionconversion/criteriontooql.class.inc.php
+++ b/sources/application/search/criterionconversion/criteriontooql.class.inc.php
@@ -114,12 +114,21 @@ class CriterionToOQL extends CriterionConversionAbstract
 		return addslashes($aValues[$iIndex]['value']);
 	}
 
+	private static function IsEmpty($sValue)
+	{
+		if ($sValue === "0")
+		{
+			return false;
+		}
+		return empty($sValue);
+	}
+
 	protected static function ContainsToOql($oSearch, $sRef, $aCriteria)
 	{
 		$aValues = self::GetValues($aCriteria);
 		$sValue = self::GetValue($aValues, 0);
 
-		if (empty($sValue))
+		if (self::IsEmpty($sValue))
 		{
 			return "1";
 		}
@@ -132,7 +141,7 @@ class CriterionToOQL extends CriterionConversionAbstract
 		$aValues = self::GetValues($aCriteria);
 		$sValue = self::GetValue($aValues, 0);
 
-		if (empty($sValue))
+		if (self::IsEmpty($sValue))
 		{
 			return "1";
 		}
@@ -145,7 +154,7 @@ class CriterionToOQL extends CriterionConversionAbstract
 		$aValues = self::GetValues($aCriteria);
 		$sValue = self::GetValue($aValues, 0);
 
-		if (empty($sValue))
+		if (self::IsEmpty($sValue))
 		{
 			return "1";
 		}
@@ -162,7 +171,7 @@ class CriterionToOQL extends CriterionConversionAbstract
 			return "({$sRef} = '0')";
 		}
 
-		if (empty($sValue) && (!(isset($aCriteria['has_undefined'])) || !($aCriteria['has_undefined'])))
+		if (self::IsEmpty($sValue) && (!(isset($aCriteria['has_undefined'])) || !($aCriteria['has_undefined'])))
 		{
 			return "1";
 		}
@@ -175,7 +184,7 @@ class CriterionToOQL extends CriterionConversionAbstract
 		$aValues = self::GetValues($aCriteria);
 		$sValue = self::GetValue($aValues, 0);
 
-		if (empty($sValue))
+		if (self::IsEmpty($sValue))
 		{
 			return "1";
 		}

--- a/sources/application/search/criterionconversion/criteriontooql.class.inc.php
+++ b/sources/application/search/criterionconversion/criteriontooql.class.inc.php
@@ -114,21 +114,12 @@ class CriterionToOQL extends CriterionConversionAbstract
 		return addslashes($aValues[$iIndex]['value']);
 	}
 
-	private static function IsEmpty($sValue)
-	{
-		if ($sValue === "0")
-		{
-			return false;
-		}
-		return empty($sValue);
-	}
-
 	protected static function ContainsToOql($oSearch, $sRef, $aCriteria)
 	{
 		$aValues = self::GetValues($aCriteria);
 		$sValue = self::GetValue($aValues, 0);
 
-		if (self::IsEmpty($sValue))
+		if (!strlen($sValue))
 		{
 			return "1";
 		}
@@ -141,7 +132,7 @@ class CriterionToOQL extends CriterionConversionAbstract
 		$aValues = self::GetValues($aCriteria);
 		$sValue = self::GetValue($aValues, 0);
 
-		if (self::IsEmpty($sValue))
+		if (!strlen($sValue))
 		{
 			return "1";
 		}
@@ -154,7 +145,7 @@ class CriterionToOQL extends CriterionConversionAbstract
 		$aValues = self::GetValues($aCriteria);
 		$sValue = self::GetValue($aValues, 0);
 
-		if (self::IsEmpty($sValue))
+		if (!strlen($sValue))
 		{
 			return "1";
 		}
@@ -171,7 +162,7 @@ class CriterionToOQL extends CriterionConversionAbstract
 			return "({$sRef} = '0')";
 		}
 
-		if (self::IsEmpty($sValue) && (!(isset($aCriteria['has_undefined'])) || !($aCriteria['has_undefined'])))
+		if (!strlen($sValue) && (!(isset($aCriteria['has_undefined'])) || !($aCriteria['has_undefined'])))
 		{
 			return "1";
 		}
@@ -184,7 +175,7 @@ class CriterionToOQL extends CriterionConversionAbstract
 		$aValues = self::GetValues($aCriteria);
 		$sValue = self::GetValue($aValues, 0);
 
-		if (self::IsEmpty($sValue))
+		if (!strlen($sValue))
 		{
 			return "1";
 		}


### PR DESCRIPTION
criterion `contains 0` will not work as expect
![image](https://user-images.githubusercontent.com/4145852/94444448-ea46bc00-01d8-11eb-9803-c168e7e2881c.png)

The redevelopped query expression should be 
```
SELECT `Server` FROM Server AS `Server` WHERE (`Server`.`friendlyname` LIKE '%0%')
```

The problem is caused by `empty()` function considered "0"(0 as a string) to be empty.