### PR TITLE
configurable default favorite_orgs

### DIFF
--- a/application/itopwebpage.class.inc.php
+++ b/application/itopwebpage.class.inc.php
@@ -784,7 +784,7 @@ JS
 		if (MetaModel::IsValidClass('Organization'))
 		{
 			// Display the list of *favorite* organizations... but keeping in mind what is the real number of organizations
-			$aFavoriteOrgs = appUserPreferences::GetPref('favorite_orgs', null);
+			$aFavoriteOrgs = appUserPreferences::GetPref('favorite_orgs', MetaModel::GetConfig()->Get('favorite_orgs'));
 			$oSearchFilter = new DBObjectSearch('Organization');
 			$oSearchFilter->SetModifierProperty('UserRightsGetSelectFilter', 'bSearchMode', true);
 			$oSet = new CMDBObjectSet($oSearchFilter);

--- a/application/itopwebpage.class.inc.php
+++ b/application/itopwebpage.class.inc.php
@@ -785,6 +785,7 @@ JS
 		{
 			// Display the list of *favorite* organizations... but keeping in mind what is the real number of organizations
 			$aFavoriteOrgs = appUserPreferences::GetPref('favorite_orgs', MetaModel::GetConfig()->Get('favorite_orgs'));
+			if(!$aFavoriteOrgs) $aFavoriteOrgs = MetaModel::GetConfig()->Get('favorite_orgs');
 			$oSearchFilter = new DBObjectSearch('Organization');
 			$oSearchFilter->SetModifierProperty('UserRightsGetSelectFilter', 'bSearchMode', true);
 			$oSet = new CMDBObjectSet($oSearchFilter);

--- a/application/user.preferences.class.inc.php
+++ b/application/user.preferences.class.inc.php
@@ -50,7 +50,7 @@ class appUserPreferences extends DBObject
 			self::Load();
 		}
 		$aPrefs = self::$oUserPrefs->Get('preferences');
-		if (array_key_exists($sCode, $aPrefs) && $aPrefs[$sCode])
+		if (array_key_exists($sCode, $aPrefs))
 		{
 			return $aPrefs[$sCode];
 		}

--- a/application/user.preferences.class.inc.php
+++ b/application/user.preferences.class.inc.php
@@ -50,7 +50,7 @@ class appUserPreferences extends DBObject
 			self::Load();
 		}
 		$aPrefs = self::$oUserPrefs->Get('preferences');
-		if (array_key_exists($sCode, $aPrefs))
+		if (array_key_exists($sCode, $aPrefs) && $aPrefs[$sCode])
 		{
 			return $aPrefs[$sCode];
 		}

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1249,6 +1249,14 @@ class Config
 			'source_of_value' => '',
 			'show_in_conf_sample' => false,
 		),
+		'favorite_orgs' => array(
+			'type' => 'array',
+			'description' => 'Default favorite organizations, array of Organization id',
+			'default' => null,
+			'value' => null,
+			'source_of_value' => null,
+			'show_in_conf_sample' => false,
+		),
 	);
 
 


### PR DESCRIPTION
If iTop manage lots of Organizations, It will be inconvenient when switch organization at the left upper corner, this pr add default favorite_orgs through config file.