### PR TITLE
:sparkles: iTop mutliple url apc_cache

### DIFF
--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -7966,7 +7966,35 @@ class AttributeImage extends AttributeBlob
 	 */
 	public function __construct($sCode, $aParams)
 	{
+		//Remove AbsoluteUrlModulesRoot hardcoded to the default_image
+		if (!empty($aParams) && array_key_exists('default_image', $aParams) && !empty($aParams['default_image'])) 
+		{
+			$sAbsoluteUrlModulesRoot = utils::GetAbsoluteUrlModulesRoot();
+			if (strpos($aParams['default_image'], $sAbsoluteUrlModulesRoot) !== false) 
+			{
+				$aParams['default_image'] = str_replace($sAbsoluteUrlModulesRoot, '', $aParams['default_image']);
+			}
+		}
 		parent::__construct($sCode, $aParams);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * @param string $sParamName
+	 * @return type
+	 */
+	public function Get($sParamName) {
+		$oParamValue = parent::Get($sParamName);
+		
+		if ($sParamName == 'default_image') 
+		{
+			if (!empty($oParamValue)) // check if not null
+			{
+				return utils::GetAbsoluteUrlModulesRoot().$oParamValue;
+			}
+		}
+		
+		return $oParamValue;
 	}
 
 	public function GetEditClass()

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -1484,6 +1484,10 @@ abstract class DBObject implements iDisplay
 			if (array_key_exists($sCode, $aHighlightScale))
 			{
 				$sIconUrl = $aHighlightScale[$sCode]['icon'];
+				if (!empty($sIconUrl)) 
+				{
+						$sIconUrl = utils::GetAbsoluteUrlModulesRoot().$sIconUrl;
+				}
 				if($bImgTag)
 				{
 					return "<img src=\"$sIconUrl\" style=\"vertical-align:middle\"/>";

--- a/core/metamodel.class.php
+++ b/core/metamodel.class.php
@@ -463,7 +463,10 @@ abstract class MetaModel
 				return self::GetClassIcon($sParentClass, $bImgTag, $sMoreStyles);
 			}
 		}
-		$sIcon = str_replace('/modules/', '/env-'.self::$m_sEnvironment.'/', $sIcon); // Support of pre-2.0 modules
+		//Dyanmic url
+		if (!empty($sIcon)) {
+			$sIcon = utils::GetAbsoluteUrlModulesRoot().$sIcon;
+		}
 		if ($bImgTag && ($sIcon != '')) {
 			$sIcon = "<img src=\"$sIcon\" style=\"vertical-align:middle;$sMoreStyles\"/>";
 		}
@@ -908,7 +911,7 @@ abstract class MetaModel
 		self::_check_subclass($sClass);
 
 		return array_key_exists("display_template",
-			self::$m_aClassParams[$sClass]) ? self::$m_aClassParams[$sClass]["display_template"] : '';
+			self::$m_aClassParams[$sClass]) ? utils::GetAbsoluteUrlModulesRoot().self::$m_aClassParams[$sClass]["display_template"] : '';
 	}
 
 	/**
@@ -3271,6 +3274,28 @@ abstract class MetaModel
 		self::$m_aParentClasses[$sClass] = array();
 		self::$m_aChildClasses[$sClass] = array();
 
+		//Update icon & display_templates
+		//Remove AbsoluteUrlModulesRoot hardcoded to the icon && disply_template, when using PHP class instead of XML one
+		if (!empty($aParams)) 
+		{
+			$sAbsoluteUrlModulesRoot = utils::GetAbsoluteUrlModulesRoot();
+			if (array_key_exists('icon', $aParams) && !empty($aParams['icon'])) 
+			{
+				$aParams['icon'] = str_replace('/modules/', '/env-'.self::$m_sEnvironment.'/', $aParams['icon']); // Support of pre-2.0 modules
+				if (strpos($aParams['icon'], $sAbsoluteUrlModulesRoot) !== false) 
+				{
+					$aParams['icon'] = str_replace($sAbsoluteUrlModulesRoot, '', $aParams['icon']);
+				}
+			}
+			if (array_key_exists('display_template', $aParams) && !empty($aParams['display_template'])) 
+			{
+				if (strpos($aParams['display_template'], $sAbsoluteUrlModulesRoot) !== false) 
+				{
+					$aParams['display_template'] = str_replace($sAbsoluteUrlModulesRoot, '', $aParams['display_template']);
+				}
+			}
+		}
+
 		self::$m_aClassParams[$sClass] = $aParams;
 
 		self::$m_aAttribDefs[$sClass] = array();
@@ -3567,6 +3592,22 @@ abstract class MetaModel
 	public static function Init_DefineHighlightScale($aHighlightScale)
 	{
 		$sTargetClass = self::GetCallersPHPClass("Init");
+		 //Update icon
+		//Remove AbsoluteUrlModulesRoot hardcoded to the icon, when using PHP class instead of XML one
+		if (!empty($aHighlightScale)) 
+		{
+			$sAbsoluteUrlModulesRoot = utils::GetAbsoluteUrlModulesRoot();
+			foreach ($aHighlightScale as $sItemKey => $aItemArray) 
+			{
+				if (array_key_exists('icon', $aItemArray) && !empty($aItemArray['icon'])) 
+				{
+					if (strpos($aParams['icon'], $sAbsoluteUrlModulesRoot) !== false) 
+					{
+						$aHighlightScale[$sItemKey]['icon'] = str_replace($sAbsoluteUrlModulesRoot, '', $aItemArray['icon']);
+					}
+				}
+			}
+		}
 		self::$m_aHighlightScales[$sTargetClass] = $aHighlightScale;
 	}
 

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -1074,14 +1074,14 @@ EOF
 		if (($sDisplayTemplate = $oProperties->GetChildText('display_template')) && (strlen($sDisplayTemplate) > 0))
 		{
 			$sDisplayTemplate = $sModuleRelativeDir.'/'.$sDisplayTemplate;
-			$aClassParams['display_template'] = "utils::GetAbsoluteUrlModulesRoot().'$sDisplayTemplate'";
+			$aClassParams['display_template'] = "'$sDisplayTemplate'";
 		}
 	
 		$this->CompileFiles($oProperties, $sTempTargetDir.'/'.$sModuleRelativeDir, $sFinalTargetDir.'/'.$sModuleRelativeDir, '');
 		if (($sIcon = $oProperties->GetChildText('icon')) && (strlen($sIcon) > 0))
 		{
 			$sIcon = $sModuleRelativeDir.'/'.$sIcon;
-			$aClassParams['icon'] = "utils::GetAbsoluteUrlModulesRoot().'$sIcon'";
+			$aClassParams['icon'] = "'$sIcon'";
 		}
 
 		$oOrder = $oProperties->GetOptionalElement('order');
@@ -1402,7 +1402,7 @@ EOF
 
 					if (($sDefault = $oField->GetChildText('default_image')) && (strlen($sDefault) > 0))
 					{
-						$aParameters['default_image'] = "utils::GetAbsoluteUrlModulesRoot().'$sModuleRelativeDir/$sDefault'";
+						$aParameters['default_image'] = "'$sModuleRelativeDir/$sDefault'";
 					}
 					else
 					{
@@ -1656,7 +1656,7 @@ EOF
 					if (($sIcon = $oItem->GetChildText('icon')) && (strlen($sIcon) > 0))
 					{
 						$sIcon = $sModuleRelativeDir.'/'.$sIcon;
-						$sIcon = "utils::GetAbsoluteUrlModulesRoot().'$sIcon'";
+						$sIcon = "'$sIcon'";
 					}
 					else
 					{


### PR DESCRIPTION
Hi,

Sorry i tried to think of tests, but it's kind of a difficult case with my time available for the moment. 

It's something that I already implemented in a client, but feel free to improve it !

The case was that multiple urls were allowed in a iTop (using $_SERVER['HTTP_HOST']), but if iTop was setup with http://itop-1.com, then all icons, display_template and especially default images were hardcoded to this url in the apc_cache.
Then if http://itop-1.com was not working anymore (eg.: proxy not working ) and i asked people to use http://itop-2.com, the default_image were still with itop-1, thus generating pages with content not loaded (as itop-1 url was still down).
It will also allow for a public and a private url, each not accessible by the other group of persons (internal having no DNS to public, and public no access to private).

In this PR, I removed the hardcoded link from the compiler (XML) and also from PHP (because there are still some extensions that are not XMLed for the datamodel...), and appending the current absolute url when generating the pages.

Have a great weekend and keep you healty