### PR TITLE
ormPassword: allow use of different password hash algo

### DIFF
--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1450,6 +1450,11 @@ class Config
 	protected $m_aCharsets;
 
 	/**
+	 * @var array Password hash algorithm to use.
+	 */
+	protected $m_iPasswordHashAlgo;
+
+	/**
 	 * Config constructor.
 	 *
 	 * @param string|null $sConfigFile
@@ -1492,6 +1497,7 @@ class Config
 		$this->m_sExtAuthVariable = DEFAULT_EXT_AUTH_VARIABLE;
 		$this->m_aCharsets = array();
 		$this->m_bQueryCacheEnabled = DEFAULT_QUERY_CACHE_ENABLED;
+		$this->m_iPasswordHashAlgo = PASSWORD_DEFAULT;
 
 		//define default encryption params according to php install
 		$aEncryptParams = SimpleCrypt::GetNewDefaultParams();
@@ -1651,6 +1657,7 @@ class Config
 		$this->m_sEncryptionKey = isset($MySettings['encryption_key']) ? trim($MySettings['encryption_key']) : $this->m_sEncryptionKey;
 		$this->m_sEncryptionLibrary = isset($MySettings['encryption_library']) ? trim($MySettings['encryption_library']) : $this->m_sEncryptionLibrary;
 		$this->m_aCharsets = isset($MySettings['csv_import_charsets']) ? $MySettings['csv_import_charsets'] : array();
+		$this->m_iPasswordHashAlgo = isset($MySettings['password_hash_algo']) ? $MySettings['password_hash_algo'] : $this->m_iPasswordHashAlgo;
 	}
 
 	protected function Verify()
@@ -1806,6 +1813,11 @@ class Config
 		return $this->m_aCharsets;
 	}
 
+	public function GetPasswordHashAlgo()
+	{
+		return $this->m_iPasswordHashAlgo;
+	}
+
 	public function SetLogGlobal($iLogGlobal)
 	{
 		$this->m_iLogGlobal = $iLogGlobal;
@@ -1921,6 +1933,7 @@ class Config
 		$aSettings['encryption_key'] = $this->m_sEncryptionKey;
 		$aSettings['encryption_library'] = $this->m_sEncryptionLibrary;
 		$aSettings['csv_import_charsets'] = $this->m_aCharsets;
+		$aSettings['password_hash_algo'] = $this->m_iPasswordHashAlgo;
 
 		foreach ($this->m_aModuleSettings as $sModule => $aProperties)
 		{

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1450,7 +1450,7 @@ class Config
 	protected $m_aCharsets;
 
 	/**
-	 * @var array Password hash algorithm to use.
+	 * @var integer Password hash algorithm to use.
 	 */
 	protected $m_iPasswordHashAlgo;
 

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -71,7 +71,7 @@ define('DEFAULT_ALLOWED_LOGIN_TYPES', 'form|external|basic');
 define('DEFAULT_EXT_AUTH_VARIABLE', '$_SERVER[\'REMOTE_USER\']');
 define('DEFAULT_ENCRYPTION_KEY', '@iT0pEncr1pti0n!'); // We'll use a random generated key later (if possible)
 define('DEFAULT_ENCRYPTION_LIB', 'Mcrypt'); // We'll define the best encryption available later
-
+define('DEFAULT_HASH_ALGO', PASSWORD_DEFAULT);
 /**
  * Config
  * configuration data (this class cannot not be localized, because it is responsible for loading the dictionaries)
@@ -1497,7 +1497,7 @@ class Config
 		$this->m_sExtAuthVariable = DEFAULT_EXT_AUTH_VARIABLE;
 		$this->m_aCharsets = array();
 		$this->m_bQueryCacheEnabled = DEFAULT_QUERY_CACHE_ENABLED;
-		$this->m_iPasswordHashAlgo = PASSWORD_DEFAULT;
+		$this->m_iPasswordHashAlgo = DEFAULT_HASH_ALGO;
 
 		//define default encryption params according to php install
 		$aEncryptParams = SimpleCrypt::GetNewDefaultParams();
@@ -1818,6 +1818,14 @@ class Config
 		return $this->m_iPasswordHashAlgo;
 	}
 
+	/**
+	 * @param $iPasswordHashAlgo
+	 */
+	public function SetPasswordHashAlgo($iPasswordHashAlgo)
+	{
+		$this->m_iPasswordHashAlgo = $iPasswordHashAlgo;
+	}
+
 	public function SetLogGlobal($iLogGlobal)
 	{
 		$this->m_iLogGlobal = $iLogGlobal;
@@ -2046,6 +2054,7 @@ class Config
 				'encryption_key' => $this->m_sEncryptionKey,
 				'encryption_library' => $this->m_sEncryptionLibrary,
 				'csv_import_charsets' => $this->m_aCharsets,
+				'password_hash_algo' => $this->m_iPasswordHashAlgo
 			);
 			foreach ($aOtherValues as $sKey => $value)
 			{

--- a/core/ormpassword.class.inc.php
+++ b/core/ormpassword.class.inc.php
@@ -51,7 +51,8 @@ class ormPassword
 	 */
 	public function SetPassword($sClearTextPassword)
 	{
-		$this->m_sHashed = password_hash($sClearTextPassword, PASSWORD_DEFAULT);
+		$iHashAlgo = MetaModel::GetConfig()->GetPasswordHashAlgo();
+		$this->m_sHashed = password_hash($sClearTextPassword, $iHashAlgo);
 	}
 
 	/**
@@ -96,18 +97,18 @@ class ormPassword
 	{
 		$bResult = false;
 		$aInfo = password_get_info($this->m_sHashed);
-		switch ($aInfo["algo"])
+		if (is_null($aInfo["algo"]) || $aInfo["algo"] === 0)
 		{
-			case 0:
-				//unknown, assume it's a legacy password
-				$sHashedPwd = $this->ComputeHash($sClearTextPassword);
-				if ($this->m_sHashed == $sHashedPwd)
-				{
-					$bResult = true;
-				}
-				break;
-			default:
-				$bResult = password_verify($sClearTextPassword, $this->m_sHashed);
+			//unknown, assume it's a legacy password
+			$sHashedPwd = $this->ComputeHash($sClearTextPassword);
+			if ($this->m_sHashed == $sHashedPwd)
+			{
+				$bResult = true;
+			}
+		}
+		else
+		{
+			$bResult = password_verify($sClearTextPassword, $this->m_sHashed);
 		}
 		return $bResult;
 	}

--- a/core/ormpassword.class.inc.php
+++ b/core/ormpassword.class.inc.php
@@ -101,10 +101,7 @@ class ormPassword
 		{
 			//unknown, assume it's a legacy password
 			$sHashedPwd = $this->ComputeHash($sClearTextPassword);
-			if ($this->m_sHashed == $sHashedPwd)
-			{
-				$bResult = true;
-			}
+			$bResult = ($this->m_sHashed == $sHashedPwd);
 		}
 		else
 		{

--- a/test/core/ormPasswordTest.php
+++ b/test/core/ormPasswordTest.php
@@ -1,0 +1,57 @@
+<?php
+/*!
+ * @copyright   Copyright (C) 2010-2020 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\Test\UnitTest\Core;
+
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use Utils;
+use ormPassword;
+
+/**
+ * Tests of the ormPassword class
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ * @backupGlobals disabled
+ */
+class ormPasswordTest extends ItopDataTestCase
+{
+
+	/**
+	 * @param $sToHashValues
+	 * @param $sToHashSalt
+	 * @param $sHashAlgo
+	 * @param $sExpectedHash
+	 *
+	 * @throws \ConfigException
+	 * @throws \CoreException
+	 * @dataProvider HashProvider
+	 */
+	public function testCheckHash($sToHashValues, $sToHashSalt, $sHashAlgo, $sExpectedHash)
+	{
+		utils::GetConfig()->SetPasswordHashAlgo($sHashAlgo);
+		$oPassword1 = new ormPassword($sExpectedHash, $sToHashSalt);
+		static::assertTrue($oPassword1->CheckPassword($sToHashValues));
+	}
+
+	public function HashProvider()
+	{
+		return array(
+			'Bcrypt' => array(
+				'admin',
+				'',
+				PASSWORD_BCRYPT,
+				'$2y$10$P6yqXv/0pT4e9kfN6d95jOKX4KR5Il.N0vRLc2DoZoycwnU9mcnia'
+			),
+			'sha256 (legacy)' => array(
+				'admin',
+				'salt',
+				'sha256',
+				'2bb7998496899acdd8137fad3a44faf96a84a03d7f230ce42e97cd17c7ae429e'
+			),
+		);
+	}
+}


### PR DESCRIPTION
Hi,
  this pull request introduces possibility to change password_hash algorithm via config file, ie. to use new, more advanced one, or to to use older algorithm if PASSWORD_DEFAULT changes.

example config:
```'password_hash_algo' => PASSWORD_ARGON2ID```

Along with this ormPassword::CheckPassword was fixed, because with different hash algo password_get_info() will return string and not integer as algo identificator, what results in code assuming that it is checking a legacy password.

Thank you