### PR TITLE
🌐 Dutch translations: distinguish between "approval" and "acceptance"

### DIFF
--- a/datamodels/2.x/itop-change-mgmt-itil/nl.dict.itop-change-mgmt-itil.php
+++ b/datamodels/2.x/itop-change-mgmt-itil/nl.dict.itop-change-mgmt-itil.php
@@ -237,9 +237,9 @@ Dict::Add('NL NL', 'Dutch', 'Nederlands', array(
 Dict::Add('NL NL', 'Dutch', 'Nederlands', array(
 	'Class:NormalChange' => 'Normale Change',
 	'Class:NormalChange+' => '',
-	'Class:NormalChange/Attribute:acceptance_date' => 'Datum goedkeuring',
+	'Class:NormalChange/Attribute:acceptance_date' => 'Datum acceptatie',
 	'Class:NormalChange/Attribute:acceptance_date+' => '',
-	'Class:NormalChange/Attribute:acceptance_comment' => 'Commentaar goedkeuring',
+	'Class:NormalChange/Attribute:acceptance_comment' => 'Commentaar acceptatie',
 	'Class:NormalChange/Attribute:acceptance_comment+' => '',
 	'Class:NormalChange/Stimulus:ev_validate' => 'Valideer',
 	'Class:NormalChange/Stimulus:ev_validate+' => '',


### PR DESCRIPTION
* distinguish between approval (goedkeuring) <=> acceptance (acceptatie). Both were translated as "datum goedkeuring" till now.

@Hipska agree? Or different translation suggestion?
@piRGoif not sure if I should do the pull request for "develop" or perhaps "support/2.7" or both?