### PR TITLE
N°3724 Print data source id in synchro_exec output

### DIFF
--- a/synchro/synchro_exec.php
+++ b/synchro/synchro_exec.php
@@ -134,6 +134,7 @@ foreach(explode(',', $sDataSourcesList) as $iSDS)
 		}
 		try
 		{
+			$oP->p("Working on ".utils::HtmlEntities($oSynchroDataSource->Get('name'))." (id=".utils::HtmlEntities($iSDS).")...");
 			$oSynchroExec = new SynchroExecution($oSynchroDataSource);
 			$oStatLog = $oSynchroExec->Process();
 			if ($bSimulate)


### PR DESCRIPTION
As it is possible to execute multiple data source
sync in one command run, print the corresponding
data source name before its output.