### PR TITLE
Fix AttributeCustomFields return null in REST/JSON service

### DIFF
--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -12689,7 +12689,7 @@ class AttributeCustomFields extends AttributeDefinition
 	 */
 	public function GetForJSON($value)
 	{
-		return null;
+		return $value->GetValues();
 	}
 
 	/**


### PR DESCRIPTION
For example, `service_details` is AttributeCustomFields，in rest/json service, it will return `null`

```json
{
  "objects": {
    "UserRequest::3979": {
      "code": 0,
      "message": "",
      "class": "UserRequest",
      "key": "3979",
      "fields": {
        "service_details": null
      }
    }
  },
  "code": 0,
  "message": "Found: 1"
}
```

After fix: 
```json
{
  "objects": {
    "UserRequest::3979": {
      "code": 0,
      "message": "",
      "class": "UserRequest",
      "key": "3979",
      "fields": {
        "service_details": {
          "legacy": "",
          "extradata_id": "3898",
          "_template_name_": "域名申请模板",
          "template_id": 7,
          "template_data": "",
          "user_data": {
            "name": "a.b.com",
            "applicationsolution_list": "22108",
            "tips_record_id": "public",
          },
          "user_data_objclass": {
            "applicationsolution_list": "ApplicationSolution"
          },
          "current_template_id": 7,
        }
      }
    }
  },
  "code": 0,
  "message": "Found: 1"
}
```