### PR TITLE
DBSearch::Init did not respect default obsolete value

### DIFF
--- a/core/dbsearch.class.php
+++ b/core/dbsearch.class.php
@@ -91,7 +91,7 @@ abstract class DBSearch
 	protected function Init()
 	{
 		$this->m_bArchiveMode = utils::IsArchiveMode();
-		$this->m_bShowObsoleteData = true;
+		$this->m_bShowObsoleteData = utils::ShowObsoleteData();
 	}
 
 	/**


### PR DESCRIPTION
By using this a (core/extension) developer always needs to call `DBSearch::SetShowObsoleteData` in order to respect the setting. With this change, that is done automatically.

If this is not accepted, at least the following should be put in place:
```php
$this->m_bShowObsoleteData = MetaModel::GetConfig()->Get('obsolescence.show_obsolete_data');
```