### PR TITLE
N°4092 setup generates symlinks when run on dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ test/vendor/*
 !/data/.htaccess
 !/data/index.php
 !/data/web.config
+!/data/exclude.txt
+!/data/.compilation-symlinks
 
 # iTop extensions
 /extensions/**

--- a/data/exclude.txt
+++ b/data/exclude.txt
@@ -1,0 +1,5 @@
+#
+# The following source files are not re-distributed with the "build" of the application
+# since they are used solely for debugging. The minified version is normally used instead.
+#
+.compilation-symlinks

--- a/setup/ajax.dataloader.php
+++ b/setup/ajax.dataloader.php
@@ -164,23 +164,27 @@ try
 			/** @var WizardStep $oStep */
 			$oStep = new $sClass($oDummyController, $sState);
 			$sConfigFile = utils::GetConfigFilePath();
-			if (file_exists($sConfigFile) && !is_writable($sConfigFile) && $oStep->RequiresWritableConfig())
-			{
+			if (file_exists($sConfigFile) && !is_writable($sConfigFile) && $oStep->RequiresWritableConfig()) {
 				$sRelativePath = utils::GetConfigFilePathRelative();
 				$oPage->error("<b>Error:</b> the configuration file '".$sRelativePath."' already exists and cannot be overwritten.");
 				$oPage->p("The wizard cannot modify the configuration file for you. If you want to upgrade ".ITOP_APPLICATION.", make sure that the file '<b>".$sRelativePath."</b>' can be modified by the web server.");
 				$oPage->output();
-			}
-			else
-			{
+			} else {
 				$oStep->AsyncAction($oPage, $sActionCode, $aParams);
 			}
 		}
-		$oPage->output();
-		break;
+			$oPage->output();
+			break;
+
+		case 'toggle_use_symbolic_links':
+			$sUseSymbolicLinks = Utils::ReadParam('bUseSymbolicLinks', false);
+			$bUseSymbolicLinks = ($sUseSymbolicLinks === 'true');
+			MFCompiler::ToggleUseSymlinksFile($bUseSymbolicLinks);
+			echo "toggle useSymbolicLInks file : $bUseSymbolicLinks";
+			break;
 
 		default:
-		throw(new Exception("Error unsupported operation '$sOperation'"));
+			throw(new Exception("Error unsupported operation '$sOperation'"));
 	}
 }
 catch(Exception $e)

--- a/setup/ajax.dataloader.php
+++ b/setup/ajax.dataloader.php
@@ -179,7 +179,7 @@ try
 		case 'toggle_use_symbolic_links':
 			$sUseSymbolicLinks = Utils::ReadParam('bUseSymbolicLinks', false);
 			$bUseSymbolicLinks = ($sUseSymbolicLinks === 'true');
-			MFCompiler::ToggleUseSymlinksFile($bUseSymbolicLinks);
+			MFCompiler::SetUseSymbolicLinksFlag($bUseSymbolicLinks);
 			echo "toggle useSymbolicLInks file : $bUseSymbolicLinks";
 			break;
 

--- a/setup/applicationinstaller.class.inc.php
+++ b/setup/applicationinstaller.class.inc.php
@@ -276,17 +276,16 @@ class ApplicationInstaller
 					$sTargetDir = $this->GetTargetDir();
 					$bUseSymbolicLinks = false;
 					$aMiscOptions = $this->oParams->Get('options', array());
-					if (isset($aMiscOptions['symlinks']) && $aMiscOptions['symlinks'])
-					{
-						if (function_exists('symlink'))
-						{
+					if (isset($aMiscOptions['symlinks']) && $aMiscOptions['symlinks']) {
+						if (function_exists('symlink')) {
 							$bUseSymbolicLinks = true;
 							SetupLog::Info("Using symbolic links instead of copying data model files (for developers only!)");
-						}
-						else
-						{
+						} else {
 							SetupLog::Info("Symbolic links (function symlinks) does not seem to be supported on this platform (OS/PHP version).");
 						}
+					}
+					if (utils::IsDevelopmentEnvironment()) {
+						$bUseSymbolicLinks = true;
 					}
 
 					self::DoCompile($aSelectedModules, $sSourceDir, $sExtensionDir, $sTargetDir, $sTargetEnvironment,

--- a/setup/applicationinstaller.class.inc.php
+++ b/setup/applicationinstaller.class.inc.php
@@ -284,7 +284,8 @@ class ApplicationInstaller
 							SetupLog::Info("Symbolic links (function symlinks) does not seem to be supported on this platform (OS/PHP version).");
 						}
 					}
-					if (utils::IsDevelopmentEnvironment()) {
+
+					if (MFCompiler::HasUseSymlinksFile()) {
 						$bUseSymbolicLinks = true;
 					}
 

--- a/setup/applicationinstaller.class.inc.php
+++ b/setup/applicationinstaller.class.inc.php
@@ -285,7 +285,7 @@ class ApplicationInstaller
 						}
 					}
 
-					if (MFCompiler::HasUseSymlinksFile()) {
+					if (MFCompiler::IsUseSymbolicLinksFlagPresent()) {
 						$bUseSymbolicLinks = true;
 					}
 

--- a/setup/applicationinstaller.class.inc.php
+++ b/setup/applicationinstaller.class.inc.php
@@ -276,7 +276,7 @@ class ApplicationInstaller
 					$sTargetDir = $this->GetTargetDir();
 					$bUseSymbolicLinks = false;
 					$aMiscOptions = $this->oParams->Get('options', array());
-					if ((isset($aMiscOptions['symlinks']) && $aMiscOptions['symlinks']) || MFCompiler::IsUseSymbolicLinksFlagPresent()) {
+					if ((isset($aMiscOptions['symlinks']) && $aMiscOptions['symlinks'])) {
 						if (function_exists('symlink')) {
 							$bUseSymbolicLinks = true;
 							SetupLog::Info("Using symbolic links instead of copying data model files (for developers only!)");

--- a/setup/applicationinstaller.class.inc.php
+++ b/setup/applicationinstaller.class.inc.php
@@ -276,17 +276,13 @@ class ApplicationInstaller
 					$sTargetDir = $this->GetTargetDir();
 					$bUseSymbolicLinks = false;
 					$aMiscOptions = $this->oParams->Get('options', array());
-					if (isset($aMiscOptions['symlinks']) && $aMiscOptions['symlinks']) {
+					if ((isset($aMiscOptions['symlinks']) && $aMiscOptions['symlinks']) || MFCompiler::IsUseSymbolicLinksFlagPresent()) {
 						if (function_exists('symlink')) {
 							$bUseSymbolicLinks = true;
 							SetupLog::Info("Using symbolic links instead of copying data model files (for developers only!)");
 						} else {
 							SetupLog::Info("Symbolic links (function symlinks) does not seem to be supported on this platform (OS/PHP version).");
 						}
-					}
-
-					if (MFCompiler::IsUseSymbolicLinksFlagPresent()) {
-						$bUseSymbolicLinks = true;
 					}
 
 					self::DoCompile($aSelectedModules, $sSourceDir, $sExtensionDir, $sTargetDir, $sTargetEnvironment,

--- a/setup/applicationinstaller.class.inc.php
+++ b/setup/applicationinstaller.class.inc.php
@@ -274,8 +274,9 @@ class ApplicationInstaller
 					$sExtensionDir = $this->oParams->Get('extensions_dir', 'extensions');
 					$sTargetEnvironment = $this->GetTargetEnv();
 					$sTargetDir = $this->GetTargetDir();
-					$bUseSymbolicLinks = false;
 					$aMiscOptions = $this->oParams->Get('options', array());
+
+					$bUseSymbolicLinks = null;
 					if ((isset($aMiscOptions['symlinks']) && $aMiscOptions['symlinks'])) {
 						if (function_exists('symlink')) {
 							$bUseSymbolicLinks = true;
@@ -500,8 +501,7 @@ class ApplicationInstaller
 	{
 		$oBackup = new SetupDBBackup($oConfig);
 		$sTargetFile = $oBackup->MakeName($sBackupFileFormat);
-		if (!empty($sMySQLBinDir))
-		{
+		if (!empty($sMySQLBinDir)) {
 			$oBackup->SetMySQLBinDir($sMySQLBinDir);
 		}
 
@@ -509,8 +509,8 @@ class ApplicationInstaller
 		$oBackup->CreateCompressedBackup($sTargetFile, $sSourceConfigFile);
 	}
 
-	
-	protected static function DoCompile($aSelectedModules, $sSourceDir, $sExtensionDir, $sTargetDir, $sEnvironment, $bUseSymbolicLinks = false)
+
+	protected static function DoCompile($aSelectedModules, $sSourceDir, $sExtensionDir, $sTargetDir, $sEnvironment, $bUseSymbolicLinks = null)
 	{
 		SetupLog::Info("Compiling data model.");
 
@@ -518,8 +518,7 @@ class ApplicationInstaller
 		require_once(APPROOT.'setup/modelfactory.class.inc.php');
 		require_once(APPROOT.'setup/compiler.class.inc.php');
 
-		if (empty($sSourceDir) || empty($sTargetDir))
-		{
+		if (empty($sSourceDir) || empty($sTargetDir)) {
 			throw new Exception("missing parameter source_dir and/or target_dir");
 		}		
 

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -176,6 +176,10 @@ class MFCompiler
 	 */
 	public function Compile($sTargetDir, $oP = null, $bUseSymbolicLinks = false, $bSkipTempDir = false)
 	{
+		if (!$bUseSymbolicLinks && static::IsUseSymbolicLinksFlagPresent()) {
+			$bUseSymbolicLinks = true;
+		}
+
 		$sFinalTargetDir = $sTargetDir;
 		$bIsAlreadyInMaintenanceMode = SetupUtils::IsInMaintenanceMode();
 		$sConfigFilePath = utils::GetConfigFilePath($this->sEnvironment);

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -112,12 +112,18 @@ class MFCompiler
 	}
 
 	/**
-	 * @return bool
+	 * @return bool always false if not in dev env, else true if flag is present, false otherwise
+	 * @uses utils::IsDevelopmentEnvironment()
+	 * @uses \file_exists()
 	 * @uses USE_SYMBOLIC_LINKS_FILE_PATH
 	 * @since 3.0.0
 	 */
 	public static function IsUseSymbolicLinksFlagPresent(): bool
 	{
+		if (!utils::IsDevelopmentEnvironment()) {
+			return false;
+		}
+
 		return (file_exists(static::USE_SYMBOLIC_LINKS_FILE_PATH));
 	}
 

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -112,15 +112,25 @@ class MFCompiler
 	}
 
 	/**
-	 * @return bool always false if not in dev env, else true if flag is present, false otherwise
+	 * @return bool possible return values :
+	 *   * always false if not in dev env
+	 *   * `symlink` function non existent : false
+	 *   * if flag is present true, false otherwise
+	 *
 	 * @uses utils::IsDevelopmentEnvironment()
+	 * @uses \function_exists()
 	 * @uses \file_exists()
 	 * @uses USE_SYMBOLIC_LINKS_FILE_PATH
+	 *
 	 * @since 3.0.0
 	 */
 	public static function IsUseSymbolicLinksFlagPresent(): bool
 	{
 		if (!utils::IsDevelopmentEnvironment()) {
+			return false;
+		}
+
+		if (!function_exists('symlink')) {
 			return false;
 		}
 

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -178,10 +178,15 @@ class MFCompiler
 	 * @return void
 	 * @throws Exception
 	 */
-	public function Compile($sTargetDir, $oP = null, $bUseSymbolicLinks = false, $bSkipTempDir = false)
+	public function Compile($sTargetDir, $oP = null, $bUseSymbolicLinks = null, $bSkipTempDir = false)
 	{
-		if (!$bUseSymbolicLinks && static::IsUseSymbolicLinksFlagPresent()) {
-			$bUseSymbolicLinks = true;
+		if (is_null($bUseSymbolicLinks)) {
+			$bUseSymbolicLinks = false;
+			if (self::IsUseSymbolicLinksFlagPresent()) {
+				// We are only overriding the useSymLinks option if the consumer didn't specify anything
+				// The toolkit always send this parameter for example, but not the Designer Connector
+				$bUseSymbolicLinks = true;
+			}
 		}
 
 		$sFinalTargetDir = $sTargetDir;

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -112,6 +112,8 @@ class MFCompiler
 	}
 
 	/**
+	 * @param bool $bForce if true then will just check file existence
+	 *
 	 * @return bool possible return values :
 	 *   * always false if not in dev env
 	 *   * `symlink` function non existent : false
@@ -124,14 +126,16 @@ class MFCompiler
 	 *
 	 * @since 3.0.0
 	 */
-	public static function IsUseSymbolicLinksFlagPresent(): bool
+	public static function IsUseSymbolicLinksFlagPresent(bool $bForce = false): bool
 	{
-		if (!utils::IsDevelopmentEnvironment()) {
-			return false;
-		}
+		if (!$bForce) {
+			if (!utils::IsDevelopmentEnvironment()) {
+				return false;
+			}
 
-		if (!function_exists('symlink')) {
-			return false;
+			if (!function_exists('symlink')) {
+				return false;
+			}
 		}
 
 		return (file_exists(static::USE_SYMBOLIC_LINKS_FILE_PATH));
@@ -145,7 +149,7 @@ class MFCompiler
 	 */
 	public static function SetUseSymbolicLinksFlag(bool $bUseSymbolicLinks): void
 	{
-		$bHasUseSymlinksFile = static::IsUseSymbolicLinksFlagPresent();
+		$bHasUseSymlinksFile = static::IsUseSymbolicLinksFlagPresent(true);
 
 		if ($bUseSymbolicLinks) {
 			if ($bHasUseSymlinksFile) {

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -51,7 +51,15 @@ class DOMFormatException extends Exception
  */ 
 class MFCompiler
 {
-	const DATA_PRECOMPILED_FOLDER = 'data' . DIRECTORY_SEPARATOR . 'precompiled_styles' . DIRECTORY_SEPARATOR;
+	const DATA_PRECOMPILED_FOLDER = 'data'.DIRECTORY_SEPARATOR.'precompiled_styles'.DIRECTORY_SEPARATOR;
+
+	/**
+	 * Path to the "use symlinks" file
+	 * If this file is present, then we will compile to symlink !
+	 *
+	 * @var string
+	 */
+	public const USE_SYMBOLIC_LINKS_FILE_PATH = APPROOT.'data/.compilation-symlinks';
 
 	/** @var \ThemeHandlerService */
 	protected static $oThemeHandlerService;
@@ -93,54 +101,81 @@ class MFCompiler
 
 	protected function DumpLog($oPage)
 	{
-		foreach ($this->aLog as $sText)
-		{
+		foreach ($this->aLog as $sText) {
 			$oPage->p($sText);
 		}
 	}
-	
+
 	public function GetLog()
 	{
 		return $this->aLog;
 	}
-	
+
+	/**
+	 * @return bool
+	 * @uses USE_SYMBOLIC_LINKS_FILE_PATH
+	 * @since 3.0.0
+	 */
+	public static function HasUseSymlinksFile(): bool
+	{
+		return (file_exists(static::USE_SYMBOLIC_LINKS_FILE_PATH));
+	}
+
+	/**
+	 * @uses USE_SYMBOLIC_LINKS_FILE_PATH
+	 * @since 3.0.0 method creation
+	 */
+	public static function ToggleUseSymlinksFile(bool $bUseSymbolicLinks): void
+	{
+		$bHasUseSymlinksFile = static::HasUseSymlinksFile();
+
+		if ($bUseSymbolicLinks) {
+			if ($bHasUseSymlinksFile) {
+				return;
+			}
+
+			touch(static::USE_SYMBOLIC_LINKS_FILE_PATH);
+
+			return;
+		}
+
+		if (!$bHasUseSymlinksFile) {
+			return;
+		}
+		unlink(static::USE_SYMBOLIC_LINKS_FILE_PATH);
+	}
 
 	/**
 	 * Compile the data model into PHP files and data structures
+	 *
 	 * @param string $sTargetDir The target directory where to put the resulting files
 	 * @param Page $oP For some output...
 	 * @param bool $bUseSymbolicLinks
 	 * @param bool $bSkipTempDir
-	 * @throws Exception
+	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function Compile($sTargetDir, $oP = null, $bUseSymbolicLinks = false, $bSkipTempDir = false)
 	{
 		$sFinalTargetDir = $sTargetDir;
 		$bIsAlreadyInMaintenanceMode = SetupUtils::IsInMaintenanceMode();
 		$sConfigFilePath = utils::GetConfigFilePath($this->sEnvironment);
-		if (is_file($sConfigFilePath))
-		{
+		if (is_file($sConfigFilePath)) {
 			$oConfig = new Config($sConfigFilePath);
-		}
-		else
-		{
+		} else {
 			$oConfig = null;
 		}
-		if (($this->sEnvironment == 'production') && !$bIsAlreadyInMaintenanceMode)
-		{
+		if (($this->sEnvironment == 'production') && !$bIsAlreadyInMaintenanceMode) {
 
 			SetupUtils::EnterMaintenanceMode($oConfig);
 		}
-		if ($bUseSymbolicLinks || $bSkipTempDir)
-		{
+		if ($bUseSymbolicLinks || $bSkipTempDir) {
 			// Skip the creation of a temporary dictionary, not compatible with symbolic links
 			$sTempTargetDir = $sFinalTargetDir;
 			SetupUtils::rrmdir($sFinalTargetDir);
 			SetupUtils::builddir($sFinalTargetDir); // Here is the directory
-		}
-		else
-		{
+		} else {
 			// Create a temporary directory
 			// Once the compilation is 100% successful, then move the results into the target directory
 			$sTempTargetDir = tempnam(SetupUtils::GetTmpDir(), 'itop-');
@@ -226,17 +261,14 @@ class MFCompiler
 		// The bullet proof implementation would be to compile in a separate directory as it has been done with the dictionaries... that's another story
 		$aModules = $this->oFactory->GetLoadedModules();
 		$sUserRightsModule = '';
-		foreach($aModules as $foo => $oModule)
-		{
-			if ($oModule->GetName() == 'itop-profiles-itil')
-			{
+		foreach ($aModules as $foo => $oModule) {
+			if ($oModule->GetName() == 'itop-profiles-itil') {
 				$sUserRightsModule = 'itop-profiles-itil';
 				break;
 			}
 		}
 		$oUserRightsNode = $this->oFactory->GetNodes('user_rights')->item(0);
-		if ($oUserRightsNode && ($sUserRightsModule == ''))
-		{
+		if ($oUserRightsNode && ($sUserRightsModule == '')) {
 			// Legacy algorithm (itop <= 2.0.3)
 			$sUserRightsModule = $oUserRightsNode->getAttribute('_created_in');
 		}
@@ -245,13 +277,12 @@ class MFCompiler
 		// List root classes
 		//
 		$this->aRootClasses = array();
-		foreach ($this->oFactory->ListRootClasses() as $oClass)
-		{
+		foreach ($this->oFactory->ListRootClasses() as $oClass) {
 			$this->Log("Root class (with child classes): ".$oClass->getAttribute('id'));
 			$this->aRootClasses[$oClass->getAttribute('id')] = $oClass;
 		}
-		
-		$this->LoadSnippets();	
+
+		$this->LoadSnippets();
 
 		// Compile, module by module
 		//
@@ -264,33 +295,25 @@ class MFCompiler
 		$this->WriteStaticOnlyHtaccess($sTempTargetDir);
 		$this->WriteStaticOnlyWebConfig($sTempTargetDir);
 
-		foreach($aModules as $foo => $oModule)
-		{
+		static::ToggleUseSymlinksFile($bUseSymbolicLinks);
+
+		foreach ($aModules as $foo => $oModule) {
 			$sModuleName = $oModule->GetName();
 			$sModuleVersion = $oModule->GetVersion();
 
 			$sModuleRootDir = $oModule->GetRootDir();
-			if ($sModuleRootDir != '')
-			{
+			if ($sModuleRootDir != '') {
 				$sModuleRootDir = realpath($sModuleRootDir);
 				$sRelativeDir = basename($sModuleRootDir);
-				if ($bUseSymbolicLinks)
-				{
+				if ($bUseSymbolicLinks) {
 					$sRealRelativeDir = substr($sModuleRootDir, $iStart);
-				}
-				else
-				{
+				} else {
 					$sRealRelativeDir = $sRelFinalTargetDir.'/'.$sRelativeDir;
 				}
 
 				// Push the other module files
 				SetupUtils::copydir($sModuleRootDir, $sTempTargetDir.'/'.$sRelativeDir, $bUseSymbolicLinks);
-
-
-
-			}
-			else
-			{
+			} else {
 				$sRelativeDir = $sModuleName;
 				$sRealRelativeDir = $sModuleName;
 			}

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -116,18 +116,20 @@ class MFCompiler
 	 * @uses USE_SYMBOLIC_LINKS_FILE_PATH
 	 * @since 3.0.0
 	 */
-	public static function HasUseSymlinksFile(): bool
+	public static function IsUseSymbolicLinksFlagPresent(): bool
 	{
 		return (file_exists(static::USE_SYMBOLIC_LINKS_FILE_PATH));
 	}
 
 	/**
-	 * @uses USE_SYMBOLIC_LINKS_FILE_PATH
+	 * @param bool $bUseSymbolicLinks
+	 *
 	 * @since 3.0.0 method creation
+	 * @uses USE_SYMBOLIC_LINKS_FILE_PATH
 	 */
-	public static function ToggleUseSymlinksFile(bool $bUseSymbolicLinks): void
+	public static function SetUseSymbolicLinksFlag(bool $bUseSymbolicLinks): void
 	{
-		$bHasUseSymlinksFile = static::HasUseSymlinksFile();
+		$bHasUseSymlinksFile = static::IsUseSymbolicLinksFlagPresent();
 
 		if ($bUseSymbolicLinks) {
 			if ($bHasUseSymlinksFile) {
@@ -295,7 +297,7 @@ class MFCompiler
 		$this->WriteStaticOnlyHtaccess($sTempTargetDir);
 		$this->WriteStaticOnlyWebConfig($sTempTargetDir);
 
-		static::ToggleUseSymlinksFile($bUseSymbolicLinks);
+		static::SetUseSymbolicLinksFlag($bUseSymbolicLinks);
 
 		foreach ($aModules as $foo => $oModule) {
 			$sModuleName = $oModule->GetName();

--- a/setup/runtimeenv.class.inc.php
+++ b/setup/runtimeenv.class.inc.php
@@ -514,17 +514,18 @@ class RunTimeEnvironment
 			}
 			$oFactory->LoadModule($oModule);
 		}
-		
 
-		if ($oModule instanceof MFDeltaModule)
-		{
+
+		if ($oModule instanceof MFDeltaModule) {
 			// A delta was loaded, let's save a second copy of the datamodel
 			$oFactory->SaveToFile(APPROOT.'data/datamodel-'.$this->sTargetEnv.'-with-delta.xml');
-		}
-		else
-		{
+		} else {
 			// No delta was loaded, let's save the datamodel now
 			$oFactory->SaveToFile(APPROOT.'data/datamodel-'.$this->sTargetEnv.'.xml');
+		}
+
+		if (!$bUseSymLinks && MFCompiler::IsUseSymbolicLinksFlagPresent()) {
+			$bUseSymLinks = true;
 		}
 
 		$sTargetDir = APPROOT.'env-'.$this->sTargetEnv;

--- a/setup/runtimeenv.class.inc.php
+++ b/setup/runtimeenv.class.inc.php
@@ -490,11 +490,13 @@ class RunTimeEnvironment
 	 * The list of modules to be installed in the target environment is:
 	 *  - the list of modules present in the "source_dir" (defined by the source environment) which are marked as "installed" in the source environment's database
 	 *  - plus the list of modules present in the "extra" directory of the target environment: data/<target_environment>-modules/
+	 *
 	 * @param string $sSourceEnv The name of the source environment to 'imitate'
 	 * @param bool $bUseSymLinks Whether to create symbolic links instead of copies
+	 *
 	 * @return string[]
 	 */
-	public function CompileFrom($sSourceEnv, $bUseSymLinks = false)
+	public function CompileFrom($sSourceEnv, $bUseSymLinks = null)
 	{
 		$oSourceConfig = new Config(utils::GetConfigFilePath($sSourceEnv));
 		$sSourceDir = $oSourceConfig->Get('source_dir');
@@ -504,7 +506,7 @@ class RunTimeEnvironment
 		//
 		$oFactory = new ModelFactory($sSourceDirFull);
 		$aModulesToCompile = $this->GetMFModulesToCompile($sSourceEnv, $sSourceDir);
-		foreach($aModulesToCompile as $oModule)
+		foreach ($aModulesToCompile as $oModule)
 		{
 			if ($oModule instanceof MFDeltaModule)
 			{
@@ -522,10 +524,6 @@ class RunTimeEnvironment
 		} else {
 			// No delta was loaded, let's save the datamodel now
 			$oFactory->SaveToFile(APPROOT.'data/datamodel-'.$this->sTargetEnv.'.xml');
-		}
-
-		if (!$bUseSymLinks && MFCompiler::IsUseSymbolicLinksFlagPresent()) {
-			$bUseSymLinks = true;
 		}
 
 		$sTargetDir = APPROOT.'env-'.$this->sTargetEnv;

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -1172,7 +1172,7 @@ $("#use-symbolic-links").on("click", function() {
 	var $this = $(this),
 		bUseSymbolicLinks = $this.prop("checked");
 	if (!bUseSymbolicLinks){
-		if (!window.confirm("This will disable symbolic links generation permanently, are you sure ?")) {
+		if (!window.confirm("This will disable symbolic links generation.\nYou'll need the toolkit to restore it.\n\nAre you sure ?")) {
 			$this.prop("checked", true);
 			return;
 		}

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -1161,6 +1161,30 @@ class WizStepUpgradeMiscParams extends WizardStep
 		});
 EOF
 		);
+
+		if (MFCompiler::HasUseSymlinksFile()) {
+			$oPage->add('<fieldset>');
+			$oPage->add('<legend>Dev parameters</legend>');
+			$oPage->p('<input id="use-symbolic-links" type="checkbox" checked><label for="use-symbolic-links">&nbsp;Create symbolic links instead of creating a copy in env-production (useful for debugging extensions)');
+			$oPage->add('</fieldset>');
+			$oPage->add_ready_script(<<<'JS'
+$("#use-symbolic-links").on("click", function() {
+	var $this = $(this),
+		bUseSymbolicLinks = $this.prop("checked");
+	if (!bUseSymbolicLinks){
+		if (!window.confirm("This will disable symbolic links generation permanently, are you sure ?")) {
+			$this.prop("checked", true);
+			return;
+		}
+	}
+	
+	var sAuthent = $('#authent_token').val();
+	var oAjaxParams = { operation: 'toggle_use_symbolic_links', bUseSymbolicLinks: bUseSymbolicLinks, authent: sAuthent};
+	$.post(GetAbsoluteUrlAppRoot()+'setup/ajax.dataloader.php', oAjaxParams);
+});
+JS
+			);
+		}
 	}
 
 	public function AsyncAction(WebPage $oPage, $sCode, $aParameters)

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -1162,7 +1162,7 @@ class WizStepUpgradeMiscParams extends WizardStep
 EOF
 		);
 
-		if (MFCompiler::HasUseSymlinksFile()) {
+		if (MFCompiler::IsUseSymbolicLinksFlagPresent()) {
 			$oPage->add('<fieldset>');
 			$oPage->add('<legend>Dev parameters</legend>');
 			$oPage->p('<input id="use-symbolic-links" type="checkbox" checked><label for="use-symbolic-links">&nbsp;Create symbolic links instead of creating a copy in env-production (useful for debugging extensions)');

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -1172,7 +1172,7 @@ $("#use-symbolic-links").on("click", function() {
 	var $this = $(this),
 		bUseSymbolicLinks = $this.prop("checked");
 	if (!bUseSymbolicLinks){
-		if (!window.confirm("This will disable symbolic links generation.\nYou'll need the toolkit to restore it.\n\nAre you sure ?")) {
+		if (!window.confirm("This will disable symbolic links generation.\nYou'll need the toolkit to restore this option.\n\nAre you sure ?")) {
 			$this.prop("checked", true);
 			return;
 		}


### PR DESCRIPTION
## Introduction

When developing, we often have to launch the setup instead of the toolkit : to select a new module to install for example. Doing so will cause symlinks to be removed, and so we need to run toolkit again afterwards.

## New functionalities added
With this PR : 

* The compiler will now generate low level (in `\MFCompiler::DoCompile`) a flag when symlinks are set (`data/.compilation-symlinks` file)
* In the setup, new "symlink" checkbox (in the misc params step, the one containing approot & graphviz path)
  * displayed if and only if : 
    * running on a dev env (`\utils::IsDevelopmentEnvironment`)
    * the symlink PHP function exists
    * symlink flag is set
  * unchecking the checkbox will remove the flag using ajax (so we don't have to save this option value all along the wizard steps)
  * if symlink flag is present, then compile with the symlinks option
* The flag is used (same conditions as the setup) in all connectors that are not setting the UseSymlinks option : Core Update, Designer, Hub
* For consumers that are setting the option (toolkit, custom scripts, ...), behavior is unchanged and the flag is set/unset according to the option value

Setup misc step screenshot with the new option : 
![image](https://user-images.githubusercontent.com/8947448/121355041-c626a780-c92f-11eb-993e-38e2c62608b0.png)

## What changed in the code
Compilation is launched in \MFCompiler::Compile.
The default $bUseSymbolicLinks parameter value is changed from false to null so that we know if the consumer has set this option, and this default value is changed also in the callee.

At the top of the method a test is added to set the option based on the flag.

We have 2 main consumers of this method : 
* `ApplicationInstaller` for the setup (ExecuteStep then Compile methods)
* `RuntimeEnvironment` for anything else : toolkit, connectors, ...

Note that for the setup in 5c7604f9 a param was used in `\ApplicationInstaller::ExecuteStep` to set the `$bUseSymbolicLinks` boolean value... but I couldn't find a documentation on how to use this parameter ? This code is left unchanged.

