### PR TITLE
N°3717 Fix create CMDBChange without any corresponding CMDBChangeOp

### DIFF
--- a/core/cmdbchangeop.class.inc.php
+++ b/core/cmdbchangeop.class.inc.php
@@ -79,13 +79,11 @@ class CMDBChangeOp extends DBObject
 	protected function OnInsert()
 	{
 		if ($this->Get('change') <= 0) {
-			$this->Set('change', CMDBObject::GetCurrentChange());
-		}
-
-		/** @var \CMDBChange $oChange */
-		$oChange = $this->Get('change');
-		if ($oChange->IsNew()) {
-			$oChange->DBWrite();
+			$oChange = CMDBObject::GetCurrentChange();
+			if ($oChange->IsNew()) {
+				$oChange->DBWrite();
+			}
+			$this->Set('change', $oChange);
 		}
 
 		parent::OnInsert();

--- a/core/cmdbchangeop.class.inc.php
+++ b/core/cmdbchangeop.class.inc.php
@@ -70,15 +70,24 @@ class CMDBChangeOp extends DBObject
 	}
 
 	/**
-	 * Safety net: in case the change is not given, let's guarantee that it will
-	 * be set to the current ongoing change (or create a new one)	
-	 */	
+	 * Safety net:
+	 * * if CMDBChange isn't persisted yet, do it !
+	 * * in case the change is not given, let's guarantee that it will be set to the current ongoing change (or create a new one)
+	 *
+	 * @since 2.7.4 do persist the CMDBChange if needed
+	 */
 	protected function OnInsert()
 	{
-		if ($this->Get('change') <= 0)
-		{
+		if ($this->Get('change') <= 0) {
 			$this->Set('change', CMDBObject::GetCurrentChange());
 		}
+
+		/** @var \CMDBChange $oChange */
+		$oChange = $this->Get('change');
+		if ($oChange->IsNew()) {
+			$oChange->DBWrite();
+		}
+
 		parent::OnInsert();
 	}
 }

--- a/core/cmdbchangeop.class.inc.php
+++ b/core/cmdbchangeop.class.inc.php
@@ -71,10 +71,10 @@ class CMDBChangeOp extends DBObject
 
 	/**
 	 * Safety net:
-	 * * if CMDBChange isn't persisted yet, do it !
+	 * * if change isn't persisted yet, use the current change and persist it if needed
 	 * * in case the change is not given, let's guarantee that it will be set to the current ongoing change (or create a new one)
 	 *
-	 * @since 2.7.4 do persist the CMDBChange if needed
+	 * @since 2.7.4 do persist the current change if needed
 	 */
 	protected function OnInsert()
 	{

--- a/core/cmdbchangeop.class.inc.php
+++ b/core/cmdbchangeop.class.inc.php
@@ -85,11 +85,29 @@ class CMDBChangeOp extends DBObject
 			return parent::Set($sAttCode, $value);
 		}
 
-		if ($value->IsNew()) {
-			throw new CoreUnexpectedValue("Cannot set CMDBChangeOp.change with a non persisted CMDBChange !");
+		if (is_int($value)) {
+			if ($value <= 0) {
+				$this->ThrowInvalidCMDBChangeException();
+			}
+
+			return parent::Set($sAttCode, $value);
 		}
 
-		return parent::Set($sAttCode, $value);
+		if (is_object($value)) {
+			if ($value->IsNew()) {
+				$this->ThrowInvalidCMDBChangeException();
+			}
+
+			return parent::Set($sAttCode, $value);
+		}
+
+		// we should never get here O:)
+		throw new CoreUnexpectedValue("Invalid value set to CMDBChangeOp.change");
+	}
+
+	protected function ThrowInvalidCMDBChangeException()
+	{
+		throw new CoreUnexpectedValue("Cannot set CMDBChangeOp.change with a non persisted CMDBChange !");
 	}
 
 	/**

--- a/core/cmdbchangeop.class.inc.php
+++ b/core/cmdbchangeop.class.inc.php
@@ -74,7 +74,7 @@ class CMDBChangeOp extends DBObject
 	 * * if change isn't persisted yet, use the current change and persist it if needed
 	 * * in case the change is not given, let's guarantee that it will be set to the current ongoing change (or create a new one)
 	 *
-	 * @since 2.7.4 do persist the current change if needed
+	 * @since 2.7.7 3.0.2 3.1.0 N°3717 do persist the current change if needed
 	 */
 	protected function OnInsert()
 	{

--- a/core/cmdbchangeop.class.inc.php
+++ b/core/cmdbchangeop.class.inc.php
@@ -70,38 +70,6 @@ class CMDBChangeOp extends DBObject
 	}
 
 	/**
-	 * @param string $sAttCode
-	 * @param mixed $value
-	 *
-	 * @return bool
-	 * @throws \CoreException
-	 * @throws \CoreUnexpectedValue
-	 *
-	 * @since 2.7.4 reject non persisted CMDBChange
-	 */
-	public function Set($sAttCode, $value)
-	{
-		if ($sAttCode !== 'change') {
-			return parent::Set($sAttCode, $value);
-		}
-
-		if ((is_int($value)) && ($value <= 0)) {
-			$this->ThrowInvalidCMDBChangeException();
-		}
-
-		if ((is_object($value)) && ($value->IsNew())) {
-			$this->ThrowInvalidCMDBChangeException();
-		}
-
-		return parent::Set($sAttCode, $value);
-	}
-
-	protected function ThrowInvalidCMDBChangeException()
-	{
-		throw new CoreUnexpectedValue("Cannot set CMDBChangeOp.change with a non persisted CMDBChange !");
-	}
-
-	/**
 	 * Safety net:
 	 * * if CMDBChange isn't persisted yet, do it !
 	 * * in case the change is not given, let's guarantee that it will be set to the current ongoing change (or create a new one)

--- a/core/cmdbchangeop.class.inc.php
+++ b/core/cmdbchangeop.class.inc.php
@@ -85,24 +85,15 @@ class CMDBChangeOp extends DBObject
 			return parent::Set($sAttCode, $value);
 		}
 
-		if (is_int($value)) {
-			if ($value <= 0) {
-				$this->ThrowInvalidCMDBChangeException();
-			}
-
-			return parent::Set($sAttCode, $value);
+		if ((is_int($value)) && ($value <= 0)) {
+			$this->ThrowInvalidCMDBChangeException();
 		}
 
-		if (is_object($value)) {
-			if ($value->IsNew()) {
-				$this->ThrowInvalidCMDBChangeException();
-			}
-
-			return parent::Set($sAttCode, $value);
+		if ((is_object($value)) && ($value->IsNew())) {
+			$this->ThrowInvalidCMDBChangeException();
 		}
 
-		// we should never get here O:)
-		throw new CoreUnexpectedValue("Invalid value set to CMDBChangeOp.change");
+		return parent::Set($sAttCode, $value);
 	}
 
 	protected function ThrowInvalidCMDBChangeException()

--- a/core/cmdbchangeop.class.inc.php
+++ b/core/cmdbchangeop.class.inc.php
@@ -63,10 +63,33 @@ class CMDBChangeOp extends DBObject
 
 	/**
 	 * Describe (as a text string) the modifications corresponding to this change
-	 */	 
+	 */
 	public function GetDescription()
 	{
 		return '';
+	}
+
+	/**
+	 * @param string $sAttCode
+	 * @param mixed $value
+	 *
+	 * @return bool
+	 * @throws \CoreException
+	 * @throws \CoreUnexpectedValue
+	 *
+	 * @since 2.7.4 reject non persisted CMDBChange
+	 */
+	public function Set($sAttCode, $value)
+	{
+		if ($sAttCode !== 'change') {
+			return parent::Set($sAttCode, $value);
+		}
+
+		if ($value->IsNew()) {
+			throw new CoreUnexpectedValue("Cannot set CMDBChangeOp.change with a non persisted CMDBChange !");
+		}
+
+		return parent::Set($sAttCode, $value);
 	}
 
 	/**
@@ -78,7 +101,8 @@ class CMDBChangeOp extends DBObject
 	 */
 	protected function OnInsert()
 	{
-		if ($this->Get('change') <= 0) {
+		$iChange = $this->Get('change');
+		if (($iChange <= 0) || (is_null($iChange))) {
 			$oChange = CMDBObject::GetCurrentChange();
 			if ($oChange->IsNew()) {
 				$oChange->DBWrite();

--- a/core/cmdbobject.class.inc.php
+++ b/core/cmdbobject.class.inc.php
@@ -114,6 +114,33 @@ abstract class CMDBObject extends DBObject
 		self::$m_oCurrChange = $oChange;
 	}
 
+	/**
+	 * @param string $sUserInfo
+	 * @param string $sOrigin
+	 * @param $oDate
+	 *
+	 * @throws \CoreException
+	 *
+	 * @since 2.7.4 3.0.0 N°3717 new method to reset current change
+	 */
+	public static function SetCurrentChangeFromParams($sUserInfo, $sOrigin = null, $oDate = null)
+	{
+		$oChange = MetaModel::NewObject('CMDBChange');
+
+		self::$m_oCurrChange->Set("userinfo", $sUserInfo);
+
+		if (!is_null($sOrigin)) {
+			self::$m_oCurrChange->Set("origin", $sOrigin);
+		}
+
+		if (is_null($oDate)) {
+			$oDate = time();
+		}
+		self::$m_oCurrChange->Set("date", $oDate);
+
+		self::$m_oCurrChange = $oChange;
+	}
+
 	//
 	// Todo: simplify the APIs and do not pass the current change as an argument anymore
 	//       SetTrackInfo to be invoked in very few cases (UI.php, CSV import, Data synchro)
@@ -167,10 +194,10 @@ abstract class CMDBObject extends DBObject
 	{
 		self::$m_sOrigin = $sOrigin;
 	}
-	
+
 	/**
 	 * Get the additional information (defaulting to user name)
-	 */	 	
+	 */
 	protected static function GetTrackInfo()
 	{
 		if (is_null(self::$m_sInfo))

--- a/core/cmdbobject.class.inc.php
+++ b/core/cmdbobject.class.inc.php
@@ -175,10 +175,16 @@ abstract class CMDBObject extends DBObject
 	 * @see SetCurrentChange to specify a CMDBObject instance instead
 	 *
 	 * @param string $sInfo
+	 *
+	 * @since 2.7.4 3.0.0 N°3717 if a current change is set then overrides its value
 	 */
 	public static function SetTrackInfo($sInfo)
 	{
 		self::$m_sInfo = $sInfo;
+
+		if (!is_null(static::$m_oCurrChange)) {
+			static::$m_oCurrChange->Set('userinfo', $sInfo);
+		}
 	}
 
 	/**
@@ -189,10 +195,16 @@ abstract class CMDBObject extends DBObject
 	 *
 	 * @param $sOrigin String: one of: interactive, csv-interactive, csv-import.php, webservice-soap, webservice-rest, syncho-data-source,
 	 *     email-processing, custom-extension
+	 *
+	 * @since 2.7.4 3.0.0 N°3717 if a current change is set then overrides its value
 	 */
 	public static function SetTrackOrigin($sOrigin)
 	{
 		self::$m_sOrigin = $sOrigin;
+
+		if (!is_null(static::$m_oCurrChange)) {
+			static::$m_oCurrChange->Set('origin', $sOrigin);
+		}
 	}
 
 	/**

--- a/core/cmdbobject.class.inc.php
+++ b/core/cmdbobject.class.inc.php
@@ -175,16 +175,10 @@ abstract class CMDBObject extends DBObject
 	 * @see SetCurrentChange to specify a CMDBObject instance instead
 	 *
 	 * @param string $sInfo
-	 *
-	 * @since 2.7.4 3.0.0 N°3717 if a current change is set then overrides its value
 	 */
 	public static function SetTrackInfo($sInfo)
 	{
 		self::$m_sInfo = $sInfo;
-
-		if (!is_null(static::$m_oCurrChange)) {
-			static::$m_oCurrChange->Set('userinfo', $sInfo);
-		}
 	}
 
 	/**
@@ -195,16 +189,10 @@ abstract class CMDBObject extends DBObject
 	 *
 	 * @param $sOrigin String: one of: interactive, csv-interactive, csv-import.php, webservice-soap, webservice-rest, syncho-data-source,
 	 *     email-processing, custom-extension
-	 *
-	 * @since 2.7.4 3.0.0 N°3717 if a current change is set then overrides its value
 	 */
 	public static function SetTrackOrigin($sOrigin)
 	{
 		self::$m_sOrigin = $sOrigin;
-
-		if (!is_null(static::$m_oCurrChange)) {
-			static::$m_oCurrChange->Set('origin', $sOrigin);
-		}
 	}
 
 	/**

--- a/core/cmdbobject.class.inc.php
+++ b/core/cmdbobject.class.inc.php
@@ -201,7 +201,9 @@ abstract class CMDBObject extends DBObject
 	/**
 	 * Set to {@link $m_oCurrChange} a standard change record (done here 99% of the time, and nearly once per page)
 	 *
-	 * The CMDBChange is persisted so that it has a key > 0, and any new CMDBChangeOp can link to it
+	 * The CMDBChange **is NOT persisted**, this will be done in \CMDBChangeOp::OnInsert
+	 *
+	 * @since 2.7.4 do not persist CMDBChange anymore, so that we won't persist CMDBChange without any CMDBChangeOp
 	 */
 	protected static function CreateChange()
 	{
@@ -209,7 +211,6 @@ abstract class CMDBObject extends DBObject
 		self::$m_oCurrChange->Set("date", time());
 		self::$m_oCurrChange->Set("userinfo", self::GetTrackInfo());
 		self::$m_oCurrChange->Set("origin", self::GetTrackOrigin());
-		self::$m_oCurrChange->DBInsert();
 	}
 
 	/**

--- a/core/cmdbobject.class.inc.php
+++ b/core/cmdbobject.class.inc.php
@@ -125,20 +125,18 @@ abstract class CMDBObject extends DBObject
 	 */
 	public static function SetCurrentChangeFromParams($sUserInfo, $sOrigin = null, $oDate = null)
 	{
-		$oChange = MetaModel::NewObject('CMDBChange');
+		static::$m_oCurrChange = MetaModel::NewObject('CMDBChange');
 
-		self::$m_oCurrChange->Set("userinfo", $sUserInfo);
+		static::$m_oCurrChange->Set("userinfo", $sUserInfo);
 
 		if (!is_null($sOrigin)) {
-			self::$m_oCurrChange->Set("origin", $sOrigin);
+			static::$m_oCurrChange->Set("origin", $sOrigin);
 		}
 
 		if (is_null($oDate)) {
 			$oDate = time();
 		}
-		self::$m_oCurrChange->Set("date", $oDate);
-
-		self::$m_oCurrChange = $oChange;
+		static::$m_oCurrChange->Set("date", $oDate);
 	}
 
 	//

--- a/core/cmdbobject.class.inc.php
+++ b/core/cmdbobject.class.inc.php
@@ -125,18 +125,13 @@ abstract class CMDBObject extends DBObject
 	 */
 	public static function SetCurrentChangeFromParams($sUserInfo, $sOrigin = null, $oDate = null)
 	{
-		static::$m_oCurrChange = MetaModel::NewObject('CMDBChange');
+		static::SetTrackInfo($sUserInfo);
+		static::SetTrackOrigin($sOrigin);
+		static::CreateChange();
 
-		static::$m_oCurrChange->Set("userinfo", $sUserInfo);
-
-		if (!is_null($sOrigin)) {
-			static::$m_oCurrChange->Set("origin", $sOrigin);
+		if (!is_null($oDate)) {
+			static::$m_oCurrChange->Set("date", $oDate);
 		}
-
-		if (is_null($oDate)) {
-			$oDate = time();
-		}
-		static::$m_oCurrChange->Set("date", $oDate);
 	}
 
 	//

--- a/core/cmdbobject.class.inc.php
+++ b/core/cmdbobject.class.inc.php
@@ -117,7 +117,7 @@ abstract class CMDBObject extends DBObject
 	/**
 	 * @param string $sUserInfo
 	 * @param string $sOrigin
-	 * @param $oDate
+	 * @param \DateTime $oDate
 	 *
 	 * @throws \CoreException
 	 *
@@ -172,6 +172,8 @@ abstract class CMDBObject extends DBObject
 	 *    $oMyChange->Set("userinfo", 'this is done by ... for ...');
 	 *    $iChangeId = $oMyChange->DBInsert();
 	 *
+	 * **warning** : this will do nothing if current change already exists !
+	 *
 	 * @see SetCurrentChange to specify a CMDBObject instance instead
 	 *
 	 * @param string $sInfo
@@ -183,6 +185,8 @@ abstract class CMDBObject extends DBObject
 
 	/**
 	 * Provides information about the origin of the change
+	 *
+	 * **warning** : this will do nothing if current change already exists !
 	 *
 	 * @see SetTrackInfo
 	 * @see SetCurrentChange to specify a CMDBObject instance instead

--- a/core/cmdbobject.class.inc.php
+++ b/core/cmdbobject.class.inc.php
@@ -195,14 +195,11 @@ abstract class CMDBObject extends DBObject
 	/**
 	 * Get the additional information (defaulting to user name)
 	 */
-	protected static function GetTrackInfo()
+	public static function GetTrackInfo()
 	{
-		if (is_null(self::$m_sInfo))
-		{
+		if (is_null(self::$m_sInfo)) {
 			return CMDBChange::GetCurrentUserName();
-		}
-		else
-		{
+		} else {
 			return self::$m_sInfo;
 		}
 	}

--- a/core/cmdbobject.class.inc.php
+++ b/core/cmdbobject.class.inc.php
@@ -201,9 +201,8 @@ abstract class CMDBObject extends DBObject
 	/**
 	 * Set to {@link $m_oCurrChange} a standard change record (done here 99% of the time, and nearly once per page)
 	 *
-	 * The CMDBChange **is NOT persisted**, this will be done in \CMDBChangeOp::OnInsert
-	 *
-	 * @since 2.7.4 do not persist CMDBChange anymore, so that we won't persist CMDBChange without any CMDBChangeOp
+	 * @since 2.7.4 CMDBChange **will be persisted later** in \CMDBChangeOp::OnInsert (was done previously directly here)
+	 *     This will avoid creating in DB CMDBChange lines without any corresponding CMDBChangeOp
 	 */
 	protected static function CreateChange()
 	{

--- a/core/cmdbobject.class.inc.php
+++ b/core/cmdbobject.class.inc.php
@@ -121,7 +121,7 @@ abstract class CMDBObject extends DBObject
 	 *
 	 * @throws \CoreException
 	 *
-	 * @since 2.7.4 3.0.0 N°3717 new method to reset current change
+	 * @since 2.7.7 3.0.2 3.1.0 N°3717 new method to reset current change
 	 */
 	public static function SetCurrentChangeFromParams($sUserInfo, $sOrigin = null, $oDate = null)
 	{
@@ -222,7 +222,7 @@ abstract class CMDBObject extends DBObject
 	/**
 	 * Set to {@link $m_oCurrChange} a standard change record (done here 99% of the time, and nearly once per page)
 	 *
-	 * @since 2.7.4 CMDBChange **will be persisted later** in \CMDBChangeOp::OnInsert (was done previously directly here)
+	 * @since 2.7.7 3.0.2 3.1.0 N°3717 {@see CMDBChange} **will be persisted later** in {@see \CMDBChangeOp::OnInsert} (was done previously directly here)
 	 *     This will avoid creating in DB CMDBChange lines without any corresponding CMDBChangeOp
 	 */
 	protected static function CreateChange()

--- a/datamodels/2.x/combodo-db-tools/dbtools.php
+++ b/datamodels/2.x/combodo-db-tools/dbtools.php
@@ -301,9 +301,7 @@ function DisplayLostAttachments(iTopWebPage &$oP, ApplicationContext &$oAppConte
 					$sHistoryEntry = Dict::Format('DBTools:LostAttachments:History', $oOrmDocument->GetFileName());
 					CMDBObject::SetTrackInfo(UserRights::GetUserFriendlyName());
 					$oChangeOp = MetaModel::NewObject('CMDBChangeOpPlugin');
-					/** @var \Change $oChange */
-					$oChange = CMDBObject::GetCurrentChange();
-					$oChangeOp->Set('change', $oChange->GetKey());
+					// CMDBChangeOp.change will be automatically filled
 					$oChangeOp->Set('objclass', $sTargetClass);
 					$oChangeOp->Set('objkey', $sTargetId);
 					$oChangeOp->Set('description', $sHistoryEntry);

--- a/test/core/CMDBObjectTest.php
+++ b/test/core/CMDBObjectTest.php
@@ -35,7 +35,7 @@ class CMDBObjectTest extends ItopDataTestCase
 		//-- new object with only track info
 		$sTrackInfo = 'PHPUnit test';
 		CMDBObject::SetTrackInfo($sTrackInfo);
-		/** @var \DocumentNote $oTestObject */
+		/** @var \DocumentWeb $oTestObject */
 		$oTestObject = MetaModel::NewObject('DocumentWeb');
 		$oTestObject->Set('name', 'PHPUnit test');
 		$oTestObject->Set('org_id', 1);

--- a/test/core/CMDBObjectTest.php
+++ b/test/core/CMDBObjectTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Combodo\iTop\Test\UnitTest\Core;
+
+
+use CMDBObject;
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use MetaModel;
+
+/**
+ * @since 2.7.4 tests history objects creation
+ *
+ * @package Combodo\iTop\Test\UnitTest\Core
+ */
+
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ * @backupGlobals disabled
+ */
+class CMDBObjectTest extends ItopDataTestCase
+{
+	/**
+	 * @covers CMDBObject::SetCurrentChange
+	 */
+	public function testCurrentChange()
+	{
+		// save initial conditions
+		$oInitialCurrentChange = CMDBObject::GetCurrentChange();
+		$sInitialTrackInfo = CMDBObject::GetTrackInfo();
+		// reset current change
+		CMDBObject::SetCurrentChange(null);
+
+		//-- new object with only track info
+		$sTrackInfo = 'PHPUnit test';
+		CMDBObject::SetTrackInfo($sTrackInfo);
+		/** @var \DocumentNote $oTestObject */
+		$oTestObject = MetaModel::NewObject('DocumentWeb');
+		$oTestObject->Set('name', 'PHPUnit test');
+		$oTestObject->Set('org_id', 1);
+		$oTestObject->Set('url', 'https://www.combodo.com');
+		$oTestObject->DBWrite();
+		self::assertFalse(CMDBObject::GetCurrentChange()->IsNew(), 'TrackInfo : Current change persisted');
+		self::assertEquals($sTrackInfo, CMDBObject::GetCurrentChange()->Get('userinfo'),
+			'TrackInfo : current change created with expected trackinfo');
+
+		//-- new object with non persisted current change
+		$sTrackInfo2 = $sTrackInfo.'_2';
+		/** @var \CMDBChange $oCustomChange */
+		$oCustomChange = MetaModel::NewObject('CMDBChange');
+		$oCustomChange->Set('date', time());
+		$oCustomChange->Set('userinfo', $sTrackInfo2);
+		CMDBObject::SetCurrentChange($oCustomChange);
+		$oTestObject->Set('url', 'https://fr.wikipedia.org');
+		$oTestObject->DBUpdate();
+		self::assertFalse(CMDBObject::GetCurrentChange()->IsNew(), 'SetCurrentChange : Current change persisted');
+		self::assertEquals($sTrackInfo2, CMDBObject::GetCurrentChange()->Get('userinfo'),
+			'SetCurrentChange : current change created with expected trackinfo');
+
+		//-- new object with current change init using helper method
+		$sTrackInfo3 = $sTrackInfo.'_3';
+		CMDBObject::SetCurrentChangeFromParams($sTrackInfo3);
+		$oTestObject->Set('url', 'https://en.wikipedia.org');
+		$oTestObject->DBUpdate();
+		self::assertFalse(CMDBObject::GetCurrentChange()->IsNew(), 'SetCurrentChangeFromParams : Current change persisted');
+		self::assertEquals($sTrackInfo3, CMDBObject::GetCurrentChange()->Get('userinfo'),
+			'SetCurrentChangeFromParams : current change created with expected trackinfo');
+
+		// restore initial conditions
+		$oTestObject->DBDelete();
+		CMDBObject::SetCurrentChange($oInitialCurrentChange);
+		CMDBObject::SetTrackInfo($sInitialTrackInfo);
+	}
+}

--- a/test/core/CMDBObjectTest.php
+++ b/test/core/CMDBObjectTest.php
@@ -8,7 +8,7 @@ use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
 use MetaModel;
 
 /**
- * @since 2.7.4 tests history objects creation
+ * @since 2.7.7 3.0.2 3.1.0 N°3717 tests history objects creation
  *
  * @package Combodo\iTop\Test\UnitTest\Core
  */

--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -266,12 +266,9 @@ function CronExec($oP, $aProcesses, $bVerbose, $bDebug=false)
 
 			// N°3219 for each process will use a specific CMDBChange object with a specific track info
 			// Any BackgroundProcess can overrides this as needed
-			CMDBObject::SetCurrentChange(null);
-			CMDBObject::SetTrackInfo("Background task ($sTaskClass)");
-			CMDBObject::SetTrackOrigin(null);
+			CMDBObject::SetCurrentChangeFromParams("Background task ($sTaskClass)");
 
-			if (!array_key_exists($sTaskClass, $aTasks))
-			{
+			if (!array_key_exists($sTaskClass, $aTasks)) {
 				// New entry, let's create a new BackgroundTask record, and plan the first execution
 				$oTask = new BackgroundTask();
 				$oTask->SetDebug($bDebug);


### PR DESCRIPTION
## Introduction

In iTop, a history functionnality exists so that user can have a clear vision of the modifications made to an object. All of this is handled in `CMDBObject` methods, and persisted in `CMDBChange` and `CMDBChangeOp` objects.

Initially the history needed to be handled manually : each developper needed to create and persist the `CMDBChange` and `CMDBChangeOp` objects.

Then in iTop 2.0 (commit 7dbbb1c2990702347780cd38130600f39f088d0c) was added an automatic generation and persistence done by the ORM itself. 
Possibility for the developper to specify his own CMDBObject was kept though (`\CMDBObject::SetCurrentChange`, and also `SetTrackInfo` and `SetTrackOrigin` methods), the ORM creating and attaching the corresponding CMDBChangeOp objects automatically.
Also were kept all the previous object CRUD methods in DBObject where you need to specify your CMDBChange having already its CMDBChangeOp attached : DBInsertTracked / DBInsertTrackedNoReload / DBUpdateTracked / DBDeleteTracked.


## Bugs in iTop 2.7.x versions

🐛 In the 2.7.* iTop versions, we had quite a hard time dealing with this object history API.
Here are the related tickets :
* 2.7.0 N°2361 deprecate all DB*Tracked and adapt code that was calling those methods
  => everything was working by chance before, and using the API as intended (instead of calling `DB*Tracked`, use the regular API but with a call to `\CMDBObject::SetCurrentChange`) caused all the previously hidden problems to appear 👻
* 2.7.0-2 N°2952 Auth API automatic provisionning not working due to wrong CMDBChange.origin
* 2.7.2 N°3218 in the "Mail to Ticket automation" extension :
  - wrong value for CMDBChange.origin
  - only one CMDBChange is generated for the whole BackgroundProcess execution
* 2.7.2 N°3219 cron.php : only one CMDBChange for the whole cron.php execution 😱
* 2.7.4 N°3716 Mail To Ticket orphan CMDBChange : since iTop products 2.7.2 or extension v3.2.0 each message read in the mailbox by the extension persists a new `CMDBChange` object. This leads to enormous volume in the corresponding table, possibily slowing down the whole application :(
  Mail to Ticket automation 3.2.1 now only compatible with iTop 2.7.2+ (in order to be able to call `CMDBObject::SetCurrentChange(null);`)
* 2.7.4 N°3464 the itop-fence module sets a CMDBChange that is not reset after
* 2.7.6 N°4486 errors due to combodo-cmdbchange-cleaner removing CMDBChange objects of ongoing modifications


## Proposition

This PR aims to improve current history API, to improve mandatory calls when working in a context when we need to customize API behavior like in `cron.php` (see commit 07bd6b853931b68a8d23d72bda90a7845b20d1ca for N°3219 in iTop 2.7.2)

* 💾 Currently we need to persist CMDBChange passed to `\CMDBObject::SetCurrentChange` : this is no longer the case. Persistance is now done in `\CMDBChangeOp::OnInsert` when needed, as this is indeed CMDBChangeOp that adds this constraint. Also, persistence isn't done anymore in `\CMDBObject::CreateChange`
* 👍 When we needed to reset current change (for example what we did for N°3219) there were multiple lines to add. For convenience we are adding a new `\CMDBObject::SetCurrentChangeFromParams` helper method : now there is only 1 line to write (`cron.php` modified as an example)


## Remaining issues

❗ Note that there is still something to solve : when setting yourself `CMDBChangeOp.change` field with your own `CMDBChange` not persisted instance, in `\CMDBChangeOp::OnInsert` we will replace silently your `CMDBChange` instance by the API's current change !
More generally, developers should be warned that history (that is `CMDBChange` and `CMDBChangeOp` objects) are the API concern, and they shouldn't deal with it directly !
This may be improved by a future PR...

❗ Also, `\CMDBObject::SetTrack*` methods are confusing, as they are doing nothing if the current change was already created... As the point before, this is something that we should improve later on.

## TODO

- [ ] Wait for 3.0.1 release
- [ ] Merge for 2.7.7 / 3.0.2 / 3.1.0
- [ ] Starting in support/3.0 add the CMDBChange.user_id field support (N°3279)