### PR TITLE
N°3731 log deprecated calls

### DIFF
--- a/bootstrap.inc.php
+++ b/bootstrap.inc.php
@@ -50,18 +50,19 @@ if (function_exists('microtime')) {
 	$fItopStarted = 1000 * time();
 }
 
-if (! isset($GLOBALS['bBypassAutoload']) || $GLOBALS['bBypassAutoload'] == false)
-{
+if (!isset($GLOBALS['bBypassAutoload']) || $GLOBALS['bBypassAutoload'] == false) {
 	require_once APPROOT.'/lib/autoload.php';
 }
+
+require_once APPROOT.'core/log.class.inc.php';
+DeprecatedCallsLog::Enable();
 
 //
 // Maintenance mode
 //
 
 // Use 'maintenance' parameter to bypass maintenance mode
-if (!isset($bBypassMaintenance))
-{
+if (!isset($bBypassMaintenance)) {
 	$bBypassMaintenance = isset($_REQUEST['maintenance']) ? boolval($_REQUEST['maintenance']) : false;
 }
 

--- a/core/coreexception.class.inc.php
+++ b/core/coreexception.class.inc.php
@@ -5,4 +5,4 @@
  * @deprecated 3.0.0 N°3663 Exception classes were moved to `/application/exceptions`, use autoloader instead of require !
  */
 require_once '../approot.inc.php';
-DeprecatedCallsLog::Error(__FILE__, DeprecatedCallsLog::CHANNEL_FILE);
+DeprecatedCallsLog::ErrorFile();

--- a/core/coreexception.class.inc.php
+++ b/core/coreexception.class.inc.php
@@ -5,4 +5,4 @@
  * @deprecated 3.0.0 N°3663 Exception classes were moved to `/application/exceptions`, use autoloader instead of require !
  */
 require_once '../approot.inc.php';
-DeprecatedCallsLog::ErrorFile();
+DeprecatedCallsLog::NotifyDeprecatedFile();

--- a/core/coreexception.class.inc.php
+++ b/core/coreexception.class.inc.php
@@ -4,3 +4,5 @@
  *
  * @deprecated 3.0.0 N°3663 Exception classes were moved to `/application/exceptions`, use autoloader instead of require !
  */
+require_once '../approot.inc.php';
+DeprecatedCallsLog::Error(__FILE__, DeprecatedCallsLog::CHANNEL_FILE);

--- a/core/coreexception.class.inc.php
+++ b/core/coreexception.class.inc.php
@@ -5,4 +5,4 @@
  * @deprecated 3.0.0 N°3663 Exception classes were moved to `/application/exceptions`, use autoloader instead of require !
  */
 require_once '../approot.inc.php';
-DeprecatedCallsLog::NotifyDeprecatedFile();
+DeprecatedCallsLog::NotifyDeprecatedFile('Classes were moved to /application/exceptions');

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -688,11 +688,7 @@ abstract class LogAPI
 		}
 
 		if (isset($sLogLevelMin[static::CHANNEL_DEFAULT])) {
-			return $sLogLevelMin[static::CHANNEL_DEFAULT];
-		}
-
-		if (isset($sLogLevelMin[''])) {
-			return $sLogLevelMin[''];
+			return $sLogLevelMin[$sChannel];
 		}
 
 		return static::GetLevelDefault();

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -765,9 +765,9 @@ class DeadLockLog extends LogAPI
  */
 class DeprecatedCallsLog extends LogAPI
 {
-	public const CHANNEL_PHP = 'deprecated-method';
-	public const CHANNEL_FILE = 'deprecated-file';
-	public const CHANNEL_DEFAULT = self::CHANNEL_PHP;
+	public const ENUM_CHANNEL_PHP = 'deprecated-method';
+	public const ENUM_CHANNEL_FILE = 'deprecated-file';
+	public const CHANNEL_DEFAULT = self::ENUM_CHANNEL_PHP;
 
 	public const LEVEL_DEFAULT = self::LEVEL_WARNING;
 
@@ -802,7 +802,7 @@ class DeprecatedCallsLog extends LogAPI
 			$sMessage .= ' : '.$sAdditionalMessage;
 		}
 
-		static::Warning($sMessage, static::CHANNEL_FILE);
+		static::Warning($sMessage, static::ENUM_CHANNEL_FILE);
 	}
 
 	/**
@@ -827,7 +827,7 @@ class DeprecatedCallsLog extends LogAPI
 			$sMessage .= ' : '.$sAdditionalMessage;
 		}
 
-		static::Warning($sMessage, static::CHANNEL_PHP);
+		static::Warning($sMessage, static::ENUM_CHANNEL_PHP);
 	}
 
 	public static function Log($sLevel, $sMessage, $sChannel = null, $aContext = array()): void

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -844,10 +844,17 @@ class DeprecatedCallsLog extends LogAPI
 			return;
 		}
 
-		$aStack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
-		$sCallerFile = $aStack[0]['file'];
+		$aStack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+		$sDeprecatedFile = $aStack[0]['file'];
+		if (array_key_exists(1, $aStack)) {
+			$sCallerFile = $aStack[1]['file'];
+			$sCallerLine = $aStack[1]['line'];
+		} else {
+			$sCallerFile = 'N/A';
+			$sCallerLine = 'N/A';
+		}
 
-		$sMessage = $sCallerFile;
+		$sMessage = "{$sCallerFile} L{$sCallerLine} including/requiring {$sDeprecatedFile}";
 
 		if (!is_null($sAdditionalMessage)) {
 			$sMessage .= ' : '.$sAdditionalMessage;

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -791,7 +791,43 @@ class DeprecatedCallsLog extends LogAPI
 		return parent::GetMinLogLevel($sChannel);
 	}
 
-	public static function Log($sLevel, $sMessage, $sChannel = null, $aContext = array())
+	public static function ErrorFile(?string $sAdditionalMessage = null): void
+	{
+		$aStack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+		$sCallerFile = $aStack[0]['file'];
+
+		$sMessage = $sCallerFile;
+
+		if (!is_null($sAdditionalMessage)) {
+			$sMessage .= ' : '.$sAdditionalMessage;
+		}
+
+		static::Error($sMessage, static::CHANNEL_FILE);
+	}
+
+	/**
+	 * @param string|null $sAdditionalMessage
+	 *
+	 * @uses \debug_backtrace()
+	 * @link https://www.php.net/debug_backtrace
+	 */
+	public static function ErrorPhp(?string $sAdditionalMessage = null): void
+	{
+		$aStack = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2);
+		$sCallerObject = $aStack[1]['class'];
+		$sCallerMethod = $aStack[1]['function'];
+		$sCallerLine = $aStack[1]['line'];
+
+		$sMessage = "{$sCallerObject}::{$sCallerMethod} L{$sCallerLine}";
+
+		if (!is_null($sAdditionalMessage)) {
+			$sMessage .= ' : '.$sAdditionalMessage;
+		}
+
+		static::Error($sMessage, static::CHANNEL_PHP);
+	}
+
+	public static function Log($sLevel, $sMessage, $sChannel = null, $aContext = array()): void
 	{
 		if ((static::LEVEL_ERROR === $sLevel) && utils::IsDevelopmentEnvironment()) {
 			trigger_error($sMessage);

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -830,7 +830,7 @@ class DeprecatedCallsLog extends LogAPI
 	public static function Log($sLevel, $sMessage, $sChannel = null, $aContext = array()): void
 	{
 		if (utils::IsDevelopmentEnvironment()) {
-			trigger_error($sMessage);
+			trigger_error($sMessage, E_USER_DEPRECATED);
 		}
 
 		parent::Log($sLevel, $sMessage, $sChannel, $aContext);

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -769,7 +769,7 @@ class DeprecatedCallsLog extends LogAPI
 	public const CHANNEL_FILE = 'deprecated-file';
 	public const CHANNEL_DEFAULT = self::CHANNEL_PHP;
 
-	public const LEVEL_DEFAULT = self::LEVEL_ERROR;
+	public const LEVEL_DEFAULT = self::LEVEL_WARNING;
 
 	/** @var \FileLog we want our own instance ! */
 	protected static $m_oFileLog = null;
@@ -802,7 +802,7 @@ class DeprecatedCallsLog extends LogAPI
 			$sMessage .= ' : '.$sAdditionalMessage;
 		}
 
-		static::Error($sMessage, static::CHANNEL_FILE);
+		static::Warning($sMessage, static::CHANNEL_FILE);
 	}
 
 	/**
@@ -824,12 +824,12 @@ class DeprecatedCallsLog extends LogAPI
 			$sMessage .= ' : '.$sAdditionalMessage;
 		}
 
-		static::Error($sMessage, static::CHANNEL_PHP);
+		static::Warning($sMessage, static::CHANNEL_PHP);
 	}
 
 	public static function Log($sLevel, $sMessage, $sChannel = null, $aContext = array()): void
 	{
-		if ((static::LEVEL_ERROR === $sLevel) && utils::IsDevelopmentEnvironment()) {
+		if (utils::IsDevelopmentEnvironment()) {
 			trigger_error($sMessage);
 		}
 

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -813,12 +813,15 @@ class DeprecatedCallsLog extends LogAPI
 	 */
 	public static function NotifyDeprecatedMethod(?string $sAdditionalMessage = null): void
 	{
-		$aStack = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2);
-		$sCallerObject = $aStack[1]['class'];
-		$sCallerMethod = $aStack[1]['function'];
-		$sCallerLine = $aStack[1]['line'];
+		$aStack = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 3);
+		$sCallerObject = $aStack[2]['class'];
+		$sCallerMethod = $aStack[2]['function'];
+		$sCallerLine = $aStack[2]['line'];
 
-		$sMessage = "{$sCallerObject}::{$sCallerMethod} L{$sCallerLine}";
+		$sDeprecatedObject = $aStack[1]['class'];
+		$sDeprecatedMethod = $aStack[1]['function'];
+
+		$sMessage = "{$sCallerObject}::{$sCallerMethod} L{$sCallerLine} calling {$sDeprecatedObject}:{$sDeprecatedMethod}";
 
 		if (!is_null($sAdditionalMessage)) {
 			$sMessage .= ' : '.$sAdditionalMessage;

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -688,7 +688,11 @@ abstract class LogAPI
 		}
 
 		if (isset($sLogLevelMin[static::CHANNEL_DEFAULT])) {
-			return $sLogLevelMin[$sChannel];
+			return $sLogLevelMin[static::CHANNEL_DEFAULT];
+		}
+
+		if (isset($sLogLevelMin[''])) {
+			return $sLogLevelMin[''];
 		}
 
 		return static::GetLevelDefault();

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -765,7 +765,7 @@ class DeadLockLog extends LogAPI
  */
 class DeprecatedCallsLog extends LogAPI
 {
-	public const CHANNEL_PHP = 'deprecated-php';
+	public const CHANNEL_PHP = 'deprecated-method';
 	public const CHANNEL_FILE = 'deprecated-file';
 	public const CHANNEL_DEFAULT = self::CHANNEL_PHP;
 
@@ -791,7 +791,7 @@ class DeprecatedCallsLog extends LogAPI
 		return parent::GetMinLogLevel($sChannel);
 	}
 
-	public static function ErrorFile(?string $sAdditionalMessage = null): void
+	public static function NotifyDeprecatedFile(?string $sAdditionalMessage = null): void
 	{
 		$aStack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
 		$sCallerFile = $aStack[0]['file'];
@@ -811,7 +811,7 @@ class DeprecatedCallsLog extends LogAPI
 	 * @uses \debug_backtrace()
 	 * @link https://www.php.net/debug_backtrace
 	 */
-	public static function ErrorPhp(?string $sAdditionalMessage = null): void
+	public static function NotifyDeprecatedMethod(?string $sAdditionalMessage = null): void
 	{
 		$aStack = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2);
 		$sCallerObject = $aStack[1]['class'];

--- a/sources/application/WebPage/WebPage.php
+++ b/sources/application/WebPage/WebPage.php
@@ -1427,6 +1427,7 @@ class WebPage implements Page
 	 */
 	protected function outputCollapsibleSectionInit()
 	{
+		DeprecatedCallsLog::ErrorPhp();
 		if (!$this->bHasCollapsibleSection) {
 			return;
 		}

--- a/sources/application/WebPage/WebPage.php
+++ b/sources/application/WebPage/WebPage.php
@@ -1427,7 +1427,7 @@ class WebPage implements Page
 	 */
 	protected function outputCollapsibleSectionInit()
 	{
-		DeprecatedCallsLog::ErrorPhp();
+		DeprecatedCallsLog::NotifyDeprecatedMethod();
 		if (!$this->bHasCollapsibleSection) {
 			return;
 		}

--- a/sources/application/WebPage/WebPage.php
+++ b/sources/application/WebPage/WebPage.php
@@ -1427,7 +1427,7 @@ class WebPage implements Page
 	 */
 	protected function outputCollapsibleSectionInit()
 	{
-		DeprecatedCallsLog::NotifyDeprecatedMethod();
+		DeprecatedCallsLog::NotifyDeprecatedPhpMethod();
 		if (!$this->bHasCollapsibleSection) {
 			return;
 		}


### PR DESCRIPTION
@Hipska suggested that we trigger warnings when calling deprecated files : https://github.com/Combodo/iTop/commit/b85b4d00674884491938a6ed02a2389838106727#r46416569

We created a deprecate/remove policy last year, but were eagger to add warnings as this could break ajax calls the way they are done in iTop for now :/
After Hipska suggestion, we decided we should try : 
* adding a dedicated LogAPI implementation, that would write to a specific file
* this logger should also trigger_error() if \utils::IsDevelopmentEnvironment
* we should call this logger in every deprecated code and files

This is a first try to implement this, as a base to discuss this with the rest of the dev team !