### PR TITLE
Added final class access control when opening object detail.

### DIFF
--- a/pages/UI.php
+++ b/pages/UI.php
@@ -435,7 +435,15 @@ try
 			{
 				try
 				{
-					$oObj->Reload();
+					// Acces control for final class
+					if (MetaModel::IsValidAttCode($sClass, "finalclass") && MetaModel::GetObject($oObj->Get("finalclass"), $id, false /* MustBeFound */) == null)
+					{
+						throw new ApplicationException("Not allowed to access derived class.");				
+					}
+					else
+					{
+						$oObj->Reload();
+					}
 				}
 				catch(Exception $e)
 				{


### PR DESCRIPTION
I use custom "MakeSelectFilter" method, which allows to see FunctionalCI (for selection in list), but denies access to ApplicationSolution for users from another organization. When user has acces to class (e.g. FunctionalCI) and tries to open its derived class (e.g. ApplicationSolution) detail, to which he has no access, app crashed. This can be solution of derived class access control. 