### PR TITLE
Add apcu as optional extension

### DIFF
--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -2152,6 +2152,7 @@ JS
 				'openssl' => 'Strong encryption will not be used.',
 			],
 			'ldap' => 'LDAP authentication will be disabled.',
+			'apcu' => 'APCu in-memory caching will be disabled.',
 		];
 
 		if (utils::IsDevelopmentEnvironment()) {


### PR DESCRIPTION
[SF#1286](https://sourceforge.net/p/itop/tickets/1286/)
The description text might need to include that a fallback to file-based cache will be used.

PS: note that there are a lot of un-needed `if(function_exists('apc_` calls still existing in the code. Do you want me to find them and fix?