### PR TITLE
🐛 Decimal values with aggregate functions (dashlet group by)

### DIFF
--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -478,7 +478,7 @@ class DisplayBlock
 					$aValues[$iRow] = $sValue;
 					$sHtmlValue = $oGroupByExp->MakeValueLabel($this->m_oFilter, $sValue, $sValue);
 					$aLabels[$iRow] = $sHtmlValue;
-					$aGroupBy[$iRow] = (int) $aRow[$sFctVar];
+					$aGroupBy[$iRow] = $aRow[$sFctVar];
 					$iTotalCount += $aRow['_itop_count_'];
 				}
 


### PR DESCRIPTION
Opening this for discussion.

Why is the returned value of an aggregate function automatically converted to an Integer? It makes sense for count, which was the (only) initial aggregate function if I remember correctly.

However, when applied to an AttributeDecimal; this will be a float.
Explicitly converting this to a float is also not recommended: 1.10 would become 1.1 

So not sure if there's a reason for this explicit conversion/enforcement.
Perhaps a check to see if it's a null/empty value (if that is a possibility) and then simply putting "0" could be enough.

Otherwise it may need more tweaking.

https://sourceforge.net/p/itop/tickets/1961/
