### PR TITLE
Feature/3968 mutex timeout

### DIFF
--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -756,6 +756,9 @@ class DeadLockLog extends LogAPI
 	 *
 	 * @throws \Exception
 	 * @noinspection PhpParameterNameChangedDuringInheritanceInspection
+	 *
+	 * @since 2.7.1 method creation
+	 * @since 2.7.5 3.0.0 rename param names and fix phpdoc (thanks Hipska !)
 	 */
 	public static function Log($sLevel, $sMessage, $iMysqlErrorNumber = null, $aContext = array())
 	{

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -740,7 +740,7 @@ class DeadLockLog extends LogAPI
 				return self::CHANNEL_WAIT_TIMEOUT;
 				break;
 			case 1213:
-				return  self::CHANNEL_DEADLOCK_FOUND;
+				return self::CHANNEL_DEADLOCK_FOUND;
 				break;
 			default:
 				return self::CHANNEL_DEFAULT;
@@ -749,17 +749,18 @@ class DeadLockLog extends LogAPI
 	}
 
 	/**
-	 * @param int $iMySQLErrNo will be converted to channel using {@link GetChannelFromMysqlErrorNo}
+	 * @param string $sLevel
 	 * @param string $sMessage
-	 * @param null $iMysqlErroNo
+	 * @param int $iMysqlErrorNumber will be converted to channel using {@link GetChannelFromMysqlErrorNo}
 	 * @param array $aContext
 	 *
 	 * @throws \Exception
+	 * @noinspection PhpParameterNameChangedDuringInheritanceInspection
 	 */
-	public static function Log($iMySQLErrNo, $sMessage, $iMysqlErroNo = null, $aContext = array())
+	public static function Log($sLevel, $sMessage, $iMysqlErrorNumber = null, $aContext = array())
 	{
-		$sChannel = self::GetChannelFromMysqlErrorNo($iMysqlErroNo);
-		parent::Log($iMySQLErrNo, $sMessage, $sChannel, $aContext);
+		$sChannel = self::GetChannelFromMysqlErrorNo($iMysqlErrorNumber);
+		parent::Log($sLevel, $sMessage, $sChannel, $aContext);
 	}
 }
 

--- a/core/mutex.class.inc.php
+++ b/core/mutex.class.inc.php
@@ -258,6 +258,38 @@ class iTopMutex
 		{
 			throw new Exception("Could not connect to the DB server (host=$sServer, user=$sUser): ".mysqli_connect_error().' (mysql errno: '.mysqli_connect_errno().')');
 		}
+
+		// Make sure that the server variable wait_timeout is at least 86400 seconds for this connection,
+		// since the lock will be released if/when the connection times out.
+
+		// BEWARE: If you want to check the value of this variable, when run from an interactive console "SHOW VARIABLES LIKE 'wait_timeout'" actually
+		// returns the value of the variable 'interactive_timeout' which may be quite different.
+
+		$sSql = "SHOW VARIABLES LIKE 'wait_timeout'";
+		$result = mysqli_query($this->hDBLink, $sSql);
+		if (!$result)
+		{
+		    throw new Exception("Failed to issue MySQL query '".$sSql."': ".mysqli_error($this->hDBLink).' (mysql errno: '.mysqli_errno($this->hDBLink).')');
+		}
+		if ($aRow = mysqli_fetch_array($result, MYSQLI_BOTH))
+		{
+		    $iTimeout = (int)$aRow[1];
+		}
+		else
+		{
+		    mysqli_free_result($result);
+		    throw new Exception("No result for query '".$sSql."'");
+		}
+		mysqli_free_result($result);
+
+		if ($iTimeout < 86400)
+		{
+		    $result = mysqli_query($this->hDBLink, 'SET SESSION wait_timeout=86400');
+		    if ($result === false)
+		    {
+		        throw new Exception("Failed to issue MySQL query '".$sSql."': ".mysqli_error($this->hDBLink).' (mysql errno: '.mysqli_errno($this->hDBLink).')');
+		    }
+		}
 	}
 
 


### PR DESCRIPTION
iTop Mutexes are based on the MySQL GET_LOCK() command. This command creates a server-side lock which is released either by calling RELEASE_LOCK() or when the connection to the MySQL server ends (which is handy in case of a PHP crash).

However, when a MySQL connection remains idle for a certain time (defined by the server parameter **wait_timeout**), it gets automatically closed by MySQL.

Since each iTop mutex uses its own MySQL connection (which sees no further commands once the lock is acquired), a "locked" Mutex is automatically  (and silently) released after wait_timeout seconds.

This pull request ensures that the wait_timeout _for the connection used by the mutex_ is at least 1 day (86400 seconds).