### PR TITLE
N°3968 - Fixed mutex being silently released after wait_timeout seconds

### DIFF
--- a/core/mutex.class.inc.php
+++ b/core/mutex.class.inc.php
@@ -258,6 +258,38 @@ class iTopMutex
 		{
 			throw new Exception("Could not connect to the DB server (host=$sServer, user=$sUser): ".mysqli_connect_error().' (mysql errno: '.mysqli_connect_errno().')');
 		}
+
+		// Make sure that the server variable wait_timeout is at least 86400 seconds for this connection,
+		// since the lock will be released if/when the connection times out.
+
+		// BEWARE: If you want to check the value of this variable, when run from an interactive console "SHOW VARIABLES LIKE 'wait_timeout'" actually
+		// returns the value of the variable 'interactive_timeout' which may be quite different.
+
+		$sSql = "SHOW VARIABLES LIKE 'wait_timeout'";
+		$result = mysqli_query($this->hDBLink, $sSql);
+		if (!$result)
+		{
+		    throw new Exception("Failed to issue MySQL query '".$sSql."': ".mysqli_error($this->hDBLink).' (mysql errno: '.mysqli_errno($this->hDBLink).')');
+		}
+		if ($aRow = mysqli_fetch_array($result, MYSQLI_BOTH))
+		{
+		    $iTimeout = (int)$aRow[1];
+		}
+		else
+		{
+		    mysqli_free_result($result);
+		    throw new Exception("No result for query '".$sSql."'");
+		}
+		mysqli_free_result($result);
+
+		if ($iTimeout < 86400)
+		{
+		    $result = mysqli_query($this->hDBLink, 'SET SESSION wait_timeout=86400');
+		    if ($result === false)
+		    {
+		        throw new Exception("Failed to issue MySQL query '".$sSql."': ".mysqli_error($this->hDBLink).' (mysql errno: '.mysqli_errno($this->hDBLink).')');
+		    }
+		}
 	}
 
 

--- a/core/mutex.class.inc.php
+++ b/core/mutex.class.inc.php
@@ -242,6 +242,8 @@ class iTopMutex
 	 *
 	 * @throws \Exception
 	 * @throws \MySQLException
+	 *
+	 * @since 2.7.5 3.0.0 N°3968 specify `wait_timeout` for the mutex dedicated connection
 	 */
 	public function InitMySQLSession()
 	{
@@ -254,41 +256,35 @@ class iTopMutex
 
 		$this->hDBLink = CMDBSource::GetMysqliInstance($sServer, $sUser, $sPwd, $sSource, $bTlsEnabled, $sTlsCA, false);
 
-		if (!$this->hDBLink)
-		{
+		if (!$this->hDBLink) {
 			throw new Exception("Could not connect to the DB server (host=$sServer, user=$sUser): ".mysqli_connect_error().' (mysql errno: '.mysqli_connect_errno().')');
 		}
 
-		// Make sure that the server variable wait_timeout is at least 86400 seconds for this connection,
+		// Make sure that the server variable `wait_timeout` is at least 86400 seconds for this connection,
 		// since the lock will be released if/when the connection times out.
-
-		// BEWARE: If you want to check the value of this variable, when run from an interactive console "SHOW VARIABLES LIKE 'wait_timeout'" actually
-		// returns the value of the variable 'interactive_timeout' which may be quite different.
-
+		// Source https://dev.mysql.com/doc/refman/5.7/en/locking-functions.html :
+		// > A lock obtained with GET_LOCK() is released explicitly by executing RELEASE_LOCK() or implicitly when your session terminates
+		//
+		// BEWARE: If you want to check the value of this variable, when run from an interactive console `SHOW VARIABLES LIKE 'wait_timeout'`
+		// will actually returns the value of the variable `interactive_timeout` which may be quite different.
 		$sSql = "SHOW VARIABLES LIKE 'wait_timeout'";
 		$result = mysqli_query($this->hDBLink, $sSql);
-		if (!$result)
-		{
-		    throw new Exception("Failed to issue MySQL query '".$sSql."': ".mysqli_error($this->hDBLink).' (mysql errno: '.mysqli_errno($this->hDBLink).')');
+		if (!$result) {
+			throw new Exception("Failed to issue MySQL query '".$sSql."': ".mysqli_error($this->hDBLink).' (mysql errno: '.mysqli_errno($this->hDBLink).')');
 		}
-		if ($aRow = mysqli_fetch_array($result, MYSQLI_BOTH))
-		{
-		    $iTimeout = (int)$aRow[1];
-		}
-		else
-		{
-		    mysqli_free_result($result);
-		    throw new Exception("No result for query '".$sSql."'");
+		if ($aRow = mysqli_fetch_array($result, MYSQLI_BOTH)) {
+			$iTimeout = (int)$aRow[1];
+		} else {
+			mysqli_free_result($result);
+			throw new Exception("No result for query '".$sSql."'");
 		}
 		mysqli_free_result($result);
 
-		if ($iTimeout < 86400)
-		{
-		    $result = mysqli_query($this->hDBLink, 'SET SESSION wait_timeout=86400');
-		    if ($result === false)
-		    {
-		        throw new Exception("Failed to issue MySQL query '".$sSql."': ".mysqli_error($this->hDBLink).' (mysql errno: '.mysqli_errno($this->hDBLink).')');
-		    }
+		if ($iTimeout < 86400) {
+			$result = mysqli_query($this->hDBLink, 'SET SESSION wait_timeout=86400');
+			if ($result === false) {
+				throw new Exception("Failed to issue MySQL query '".$sSql."': ".mysqli_error($this->hDBLink).' (mysql errno: '.mysqli_errno($this->hDBLink).')');
+			}
 		}
 	}
 


### PR DESCRIPTION
iTop Mutexes are based on the MySQL GET_LOCK() command. This command creates a server-side lock which is released either by calling RELEASE_LOCK() or when the connection to the MySQL server ends (which is handy in case of a PHP crash).

However, when a MySQL connection remains idle for a certain time (defined by the server parameter **wait_timeout**), it gets automatically closed by MySQL.

Since each iTop mutex uses its own MySQL connection (which sees no further commands once the lock is acquired), a "locked" Mutex is automatically  (and silently) released after wait_timeout seconds.

Thi spull request ensures that the wait_timeout _for the connection used by the mutex_ is at least 86400 seconds (1 day).