### PR TITLE
Handle errors when sending large volumes of data in datatable's XHR queries, on server with low `max_input_vars`

### DIFF
--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -132,6 +132,35 @@ try
 			$aClassAliases = utils::ReadParam('class_aliases', array());
 			$iListId = utils::ReadParam('list_id', 0);
 
+			if (is_array($aColumns) && (count($aColumns) > 1)) {
+				/**
+				 * Check $aColumns content consistency
+				 * For data passed in XHR queries with some volume, on some servers data can be cut off because of a php.ini's `max_input_vars` set too low
+				 * In the documentation we recommend 5000, while default value is 1000
+				 *
+				 * @link https://www.php.net/manual/fr/info.configuration.php#ini.max-input-vars PHP doc on `max_input_vars`
+				 * @link https://www.itophub.io/wiki/page?id=latest%3Ainstall%3Aphp_and_mysql_configuration#php_mysql_mariadb_settings Combodo's recommended options
+				 */
+				$aColumnsFirstClass = $aColumns[0];
+				$aColumnsFirstClassFirstField = $aColumnsFirstClass[0];
+				$iColumnsFirstClassFirstFieldPropertiesNb = count($aColumnsFirstClassFirstField);
+				$aColumnsLastClass = end($aColumns);
+				$aColumnsLastClassLastField = end($aColumnsLastClass);
+				$iColumnsLastClassLastFieldPropertiesNb = count($aColumnsLastClassLastField);
+				if ($iColumnsFirstClassFirstFieldPropertiesNb !== $iColumnsLastClassLastFieldPropertiesNb) {
+					$iMaxInputVarsValue = ini_get('max_input_vars');
+					IssueLog::Warning(
+						"ajax.render.php received an invalid array for columns : check max_input_vars value in php.ini !",
+						null,
+						array(
+							'operation' => $operation,
+							'max_input_vars' => $iMaxInputVarsValue,
+							'$aColumns' => $aColumns,
+						)
+					);
+				}
+			}
+
 			// Filter the list to removed linked set since we are not able to display them here
 			$aOrderBy = array();
 			$iSortIndex = 0;

--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -173,7 +173,7 @@ try
 				{
 					if (!array_key_exists('checked', $aData)) {
 						// could happen if max_input_vars too low to handle JSON volume
-						$aData['checked'] = false;
+						$aData['checked'] = 'false';
 					}
 					if ($aData['checked'] == 'true')
 					{

--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -171,6 +171,10 @@ try
 				$aColumnsLoad[$sAlias] = array();
 				foreach($aColumns[$sAlias] as $sAttCode => $aData)
 				{
+					if (!array_key_exists('checked', $aData)) {
+						// could happen if max_input_vars too low to handle JSON volume
+						$aData['checked'] = false;
+					}
 					if ($aData['checked'] == 'true')
 					{
 						$aColumns[$sAlias][$sAttCode]['checked'] = true;


### PR DESCRIPTION
# Introduction

Multiple problems can occur in iTop if the `max_input_vars` php.ini option is set to a low value : actually iTop does a lot of XHR queries, and can send some large amount of data.
Default value for this option is 1000, [we recommend](https://www.itophub.io/wiki/page?id=latest%3Ainstall%3Aphp_and_mysql_configuration#php_mysql_mariadb_settings) setting it to 5000.

# Case that we want to address

This PR is an improvements for a recent support case : in a objects' list, when clicking on a column header an XHR query is sent to the server (ajax.render.php?operation=pagination). This was failing cause the $aColumns variable contained invalid data. 
An easy way to reproduce with a standard datamodel is set `max_input_vars` to 220, search for UserRequest objects then click on a column header.

If PHP notice are enabled then the table gets populated with this notice : 

![image](https://user-images.githubusercontent.com/8947448/117837740-fe2bc380-b279-11eb-9dd1-800289459e86.png)

Otherwise we get a content with lot more columns that the one selected to display.

In ajax.render we should get something like : 

```
array (
  'UserRequest' =>
  array (
    '_key_' =>
    array (
      'label' => 'User Request (Link)',
      'checked' => 'true',
      'disabled' => 'true',
      'alias' => 'UserRequest',
      'code' => '_key_',
      'sort' => 'none',
    ),
   // ...
    'parent_request_id_friendlyname' =>
    array (
      'label' => 'parent_request_id_friendlyname (Friendly Name)',
      'checked' => 'false',
      'disabled' => 'false',
      'alias' => 'UserRequest',
      'code' => 'parent_request_id_friendlyname',
      'sort' => 'none',
    ),
)
```

But instead we are getting : 

```
array (
  'UserRequest' =>
  array (
    '_key_' =>
    array (
      'label' => 'User Request (Link)',
      'checked' => 'true',
      'disabled' => 'true',
      'alias' => 'UserRequest',
      'code' => '_key_',
      'sort' => 'none',
    ),
   // ...
    'parent_request_id_friendlyname' =>
    array (
      'label' => 'parent_request_id_friendlyname (Friendly Name)',
    ),
)
```

Actually the data are truncated because of the `max_input_vars`value set too low.


# Technical details

The XHR query is sent by the tablesorter.pager JQuery widget, in its getData method.
The data are originally generated in \DataTable::GetHTMLTable ($sJSColumns variable)

In ajax.render.php we were failing when doing the foreach loop on the $aColumns[$sAlias] variable : at first we are checking $aData['checked'], and this was failing cause this key wasn't present for the last column of the array.


# What this PR adds 

In ajax.render, we are testing if $aData['checked'] exists if not : 

* log a warning
* set value to false (so column won't be displayed)

Here is a sample log : 

```
2021-05-11 14:42:53 | Warning | ajax.render.php received an invalid array for columns : check max_input_vars value in php.ini ! | IssueLog
array (
  'operation' => 'pagination',
  'max_input_vars' => '220',
  'class.attcode with invalid format' => 'UserRequest.pending_reason',
)
```

In an ideal world we would have simply throw an exception, but this ajax call is unable to handle this : no specific processing is done, simple the datatable is refreshed... with an empty content !

Implementing a generic solution seems quite hard. We have the [php://input](https://www.php.net/manual/en/wrappers.php.php) file but we can't use it for multipart/form-data :(
On Stack Overflow we found [a solution](https://stackoverflow.com/a/12169913) using `count($_POST, COUNT_RECURSIVE)` : this needs further testing and will be subject of another PR !