### PR TITLE
N°3996 Add max_input_vars check in setup

### DIFF
--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -332,6 +332,17 @@ class SetupUtils
 			$aResult[] = new CheckResult(CheckResult::INFO,  "Loaded php.ini files: $sPhpIniFile");
 		}
 
+		$iMaxInputVarsCurrent = ini_get('max_input_vars');
+		$iMaxInputVarsRecommended = 5000;
+		if (!is_numeric($iMaxInputVarsCurrent)) {
+			$iMaxInputVarsCurrent = 0;
+		}
+		if ($iMaxInputVarsCurrent < $iMaxInputVarsRecommended) {
+			$aResult[] = new CheckResult(CheckResult::WARNING,  "max_input_vars is set to $iMaxInputVarsCurrent : this is below recommended value of $iMaxInputVarsRecommended");
+		} else {
+			$aResult[] = new CheckResult(CheckResult::INFO,  "max_input_vars is set to $iMaxInputVarsCurrent (recommended value is $iMaxInputVarsRecommended)");
+		}
+
 		// Check the configuration of the sessions persistence, since this is critical for the authentication
 		if (ini_get('session.save_handler') == 'files')
 		{


### PR DESCRIPTION
Check that max_input_vars is aligned with recommendation

If not, returns a warning : 

![image](https://user-images.githubusercontent.com/8947448/117432402-9e0be900-af2a-11eb-90aa-dcfcd2f3e173.png)

If equal or above recommended value then adds an info : 

![image](https://user-images.githubusercontent.com/8947448/117432525-c398f280-af2a-11eb-856b-c6be93ffc0f6.png)
