### PR TITLE
Protect \iApplicationUIExtension::EnumAllowedActions uses

### DIFF
--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -1992,7 +1992,7 @@ class MenuBlock extends DisplayBlock
 
 						$this->AddMenuSeparator($aRegularActions);
 
-						$this->GetEnumAllowedActions($oSet, function ($sLabel, $data) use ($aRegularActions, $aActionParams) {
+						$this->GetEnumAllowedActions($oSet, function ($sLabel, $data) use (&$aRegularActions, $aActionParams) {
 							$aRegularActions[$sLabel] = array('label' => $sLabel, 'url' => $data) + $aActionParams;
 						});
 					}
@@ -2096,7 +2096,7 @@ class MenuBlock extends DisplayBlock
 
 			$this->AddMenuSeparator($aRegularActions);
 
-			$this->GetEnumAllowedActions($oSet, function ($sLabel, $data) use ($aRegularActions, $aActionParams) {
+			$this->GetEnumAllowedActions($oSet, function ($sLabel, $data) use (&$aRegularActions, $aActionParams) {
 				if (is_array($data)) {
 					// New plugins can provide javascript handlers via the 'onclick' property
 					//TODO: enable extension of different menus by checking the 'target' property ??

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -1995,7 +1995,15 @@ class MenuBlock extends DisplayBlock
 						/** @var \iApplicationUIExtension $oExtensionInstance */
 						foreach (MetaModel::EnumPlugins('iApplicationUIExtension') as $oExtensionInstance) {
 							$oSet->Rewind();
-							foreach ($oExtensionInstance->EnumAllowedActions($oSet) as $sLabel => $sUrl) {
+							$aExtEnumAllowedActions = $oExtensionInstance->EnumAllowedActions($oSet);
+							if (!is_array($aExtEnumAllowedActions)) {
+								$sExtensionClass = get_class($oExtensionInstance);
+								IssueLog::Warning(
+									"Extension '{$sExtensionClass}' returned non array value for EnumAllowedActions() method impl"
+								);
+								continue;
+							}
+							foreach ($aExtEnumAllowedActions as $sLabel => $sUrl) {
 								$aRegularActions[$sLabel] = array('label' => $sLabel, 'url' => $sUrl) + $aActionParams;
 							}
 						}
@@ -2103,7 +2111,15 @@ class MenuBlock extends DisplayBlock
 			/** @var \iApplicationUIExtension $oExtensionInstance */
 			foreach (MetaModel::EnumPlugins('iApplicationUIExtension') as $oExtensionInstance) {
 				$oSet->Rewind();
-				foreach ($oExtensionInstance->EnumAllowedActions($oSet) as $sLabel => $data) {
+				$aExtEnumAllowedActions = $oExtensionInstance->EnumAllowedActions($oSet);
+				if (!is_array($aExtEnumAllowedActions)) {
+					$sExtensionClass = get_class($oExtensionInstance);
+					IssueLog::Warning(
+						"Extension '{$sExtensionClass}' returned non array value for EnumAllowedActions() method impl"
+					);
+					continue;
+				}
+				foreach ($aExtEnumAllowedActions as $sLabel => $data) {
 					if (is_array($data)) {
 						// New plugins can provide javascript handlers via the 'onclick' property
 						//TODO: enable extension of different menus by checking the 'target' property ??


### PR DESCRIPTION
Some impl just return null while we expect to have an array... This is causing PHP notices in lots of iTop instances with modules implementing this method incorrectly !

This modification get rid of the notice and add a log (warning level) indicating the impl class.

Sample XML to reproduce this error :

```xml
<?xml version="1.0" encoding="UTF-8"?>
<itop_design xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.7">
  <snippets>
    <snippet id="invalid_EnumAllowedActions_1" _delta="define">
      <placement>core</placement>
      <rank>0</rank>
      <content><![CDATA[
class InvalidEnumAllowedActions1 extends AbstractApplicationUIExtension {
    public function EnumAllowedActions(DBObjectSet $oSet){
     return null;
    }
}
      ]]></content>
    </snippet>
    <snippet id="invalid_EnumAllowedActions_2" _delta="define">
      <placement>core</placement>
      <rank>0</rank>
      <content><![CDATA[
class InvalidEnumAllowedActions2 extends AbstractApplicationUIExtension {
    public function EnumAllowedActions(DBObjectSet $oSet){
     return null;
    }
}
      ]]></content>
    </snippet>
    <snippet id="correct_EnumAllowedActions" _delta="define">
      <placement>core</placement>
      <rank>0</rank>
      <content><![CDATA[
class CorrectEnumAllowedActions extends AbstractApplicationUIExtension {
    public function EnumAllowedActions(DBObjectSet $oSet){
     return ['🏢 Combodo website' => 'https://www.combodo.com'];
    }
}
      ]]></content>
    </snippet>
  </snippets>
</itop_design>
```

This would generate 2 PHP notice in object list, and 4 in object details.

After the modification, no more PHP notice and we get those logs (plus an exception) : 
```
2021-05-19 12:17:21 | Warning | Some extensions returned non array value for EnumAllowedActions() method impl | IssueLog
array (
  'extensions' => 
  array (
    0 => 'InvalidEnumAllowedActions1',
    1 => 'InvalidEnumAllowedActions2',
  ),
)
2021-05-19 12:17:21 | Error   | Exception during GetDisplay: Some extensions returned non array value for EnumAllowedActions() method impl: 0 = InvalidEnumAllowedActions1, 1 = InvalidEnumAllowedActions2 | IssueLog
```
On a non dev env, we would get only the first log, and no exception.