### PR TITLE
N°4518 Add config parameter to set platform as dev env

### DIFF
--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -2816,15 +2816,15 @@ HTML;
 	 * @return bool
 	 *
 	 * @since 2.6.0 method creation
-	 * @since 3.0.0 add the `is_dev_env` config parameter
+	 * @since 3.0.0 add the `developer_mode.enabled` config parameter
 	 *
-	 * @use `is_dev_env` config parameter
+	 * @use `developer_mode.enabled` config parameter
 	 * @use ITOP_REVISION
 	 */
 	public static function IsDevelopmentEnvironment()
 	{
 		$oConfig = utils::GetConfig();
-		$bIsDevEnvInConfig = $oConfig->Get('is_dev_env');
+		$bIsDevEnvInConfig = $oConfig->Get('developer_mode.enabled');
 		if ($bIsDevEnvInConfig === true) {
 			return true;
 		}

--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -2814,6 +2814,12 @@ HTML;
 	 * Check if iTop is in a development environment (VCS vs build number)
 	 *
 	 * @return bool
+	 *
+	 * @since 2.6.0 method creation
+	 * @since 3.0.0 add the `is_dev_env` config parameter
+	 *
+	 * @use `is_dev_env` config parameter
+	 * @use ITOP_REVISION
 	 */
 	public static function IsDevelopmentEnvironment()
 	{

--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -2817,12 +2817,18 @@ HTML;
 	 */
 	public static function IsDevelopmentEnvironment()
 	{
-		if (! defined('ITOP_REVISION')) {
+		$oConfig = utils::GetConfig();
+		$bIsDevEnvInConfig = $oConfig->Get('is_dev_env');
+		if ($bIsDevEnvInConfig === true) {
+			return true;
+		}
+
+		if (!defined('ITOP_REVISION')) {
 			//defensive behaviour: by default we are not in dev environment
 			//can happen even in production (unattended install for example) or with exotic use of iTop
 			return false;
 		}
-		
+
 		return ITOP_REVISION === 'svn';
 	}
 

--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -2822,6 +2822,9 @@ HTML;
 		if ($bIsDevEnvInConfig === true) {
 			return true;
 		}
+		if ($bIsDevEnvInConfig === false) {
+			return false;
+		}
 
 		if (!defined('ITOP_REVISION')) {
 			//defensive behaviour: by default we are not in dev environment

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1415,7 +1415,7 @@ class Config
 			'source_of_value' => '',
 			'show_in_conf_sample' => true,
 		],
-		'is_dev_env' => [
+		'developer_mode.enabled' => [
 			'type' => 'bool',
 			'description' => 'If true then uncloks dev env functionnalities, see \utils::IsDevelopmentEnvironment',
 			'default' => null,

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1415,6 +1415,14 @@ class Config
 			'source_of_value' => '',
 			'show_in_conf_sample' => true,
 		],
+		'is_dev_env' => [
+			'type' => 'bool',
+			'description' => 'If true then uncloks dev env functionnalities, see \utils::IsDevelopmentEnvironment',
+			'default' => false,
+			'value' => false,
+			'source_of_value' => '',
+			'show_in_conf_sample' => false,
+		],
 		'theme.enable_precompilation' => [
 			'type' => 'bool',
 			'description' => 'If false, theme compilation will not use any precompiled file setup optimization.)',

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1416,11 +1416,11 @@ class Config
 			'show_in_conf_sample' => true,
 		],
 		'developer_mode.enabled' => [
-			'type' => 'bool',
-			'description' => 'If true then uncloks dev env functionnalities, see \utils::IsDevelopmentEnvironment',
-			'default' => null,
-			'value' => null,
-			'source_of_value' => '',
+			'type'                => 'bool',
+			'description'         => 'If true then unlocks dev env functionalities, see \utils::IsDevelopmentEnvironment',
+			'default'             => null,
+			'value'               => null,
+			'source_of_value'     => '',
 			'show_in_conf_sample' => false,
 		],
 		'theme.enable_precompilation' => [

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1418,8 +1418,8 @@ class Config
 		'is_dev_env' => [
 			'type' => 'bool',
 			'description' => 'If true then uncloks dev env functionnalities, see \utils::IsDevelopmentEnvironment',
-			'default' => false,
-			'value' => false,
+			'default' => null,
+			'value' => null,
 			'source_of_value' => '',
 			'show_in_conf_sample' => false,
 		],


### PR DESCRIPTION
Since 2.6.0 we have the `\utils::IsDevelopmentEnvironment` that is used by lots of behaviors.

This method is based on the `ITOP_REVISION` constant value, so that we can suppose we're using a repo clone directly or a package.

But now we want to extend its use to other use cases : for example, shared dev platform based on a package...
This would benefits especially on Twig cache, symlinks in setup, DeprecatedCallsLog, ...

That's the goal of this new `developer_mode.enabled` config parameter. If set to true, it will unlocks dev env functionalities. False will disabled those functionalities.
Default value is null : that will keep existing behavior.