### PR TITLE
N°3863 - exec.php : allow subdirectories in the page parameter

### DIFF
--- a/pages/exec.php
+++ b/pages/exec.php
@@ -72,9 +72,11 @@ $sEnvFullPath = APPROOT.'env-'.$sEnvironment;
 $sPageRelativePath = $sModule.'/'.$sPage;
 $sPageEnvFullPath = $sEnvFullPath.'/'.$sPageRelativePath;
 if (is_link($sPageEnvFullPath)) {
+	$oConfig = utils::GetConfig();
+	$sSourceDir = $oConfig->Get('source_dir'); // generated at compile time, works for legacy build with datamodels/1.x
 	// in case module was compiled to symlink, we need to check against real linked path as symlink is resolved
 	$aPossibleBasePaths = [
-		APPROOT.'datamodels/2.x', // warning, won't work for datamodels/1.x for example !
+		APPROOT.$sSourceDir,
 		APPROOT.'extensions',
 		APPROOT.'data/'.$sEnvironment.'-modules',
 		APPROOT.'data/downloaded-extensions', // Hub connector


### PR DESCRIPTION
For now, exec.php can only call pages at the root level of modules. This is caused by basename() calls on both page and module parameters.

This PR brings the possibility to call pages in the whole module hierarchy, still using `\utils::RealPath` to ensure we're not trying to access something outside of the module.