### PR TITLE
N°3200 Add "filter list" menu item for any datatable widget

### DIFF
--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -2216,11 +2216,25 @@ class MenuBlock extends DisplayBlock
 				$oActionsToolbar->AddSubBlock($oActionButton);
 			}
 
-			// - Search
 			if ($this->m_sStyle == 'details') {
+				// - Search
 				$oActionButton = ButtonUIBlockFactory::MakeIconLink('fas fa-search', Dict::Format('UI:SearchFor_Class', MetaModel::GetName($sClass)), "{$sRootUrl}pages/UI.php?operation=search_form&do_search=0&class=$sClass{$sContext}", '', 'UI:SearchFor_Class');
 				$oActionButton->AddCSSClasses(['ibo-action-button', 'ibo-regular-action-button']);
 				$oActionsToolbar->AddSubBlock($oActionButton);
+			} else {
+				// - Filter list
+				$sSearchUrl = utils::GetDataTableSearchUrl($this->m_oFilter);
+				if (!empty($sSearchUrl)) {
+					$oActionButton = ButtonUIBlockFactory::MakeIconLink(
+						'fas fa-filter',
+						Dict::S('UI:Menu:FilterList'),
+						$sSearchUrl,
+						'',
+						'UI:Menu:FilterList'
+					);
+					$oActionButton->AddCSSClasses(['ibo-action-button', 'ibo-regular-action-button']);
+					$oActionsToolbar->AddSubBlock($oActionButton);
+				}
 			}
 
 			// - Others

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -2223,7 +2223,7 @@ class MenuBlock extends DisplayBlock
 				$oActionsToolbar->AddSubBlock($oActionButton);
 			} else {
 				// - Filter list
-				$sSearchUrl = utils::GetDataTableSearchUrl($this->m_oFilter);
+				$sSearchUrl = utils::GetDataTableSearchUrl($this->m_oFilter, $aExtraParams);
 				if (!empty($sSearchUrl)) {
 					$oActionButton = ButtonUIBlockFactory::MakeIconLink(
 						'fas fa-filter',

--- a/application/menunode.class.inc.php
+++ b/application/menunode.class.inc.php
@@ -1111,6 +1111,7 @@ class OQLMenuNode extends MenuNode
 	 */
 	public function RenderContent(WebPage $oPage, $aExtraParams = array())
 	{
+		ContextTag::AddContext(ContextTag::TAG_OBJECT_SEARCH);
 		ApplicationMenu::CheckMenuIdEnabled($this->GetMenuId());
 		OQLMenuNode::RenderOQLSearch
 		(

--- a/core/contexttag.class.inc.php
+++ b/core/contexttag.class.inc.php
@@ -52,17 +52,19 @@
  */
 class ContextTag
 {
-	const TAG_PORTAL = 'GUI:Portal';
-	const TAG_CRON = 'CRON';
-	const TAG_CONSOLE = 'GUI:Console';
-	const TAG_SETUP = 'Setup';
-	const TAG_SYNCHRO = 'Synchro';
-	const TAG_REST = 'REST/JSON';
+	public const TAG_PORTAL = 'GUI:Portal';
+	public const TAG_CRON = 'CRON';
+	public const TAG_CONSOLE = 'GUI:Console';
+	public const TAG_SETUP = 'Setup';
+	public const TAG_SYNCHRO = 'Synchro';
+	public const TAG_REST = 'REST/JSON';
+	public const TAG_SEARCH = 'Search';
 
 	protected static $aStack = array();
 
 	/**
 	 * Store a context tag on the stack
+	 *
 	 * @param string $sTag
 	 */
 	public function __construct($sTag)

--- a/core/contexttag.class.inc.php
+++ b/core/contexttag.class.inc.php
@@ -52,13 +52,17 @@
  */
 class ContextTag
 {
-	public const TAG_PORTAL = 'GUI:Portal';
-	public const TAG_CRON = 'CRON';
+	public const TAG_PORTAL  = 'GUI:Portal';
+	public const TAG_CRON    = 'CRON';
 	public const TAG_CONSOLE = 'GUI:Console';
-	public const TAG_SETUP = 'Setup';
+	public const TAG_SETUP   = 'Setup';
 	public const TAG_SYNCHRO = 'Synchro';
-	public const TAG_REST = 'REST/JSON';
-	public const TAG_SEARCH = 'Search';
+	public const TAG_REST    = 'REST/JSON';
+	/**
+	 * @var string
+	 * @since 3.1.0 N°3200
+	 */
+	public const TAG_OBJECT_SEARCH = 'ObjectSearch';
 
 	protected static $aStack = array();
 

--- a/core/metamodel.class.php
+++ b/core/metamodel.class.php
@@ -2072,6 +2072,9 @@ abstract class MetaModel
 	 *
 	 * @return string[] attcodes to display, containing aliases
 	 * @throws \CoreException
+	 *
+	 * @since 3.0.0 N°2334 added code for n-n relations in {@see BlockIndirectLinksViewTable::GetAttCodesToDisplay}
+	 * @since 3.1.0 N°3200 method creation so that it can be used elsewhere
 	 */
 	public static function GetAttributeLinkedSetIndirectDatatableAttCodesToDisplay(string $sObjectClass, string $sObjectLinkedSetIndirectAttCode, string $sRemoteClass, string $sLnkExternalKeyToRemoteClassAttCode):array
 	{
@@ -2079,17 +2082,17 @@ abstract class MetaModel
 		$aRemoteAttDefsToDisplay = MetaModel::GetZListAttDefsFilteredForIndirectRemoteClass($sRemoteClass);
 		$aLnkAttCodesToDisplay = array_map(
 			function ($oLnkAttDef) {
-				return \ormLinkSet::LINK_ALIAS.'.'.$oLnkAttDef->GetCode();
+				return ormLinkSet::LINK_ALIAS.'.'.$oLnkAttDef->GetCode();
 			},
 			$aLnkAttDefsToDisplay
 		);
-		if (!in_array(\ormLinkSet::LINK_ALIAS.'.'.$sLnkExternalKeyToRemoteClassAttCode, $aLnkAttCodesToDisplay)) {
+		if (!in_array(ormLinkSet::LINK_ALIAS.'.'.$sLnkExternalKeyToRemoteClassAttCode, $aLnkAttCodesToDisplay)) {
 			// we need to display a link to the remote class instance !
-			$aLnkAttCodesToDisplay[] = \ormLinkSet::LINK_ALIAS.'.'.$sLnkExternalKeyToRemoteClassAttCode;
+			$aLnkAttCodesToDisplay[] = ormLinkSet::LINK_ALIAS.'.'.$sLnkExternalKeyToRemoteClassAttCode;
 		}
 		$aRemoteAttCodesToDisplay = array_map(
 			function ($oRemoteAttDef) {
-				return \ormLinkSet::REMOTE_ALIAS.'.'.$oRemoteAttDef->GetCode();
+				return ormLinkSet::REMOTE_ALIAS.'.'.$oRemoteAttDef->GetCode();
 			},
 			$aRemoteAttDefsToDisplay
 		);

--- a/core/metamodel.class.php
+++ b/core/metamodel.class.php
@@ -2065,6 +2065,40 @@ abstract class MetaModel
 	}
 
 	/**
+	 * @param string $sObjectClass class of the object containing the AttributeLinkedSetIndirect (eg: Team)
+	 * @param string $sObjectLinkedSetIndirectAttCode code of the AttributeLinkedSetIndirect in the sObjectClass (eg: persons_list in the Team class, pointing to lnkPersonToTeam lnk class)
+	 * @param string $sRemoteClass remote class pointed by the lnk class (eg: Person pointed by lnkPersonToTeam)
+	 * @param string $sLnkExternalKeyToRemoteClassAttCode in the lnk class, external key to the remote class (eg: person_id in lnkPersonToTeam, pointing to a Person instance)
+	 *
+	 * @return string[] attcodes to display, containing aliases
+	 * @throws \CoreException
+	 */
+	public static function GetAttributeLinkedSetIndirectDatatableAttCodesToDisplay(string $sObjectClass, string $sObjectLinkedSetIndirectAttCode, string $sRemoteClass, string $sLnkExternalKeyToRemoteClassAttCode):array
+	{
+		$aLnkAttDefsToDisplay = MetaModel::GetZListAttDefsFilteredForIndirectLinkClass($sObjectClass, $sObjectLinkedSetIndirectAttCode);
+		$aRemoteAttDefsToDisplay = MetaModel::GetZListAttDefsFilteredForIndirectRemoteClass($sRemoteClass);
+		$aLnkAttCodesToDisplay = array_map(
+			function ($oLnkAttDef) {
+				return \ormLinkSet::LINK_ALIAS.'.'.$oLnkAttDef->GetCode();
+			},
+			$aLnkAttDefsToDisplay
+		);
+		if (!in_array(\ormLinkSet::LINK_ALIAS.'.'.$sLnkExternalKeyToRemoteClassAttCode, $aLnkAttCodesToDisplay)) {
+			// we need to display a link to the remote class instance !
+			$aLnkAttCodesToDisplay[] = \ormLinkSet::LINK_ALIAS.'.'.$sLnkExternalKeyToRemoteClassAttCode;
+		}
+		$aRemoteAttCodesToDisplay = array_map(
+			function ($oRemoteAttDef) {
+				return \ormLinkSet::REMOTE_ALIAS.'.'.$oRemoteAttDef->GetCode();
+			},
+			$aRemoteAttDefsToDisplay
+		);
+		$aAttCodesToDisplay = array_merge($aLnkAttCodesToDisplay, $aRemoteAttCodesToDisplay);
+
+		return $aAttCodesToDisplay;
+	}
+
+	/**
 	 * @param string $sClass
 	 * @param string $sListCode
 	 * @param string $sAttCodeOrFltCode

--- a/dictionaries/en.dictionary.itop.ui.php
+++ b/dictionaries/en.dictionary.itop.ui.php
@@ -1422,6 +1422,7 @@ When associated with a trigger, each action is given an "order" number, specifyi
 	'Calendar-FirstDayOfWeek' => 0,// 0 = Sunday, 1 = Monday, etc...
 
 	'UI:Menu:ShortcutList' => 'Create a Shortcut...',
+	'UI:Menu:FilterList' => 'Filter list...',
 	'UI:ShortcutRenameDlg:Title' => 'Rename the shortcut',
 	'UI:ShortcutListDlg:Title' => 'Create a shortcut for the list',
 	'UI:ShortcutDelete:Confirm' => 'Please confirm that wou wish to delete the shortcut(s).',

--- a/dictionaries/fr.dictionary.itop.ui.php
+++ b/dictionaries/fr.dictionary.itop.ui.php
@@ -1402,6 +1402,7 @@ Lors de l\'association à un déclencheur, on attribue à chaque action un numé
 	'Calendar-FirstDayOfWeek' => '1',// 0 = Sunday, 1 = Monday, etc...
 
 	'UI:Menu:ShortcutList' => 'Créer un Raccourci...',
+	'UI:Menu:FilterList' => 'Filtrer la liste...',
 	'UI:ShortcutRenameDlg:Title' => 'Renommer le raccourci',
 	'UI:ShortcutListDlg:Title' => 'Créer un raccourci pour la liste',
 	'UI:ShortcutDelete:Confirm' => 'Veuillez confirmer la suppression du ou des raccourci(s)',

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -519,6 +519,7 @@ try
 			///////////////////////////////////////////////////////////////////////////////////////////
 
 			case 'search': // Serialized DBSearch
+				$oSearchContext = new ContextTag(ContextTag::TAG_SEARCH);
 				$sFilter = utils::ReadParam('filter', '', false, 'raw_data');
 				$sFormat = utils::ReadParam('format', '');
 				$bSearchForm = utils::ReadParam('search_form', true);

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -143,12 +143,15 @@ function SetObjectBreadCrumbEntry(DBObject $oObj, WebPage $oPage)
  * @throws \CoreException
  * @throws \DictExceptionMissingString
  */
-function DisplaySearchSet($oP, $oFilter, $bSearchForm = true, $sBaseClass = '', $sFormat = '', $bDoSearch = true, $bSearchFormOpen = true)
+function DisplaySearchSet($oP, $oFilter, $bSearchForm = true, $sBaseClass = '', $sFormat = '', $bDoSearch = true, $bSearchFormOpen = true, $aParams = [])
 {
 	//search block
 	$oBlockForm = null;
 	if ($bSearchForm) {
-		$aParams = array('open' => $bSearchFormOpen, 'table_id' => 'result_1');
+		$aParams['open'] = $bSearchFormOpen;
+		if (false === isset($aParams['table_id'])) {
+			$aParams['table_id'] = 'result_1';
+		}
 		if (!empty($sBaseClass)) {
 			$aParams['baseClass'] = $sBaseClass;
 		}
@@ -519,7 +522,7 @@ try
 			///////////////////////////////////////////////////////////////////////////////////////////
 
 			case 'search': // Serialized DBSearch
-				$oSearchContext = new ContextTag(ContextTag::TAG_SEARCH);
+				$oSearchContext = new ContextTag(ContextTag::TAG_OBJECT_SEARCH);
 				$sFilter = utils::ReadParam('filter', '', false, 'raw_data');
 				$sFormat = utils::ReadParam('format', '');
 				$bSearchForm = utils::ReadParam('search_form', true);
@@ -530,7 +533,13 @@ try
 				$oP->set_title(Dict::S('UI:SearchResultsPageTitle'));
 				$oFilter = DBSearch::unserialize($sFilter); // TO DO : check that the filter is valid
 				$oFilter->UpdateContextFromUser();
-				DisplaySearchSet($oP, $oFilter, $bSearchForm, '' /* sBaseClass */, $sFormat);
+
+				//FIXME Params won't work as expected :(
+				// During the ajax call fetching the datatable data, the URL is rewritten and the info are lost, and we are getting a worse result :(
+//				$sParams = utils::ReadParam('aParams', '{}', false, \utils::ENUM_SANITIZATION_FILTER_RAW_DATA);
+//				$aParams = json_decode($sParams, true);
+
+				DisplaySearchSet($oP, $oFilter, $bSearchForm, '' /* sBaseClass */, $sFormat, ''); //, true, $aParams
 			break;
 
 			///////////////////////////////////////////////////////////////////////////////////////////

--- a/pages/ajax.searchform.php
+++ b/pages/ajax.searchform.php
@@ -29,6 +29,7 @@ try
 		throw new AjaxSearchException("Invalid query (empty filter)", 400);
 	}
 
+	$oSearchContext = new ContextTag(ContextTag::TAG_SEARCH);
 	$oPage = new AjaxPage("");
 	$oPage->SetContentType('text/html');
 

--- a/pages/ajax.searchform.php
+++ b/pages/ajax.searchform.php
@@ -29,7 +29,7 @@ try
 		throw new AjaxSearchException("Invalid query (empty filter)", 400);
 	}
 
-	$oSearchContext = new ContextTag(ContextTag::TAG_SEARCH);
+	$oSearchContext = new ContextTag(ContextTag::TAG_OBJECT_SEARCH);
 	$oPage = new AjaxPage("");
 	$oPage->SetContentType('text/html');
 

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinksViewTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinksViewTable.php
@@ -76,35 +76,20 @@ class BlockIndirectLinksViewTable extends AbstractBlockLinksViewTable
 	}
 
 	/**
-	 * GetAttCodesToDisplay.
-	 *
 	 * @return string
 	 * @throws \CoreException
 	 */
 	private function GetAttCodesToDisplay(): string
 	{
-		$oLinkingAttDef = MetaModel::GetAttributeDef($this->oAttDef->GetLinkedClass(), $this->oAttDef->GetExtKeyToRemote());
-		$sLinkingAttCode = $oLinkingAttDef->GetCode();
-		$sTargetClass = $oLinkingAttDef->GetTargetClass();
+		/** @var \AttributeLinkedSetIndirect $oAttributeLinkedSetIndirectDefinition */
+		$oAttributeLinkedSetIndirectDefinition = MetaModel::GetAttributeDef($this->oAttDef->GetLinkedClass(), $this->oAttDef->GetExtKeyToRemote());
+		$sAttributeLinkedSetIndirectAttCode = $oAttributeLinkedSetIndirectDefinition->GetCode();
+		$sAttributeLinkedSetIndirectLinkedClass = $oAttributeLinkedSetIndirectDefinition->GetTargetClass();
 
-		$aLnkAttDefsToDisplay = MetaModel::GetZListAttDefsFilteredForIndirectLinkClass($this->sObjectClass, $this->sAttCode);
-		$aRemoteAttDefsToDisplay = MetaModel::GetZListAttDefsFilteredForIndirectRemoteClass($sTargetClass);
-		$aLnkAttCodesToDisplay = array_map(function ($oLnkAttDef) {
-			return \ormLinkSet::LINK_ALIAS.'.'.$oLnkAttDef->GetCode();
-		},
-			$aLnkAttDefsToDisplay
-		);
-		if (!in_array(\ormLinkSet::LINK_ALIAS.'.'.$sLinkingAttCode, $aLnkAttCodesToDisplay)) {
-			// we need to display a link to the remote class instance !
-			$aLnkAttCodesToDisplay[] = \ormLinkSet::LINK_ALIAS.'.'.$sLinkingAttCode;
-		}
-		$aRemoteAttCodesToDisplay = array_map(function ($oRemoteAttDef) {
-			return \ormLinkSet::REMOTE_ALIAS.'.'.$oRemoteAttDef->GetCode();
-		},
-			$aRemoteAttDefsToDisplay
-		);
-		$aAttCodesToDisplay = array_merge($aLnkAttCodesToDisplay, $aRemoteAttCodesToDisplay);
+		$aAttCodesToDisplay = MetaModel::GetAttributeLinkedSetIndirectDatatableAttCodesToDisplay($this->sObjectClass, $this->sAttCode, $sAttributeLinkedSetIndirectLinkedClass, $sAttributeLinkedSetIndirectAttCode);
+		/** @noinspection PhpUnnecessaryLocalVariableInspection *//** @noinspection OneTimeUseVariablesInspection */
+		$sAttCodesToDisplay = implode(',', $aAttCodesToDisplay);
 
-		return implode(',', $aAttCodesToDisplay);
+		return $sAttCodesToDisplay;
 	}
 }


### PR DESCRIPTION
There was already two existing actions : 
* Add To Dashboard
* Create a Shortcut

This adds a new icon "Filter list".
This options is present in any datatable, except when we are in a search (UI.php operation=search, OQLMenuNode). That means this icon will appear for example in : 
* list dashlet
* 1-n or n-n attributes
* run query

For object relations, the query is rewritten otherwise we won't be having the correct advanced search criteria. It will also ease the "configure this list" option.
Unfortunately, there are no mean for now to pass fields list to UI.php, so we will display the default. Also we won't pass the table id so we won't get the datatable configuration set in the object.

Screenshot in the Team object's members tab :

![image](https://user-images.githubusercontent.com/8947448/208727866-63b68b27-ecac-4f18-995a-0f1fa4cefde2.png)


