### PR TITLE
N°5370 - Improve feedback when updating objects via REST without changes

### DIFF
--- a/core/restservices.class.inc.php
+++ b/core/restservices.class.inc.php
@@ -366,8 +366,13 @@ class CoreServices implements iRestServiceProvider
 			{
 				$oObject = RestUtils::FindObjectFromKey($sClass, $key);
 				RestUtils::UpdateObjectFromFields($oObject, $aFields);
-				$oObject->DBUpdate();
-				$oResult->AddObject(0, 'updated', $oObject, $aShowFields, $bExtendedOutput);
+				$sMessage = 'unchanged';
+				if($oObject->IsModified())
+				{
+					$oObject->DBUpdate();
+					$sMessage = 'updated';
+				}
+				$oResult->AddObject(0, $sMessage, $oObject, $aShowFields, $bExtendedOutput);
 			}
 			break;
 	


### PR DESCRIPTION
When updating an object via REST the feedback is always "updated", doesn't matter whether there is a real change.

It might be interesting to give a feedback via rest whether the object has been changed or not, just like it is in the UI.

This PR checks whether an object is modified and set message to "unchanged" if not.