### PR TITLE
Properly init objects array

### DIFF
--- a/core/restservices.class.inc.php
+++ b/core/restservices.class.inc.php
@@ -137,6 +137,12 @@ class RestResultWithObjects extends RestResult
 {
 	public $objects;
 
+	public function __construct()
+	{
+		parent::__construct();
+		$this->objects = array();
+	}
+
 	/**
 	 * Report the given object
 	 * 	 

--- a/core/restservices.class.inc.php
+++ b/core/restservices.class.inc.php
@@ -135,6 +135,7 @@ class ObjectResult
  */
 class RestResultWithObjects extends RestResult
 {
+	/** @var DBObject[] */
 	public $objects;
 
 	public function __construct()
@@ -191,6 +192,7 @@ class RestResultWithObjects extends RestResult
 
 class RestResultWithRelations extends RestResultWithObjects
 {
+	/** @var array */
 	public $relations;
 	
 	public function __construct()


### PR DESCRIPTION
This caused a warning in data-collector-base/toolkit/dump_tasks.php when there are no DataSources yet.