### PR TITLE
Portal ExceptionHandler : add concerned file and line in IssueLog

### DIFF
--- a/datamodels/2.x/itop-portal-base/portal/src/EventListener/ExceptionListener.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/EventListener/ExceptionListener.php
@@ -24,6 +24,7 @@ namespace Combodo\iTop\Portal\EventListener;
 
 use Dict;
 use IssueLog;
+use LogChannels;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -86,7 +87,10 @@ class ExceptionListener implements ContainerAwareInterface
 		}
 
 		// Log exception in iTop log
-		IssueLog::Error($sErrorTitle.': '.$sErrorMessage);
+		IssueLog::Error($sErrorTitle.': '.$sErrorMessage, LogChannels::PORTAL, [
+			'file' => $oException->getFile(),
+			'line' => $oException->getLine(),
+		]);
 
 		// Prepare data for template
 		$aData = array(


### PR DESCRIPTION
When an exception occurs, a message is sent to IssueLog but containing only the message and no other info.
This adds concerned file and line, which will help greatly for debug.
Also, adding the portal channel (introduced in 2.7.5)