### PR TITLE
Portal ExceptionHandler : add concerned file and line in IssueLog

### DIFF
--- a/datamodels/2.x/itop-portal-base/portal/src/EventListener/ExceptionListener.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/EventListener/ExceptionListener.php
@@ -24,6 +24,7 @@ namespace Combodo\iTop\Portal\EventListener;
 
 use Dict;
 use IssueLog;
+use LogChannels;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -86,7 +87,10 @@ class ExceptionListener implements ContainerAwareInterface
 		}
 
 		// Log exception in iTop log
-		IssueLog::Error($sErrorTitle.': '.$sErrorMessage);
+		IssueLog::Error($sErrorTitle.': '.$sErrorMessage, LogChannels::PORTAL, [
+			'file' => $oException->getFile(),
+			'line' => $oException->getLine(),
+		]);
 
 		// Prepare data for template
 		$aData = array(


### PR DESCRIPTION
When an exception occurs, a message is sent to IssueLog but containing only the message and no other info.
This adds concerned file and line, which will help greatly for debug.
Also, adding the portal channel (introduced in 2.7.5)

IssueLog before : 

```
2021-09-17 13:09:08 | Error   | Oups ! Une erreur est survenue.: Key "portals" for array with keys "properties, forms, bricks, bricks_total_width, lists" does not exist. | IssueLog
```

And after this PR : 

```
2021-09-17 13:47:48 | Error   | Oups ! Une erreur est survenue.: Key "portals" for array with keys "properties, forms, bricks, bricks_total_width, lists" does not exist. | portal
array (
  'filename' => '/path/to/faulty/template.html.twig',
  'line' => 222,
)
```

As we are using the standard Exception getters, and because IssueLog does simply a `var_export()` call on its aContext param, we should be protected if file and line are null.