### PR TITLE
N°4766 - DataSynchro: Allow binary data to be imported/synchronised with the synchro_import.php

### DIFF
--- a/synchro/synchro_import.php
+++ b/synchro/synchro_import.php
@@ -435,6 +435,7 @@ try
 
 	$aIsDateToTransform = array();
 	$aDateToTransformReport = array();
+	$aIsBinaryToTransform = array();
 	foreach ($aInputColumns as $iFieldId => $sInputColumn)
 	{
 		if (array_key_exists($sInputColumn, $aDateColumns))
@@ -456,6 +457,7 @@ try
 		{
 			throw new ExchangeException("Unknown column '$sInputColumn' (class: '$sClass')");
 		}
+		$aIsBinaryToTransform[$iFieldId] = $aColumns[$sInputColumn] === 'LONGBLOB';
 	}
 	if (!isset($iPrimaryKeyCol))
 	{
@@ -535,6 +537,10 @@ try
 							$aValues[] = $sDate;
 						}
 					}
+					elseif ($aIsBinaryToTransform[$iCol])
+					{
+						$aValues[] = base64_decode($value);
+					}
 					else
 					{
 						$aValues[] = $value;
@@ -599,6 +605,10 @@ try
 						{
 							$aValuePairs[] = "`$sCol` = ".CMDBSource::Quote($sDate);
 						}
+					}
+					elseif ($aIsBinaryToTransform[$iCol])
+					{
+						$aValuePairs[] = "`$sCol` = FROM_BASE64(".CMDBSource::Quote($aRow[$iCol], true).")";
 					}
 					else
 					{


### PR DESCRIPTION
Currently it is not possible to fill the binary (LONGBLOB) fields of the synchro_data tables by csv upload using synchro_import.php

When the provided data is base64 encoded, this becomes possible, but the tool needs to support it.

See the following example synchronising a Person object with picture using synchro_import.php:
![SynchroReplica example](https://user-images.githubusercontent.com/228588/133787885-ccd3c115-b98b-4d09-91b6-7954d150f55d.png)
