### PR TITLE
N°4325 CMDBSource wrap both mysqli attributes

### DIFF
--- a/core/DbConnectionWrapper.php
+++ b/core/DbConnectionWrapper.php
@@ -17,8 +17,10 @@ use mysqli;
  *
  * @used-by \CMDBSource
  *
- * @since 2.7.5 N°3513 new mockable {@see mysqli} object in {@see CMDBSource} //FIXME
- * @since 3.0.0 N°4325 add this object to avoid confusions and document the wanted behavior
+ * @since 3.0.0 N°4325 Object creation
+ *          This wrapper handles the 2 {@mysqli myqsli} attributes that were previously in {@see CMDBSource}
+ *          To allow testing we added a second mysqli object (N°3513 in 2.7.5) and code became a bit confusing :/
+ *          With this wrapper everything is in the same place, and we can express the intention more clearly !
  */
 class DbConnectionWrapper
 {

--- a/core/DbConnectionWrapper.php
+++ b/core/DbConnectionWrapper.php
@@ -26,27 +26,40 @@ class DbConnectionWrapper
 	protected static $oDbCnxStandard;
 
 	/**
+	 * Can contain a genuine mysqli object, or a mock that would emulate {@see mysqli::query()}
+	 *
 	 * @var mysqli
 	 * @used-by \Combodo\iTop\Test\UnitTest\Core\TransactionsTest
 	 */
-	protected static $oDbCnxMockable;
+	protected static $oDbCnxMockableForQuery;
 
-	public static function GetDbConnection(bool $bIsMockable = false): ?mysqli
+	/**
+	 * @param bool $bIsForQuery set to true if using {@see mysqli::query()}
+	 *
+	 * @return \mysqli|null
+	 */
+	public static function GetDbConnection(bool $bIsForQuery = false): ?mysqli
 	{
-		if ($bIsMockable) {
-			return self::$oDbCnxMockable;
+		if ($bIsForQuery) {
+			return static::$oDbCnxMockableForQuery;
 		}
 
-		return self::$oDbCnxStandard;
+		return static::$oDbCnxStandard;
 	}
 
-	public static function SetDbConnection(mysqli $oMysqli, bool $bIsMockable = false): void
+	public static function SetDbConnections(mysqli $oMysqli): void
 	{
-		self::$oDbCnxMockable = $oMysqli;
-		if ($bIsMockable) {
-			return;
-		}
+		static::$oDbCnxStandard = $oMysqli;
+		static::SetDbConnectionMockForQuery($oMysqli);
+	}
 
-		self::$oDbCnxStandard = $oMysqli;
+	/**
+	 * Use this to register a mock that will handle {@see mysqli::query()}
+	 *
+	 * @param \mysqli $oMysqli
+	 */
+	public static function SetDbConnectionMockForQuery(mysqli $oMysqli): void
+	{
+		static::$oDbCnxMockableForQuery = $oMysqli;
 	}
 }

--- a/core/DbConnectionWrapper.php
+++ b/core/DbConnectionWrapper.php
@@ -47,7 +47,7 @@ class DbConnectionWrapper
 		return static::$oDbCnxStandard;
 	}
 
-	public static function SetDbConnections(mysqli $oMysqli): void
+	public static function SetDbConnection(mysqli $oMysqli): void
 	{
 		static::$oDbCnxStandard = $oMysqli;
 		static::SetDbConnectionMockForQuery($oMysqli);

--- a/core/DbConnectionWrapper.php
+++ b/core/DbConnectionWrapper.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * @copyright   Copyright (C) 2010-2021 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\Core;
+
+use mysqli;
+
+/**
+ * mysqli object is really hard to mock as it contains lots of attributes & methods ! Thought we need to mock it to test transactions !
+ *
+ * To solve this, a new attribute exists and is only used in specific use cases, so there are just few things to mock.
+ *
+ * This object adds more readability than previous model with 2 attributes in {@see CMDBSource}.
+ *
+ * @used-by \CMDBSource
+ *
+ * @since 2.7.5 N°3513 new mockable {@see mysqli} object in {@see CMDBSource}
+ * @since 3.0.0 N°4325 add this object to avoid confusions and document the wanted behavior
+ */
+class DbConnectionWrapper
+{
+	/** @var mysqli */
+	protected static $oDbCnxStandard;
+
+	/**
+	 * @var mysqli
+	 * @used-by \Combodo\iTop\Test\UnitTest\Core\TransactionsTest
+	 */
+	protected static $oDbCnxMockable;
+
+	public static function GetDbConnection(bool $bIsMockable = false): ?mysqli
+	{
+		if ($bIsMockable) {
+			return self::$oDbCnxMockable;
+		}
+
+		return self::$oDbCnxStandard;
+	}
+
+	public static function SetDbConnection(mysqli $oMysqli, bool $bIsMockable = false): void
+	{
+		self::$oDbCnxMockable = $oMysqli;
+		if ($bIsMockable) {
+			return;
+		}
+
+		self::$oDbCnxStandard = $oMysqli;
+	}
+}

--- a/core/DbConnectionWrapper.php
+++ b/core/DbConnectionWrapper.php
@@ -17,7 +17,7 @@ use mysqli;
  *
  * @used-by \CMDBSource
  *
- * @since 2.7.5 N°3513 new mockable {@see mysqli} object in {@see CMDBSource}
+ * @since 2.7.5 N°3513 new mockable {@see mysqli} object in {@see CMDBSource} //FIXME
  * @since 3.0.0 N°4325 add this object to avoid confusions and document the wanted behavior
  */
 class DbConnectionWrapper

--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -343,7 +343,7 @@ class CMDBSource
 			// In case we don't have rights to enumerate the databases
 			// Let's try to connect directly
 			/** @noinspection NullPointerExceptionInspection this shouldn't be called with un-init DB */
-			return @((bool)DbConnectionWrapper::GetDbConnection()->query("USE `$sSource`"));
+			return @((bool)DbConnectionWrapper::GetDbConnection(true)->query("USE `$sSource`"));
 		}
 
 	}
@@ -391,7 +391,7 @@ class CMDBSource
 	public static function SelectDB($sSource)
 	{
 		/** @noinspection NullPointerExceptionInspection this shouldn't be called with un-init DB */
-		if (!((bool)DbConnectionWrapper::GetDbConnection()->query("USE `$sSource`"))) {
+		if (!((bool)DbConnectionWrapper::GetDbConnection(true)->query("USE `$sSource`"))) {
 			throw new MySQLException('Could not select DB', array('db_name' => $sSource));
 		}
 		self::$m_sDBName = $sSource;
@@ -630,7 +630,7 @@ class CMDBSource
 		// Get error info
 		$sUser = UserRights::GetUser();
 		/** @noinspection NullPointerExceptionInspection this shouldn't be called with un-init DB */
-		$oError = DbConnectionWrapper::GetDbConnection($bForQuery)->query('SHOW ENGINE INNODB STATUS');
+		$oError = DbConnectionWrapper::GetDbConnection(true)->query('SHOW ENGINE INNODB STATUS');
 		if ($oError !== false) {
 			$aData = $oError->fetch_all(MYSQLI_ASSOC);
 			$sInnodbStatus = $aData[0];

--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -614,15 +614,15 @@ class CMDBSource
 
 	/**
 	 * @param \Exception $e
-	 * @param bool $bIsCnxMockable
+	 * @param bool $bForQuery to get the proper DB connection
 	 *
 	 * @since 2.7.1
 	 * @since 3.0.0 N°4325 add new optional parameter to use the correct DB connection
 	 */
-	private static function LogDeadLock(Exception $e, $bIsCnxMockable = false)
+	private static function LogDeadLock(Exception $e, $bForQuery = false)
 	{
 		// checks MySQL error code
-		$iMySqlErrorNo = DbConnectionWrapper::GetDbConnection($bIsCnxMockable)->errno;
+		$iMySqlErrorNo = DbConnectionWrapper::GetDbConnection($bForQuery)->errno;
 		if (!in_array($iMySqlErrorNo, array(self::MYSQL_ERRNO_WAIT_TIMEOUT, self::MYSQL_ERRNO_DEADLOCK))) {
 			return;
 		}
@@ -630,7 +630,7 @@ class CMDBSource
 		// Get error info
 		$sUser = UserRights::GetUser();
 		/** @noinspection NullPointerExceptionInspection this shouldn't be called with un-init DB */
-		$oError = DbConnectionWrapper::GetDbConnection($bIsCnxMockable)->query('SHOW ENGINE INNODB STATUS');
+		$oError = DbConnectionWrapper::GetDbConnection($bForQuery)->query('SHOW ENGINE INNODB STATUS');
 		if ($oError !== false) {
 			$aData = $oError->fetch_all(MYSQLI_ASSOC);
 			$sInnodbStatus = $aData[0];
@@ -940,7 +940,7 @@ class CMDBSource
 		try
 		{
 			/** @noinspection NullPointerExceptionInspection this shouldn't be called with un-init DB */
-			$oResult = DbConnectionWrapper::GetDbConnection()->query($sSql);
+			$oResult = DbConnectionWrapper::GetDbConnection(true)->query($sSql);
 		}
 		catch(mysqli_sql_exception $e)
 		{

--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -133,7 +133,7 @@ class CMDBSource
 		self::$m_sDBTlsCA = empty($sTlsCA) ? null : $sTlsCA;
 
 		$oMysqli = self::GetMysqliInstance($sServer, $sUser, $sPwd, $sSource, $bTlsEnabled, $sTlsCA, true);
-		DbConnectionWrapper::SetDbConnection($oMysqli);
+		DbConnectionWrapper::SetDbConnections($oMysqli);
 	}
 
 	/**
@@ -447,19 +447,6 @@ class CMDBSource
 	public static function GetMysqli()
 	{
 		return DbConnectionWrapper::GetDbConnection(false);
-	}
-
-	/**
-	 * @param mysqli $oMysqli
-	 *
-	 * @used-by \Combodo\iTop\Test\UnitTest\Core\TransactionsTest
-	 * @noinspection PhpUnused
-	 * @noinspection PhpMissingParamTypeInspection
-	 * @noinspection ReturnTypeCanBeDeclaredInspection
-	 */
-	protected static function SetMySQLiForQuery($oMysqli)
-	{
-		DbConnectionWrapper::SetDbConnection($oMysqli, true);
 	}
 
 	public static function GetErrNo()

--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -133,7 +133,7 @@ class CMDBSource
 		self::$m_sDBTlsCA = empty($sTlsCA) ? null : $sTlsCA;
 
 		$oMysqli = self::GetMysqliInstance($sServer, $sUser, $sPwd, $sSource, $bTlsEnabled, $sTlsCA, true);
-		DbConnectionWrapper::SetDbConnections($oMysqli);
+		DbConnectionWrapper::SetDbConnection($oMysqli);
 	}
 
 	/**

--- a/lib/composer/ClassLoader.php
+++ b/lib/composer/ClassLoader.php
@@ -420,7 +420,7 @@ class ClassLoader
      * Loads the given class or interface.
      *
      * @param  string    $class The name of the class
-     * @return true|null True if loaded, null otherwise
+     * @return bool|null True if loaded, null otherwise
      */
     public function loadClass($class)
     {
@@ -429,8 +429,6 @@ class ClassLoader
 
             return true;
         }
-
-        return null;
     }
 
     /**

--- a/lib/composer/autoload_classmap.php
+++ b/lib/composer/autoload_classmap.php
@@ -299,6 +299,7 @@ return array(
     'Combodo\\iTop\\Controller\\Base\\Layout\\ActivityPanelController' => $baseDir . '/sources/Controller/Base/Layout/ActivityPanelController.php',
     'Combodo\\iTop\\Controller\\PreferencesController' => $baseDir . '/sources/Controller/PreferencesController.php',
     'Combodo\\iTop\\Core\\CMDBChange\\CMDBChangeOrigin' => $baseDir . '/sources/Core/CMDBChange/CMDBChangeOrigin.php',
+    'Combodo\\iTop\\Core\\DbConnectionWrapper' => $baseDir . '/core/DbConnectionWrapper.php',
     'Combodo\\iTop\\Core\\MetaModel\\FriendlyNameType' => $baseDir . '/sources/Core/MetaModel/FriendlyNameType.php',
     'Combodo\\iTop\\DesignDocument' => $baseDir . '/core/designdocument.class.inc.php',
     'Combodo\\iTop\\DesignElement' => $baseDir . '/core/designdocument.class.inc.php',

--- a/lib/composer/autoload_static.php
+++ b/lib/composer/autoload_static.php
@@ -529,6 +529,7 @@ class ComposerStaticInit0018331147de7601e7552f7da8e3bb8b
         'Combodo\\iTop\\Controller\\Base\\Layout\\ActivityPanelController' => __DIR__ . '/../..' . '/sources/Controller/Base/Layout/ActivityPanelController.php',
         'Combodo\\iTop\\Controller\\PreferencesController' => __DIR__ . '/../..' . '/sources/Controller/PreferencesController.php',
         'Combodo\\iTop\\Core\\CMDBChange\\CMDBChangeOrigin' => __DIR__ . '/../..' . '/sources/Core/CMDBChange/CMDBChangeOrigin.php',
+        'Combodo\\iTop\\Core\\DbConnectionWrapper' => __DIR__ . '/../..' . '/core/DbConnectionWrapper.php',
         'Combodo\\iTop\\Core\\MetaModel\\FriendlyNameType' => __DIR__ . '/../..' . '/sources/Core/MetaModel/FriendlyNameType.php',
         'Combodo\\iTop\\DesignDocument' => __DIR__ . '/../..' . '/core/designdocument.class.inc.php',
         'Combodo\\iTop\\DesignElement' => __DIR__ . '/../..' . '/core/designdocument.class.inc.php',

--- a/lib/composer/platform_check.php
+++ b/lib/composer/platform_check.php
@@ -8,22 +8,6 @@ if (!(PHP_VERSION_ID >= 70103)) {
     $issues[] = 'Your Composer dependencies require a PHP version ">= 7.1.3". You are running ' . PHP_VERSION . '.';
 }
 
-$missingExtensions = array();
-extension_loaded('ctype') || $missingExtensions[] = 'ctype';
-extension_loaded('dom') || $missingExtensions[] = 'dom';
-extension_loaded('gd') || $missingExtensions[] = 'gd';
-extension_loaded('iconv') || $missingExtensions[] = 'iconv';
-extension_loaded('json') || $missingExtensions[] = 'json';
-extension_loaded('libxml') || $missingExtensions[] = 'libxml';
-extension_loaded('mysqli') || $missingExtensions[] = 'mysqli';
-extension_loaded('soap') || $missingExtensions[] = 'soap';
-extension_loaded('tokenizer') || $missingExtensions[] = 'tokenizer';
-extension_loaded('xml') || $missingExtensions[] = 'xml';
-
-if ($missingExtensions) {
-    $issues[] = 'Your Composer dependencies require the following PHP extensions to be installed: ' . implode(', ', $missingExtensions) . '.';
-}
-
 if ($issues) {
     if (!headers_sent()) {
         header('HTTP/1.1 500 Internal Server Error');

--- a/test/core/CMDBSource/TransactionsTest.php
+++ b/test/core/CMDBSource/TransactionsTest.php
@@ -7,6 +7,7 @@
 namespace Combodo\iTop\Test\UnitTest\Core;
 
 use CMDBSource;
+use Combodo\iTop\Core\DbConnectionWrapper;
 use Combodo\iTop\Test\UnitTest\ItopTestCase;
 use Exception;
 use MetaModel;
@@ -48,7 +49,7 @@ class TransactionsTest extends ItopTestCase
 				}
 			));
 
-		$this->InvokeNonPublicStaticMethod('CMDBSource', 'SetMySQLiForQuery', [$oMockMysqli]);
+		DbConnectionWrapper::SetDbConnectionMockForQuery($oMockMysqli);
 	}
 
 	/**


### PR DESCRIPTION
In 2.7.5 with N°3513 we added a second mysqli attribute in CMDBSource, so that we can test transactions (see TransactionsTest).

But this wasn't documented, and was really causing confusion.

This refactor wraps both attributes in a dedicated object so that the logic is clearer.