### PR TITLE
N°4261 Refactor ExceptionLog

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ tab_width = 4
 ij_continuation_indent_size = 8
 ij_formatter_off_tag = @formatter:off
 ij_formatter_on_tag = @formatter:on
-ij_formatter_tags_enabled = false
+ij_formatter_tags_enabled = true
 ij_smart_tabs = false
 ij_visual_guides = 300
 ij_wrap_on_typing = true
@@ -78,7 +78,7 @@ ij_editorconfig_space_before_colon = false
 ij_editorconfig_space_before_comma = false
 ij_editorconfig_spaces_around_assignment_operators = true
 
-[{*.ant, *.fxml, *.jhm, *.jnlp, *.jrxml, *.rng, *.tld, *.wsdl, *.xml, *.xsd, *.xsl, *.xslt, *.xul, phpunit.xml.dist}]
+[{*.ant,*.fxml,*.jhm,*.jnlp,*.jrxml,*.rng,*.tld,*.wsdl,*.xml,*.xsd,*.xsl,*.xslt,*.xul,phpunit.xml.dist}]
 indent_size = 2
 tab_width = 2
 ij_smart_tabs = true
@@ -280,16 +280,17 @@ ij_javascript_while_brace_force = always
 ij_javascript_while_on_new_line = false
 ij_javascript_wrap_comments = false
 
-[{*.ctp, *.hphp, *.inc, *.module, *.php, *.php4, *.php5, *.phtml}]
+[{*.ctp,*.hphp,*.inc,*.module,*.php,*.php4,*.php5,*.phtml}]
 indent_style = tab
 ij_continuation_indent_size = 4
 ij_smart_tabs = true
 ij_wrap_on_typing = false
 ij_php_align_assignments = false
-ij_php_align_class_constants = false
+ij_php_align_class_constants = true
 ij_php_align_group_field_declarations = false
 ij_php_align_inline_comments = false
 ij_php_align_key_value_pairs = true
+ij_php_align_match_arm_bodies = false
 ij_php_align_multiline_array_initializer_expression = true
 ij_php_align_multiline_binary_operation = false
 ij_php_align_multiline_chained_methods = false
@@ -298,6 +299,7 @@ ij_php_align_multiline_for = true
 ij_php_align_multiline_parameters = false
 ij_php_align_multiline_parameters_in_calls = false
 ij_php_align_multiline_ternary_operation = false
+ij_php_align_named_arguments = false
 ij_php_align_phpdoc_comments = false
 ij_php_align_phpdoc_param_names = false
 ij_php_anonymous_brace_style = end_of_line
@@ -417,6 +419,7 @@ ij_php_see_weight = 3
 ij_php_since_weight = 28
 ij_php_sort_phpdoc_elements = true
 ij_php_space_after_colon = true
+ij_php_space_after_colon_in_enum_backed_type = true
 ij_php_space_after_colon_in_named_argument = true
 ij_php_space_after_colon_in_return_type = true
 ij_php_space_after_comma = true
@@ -431,6 +434,7 @@ ij_php_space_before_catch_parentheses = true
 ij_php_space_before_class_left_brace = true
 ij_php_space_before_closure_left_parenthesis = true
 ij_php_space_before_colon = true
+ij_php_space_before_colon_in_enum_backed_type = false
 ij_php_space_before_colon_in_named_argument = false
 ij_php_space_before_colon_in_return_type = false
 ij_php_space_before_comma = false
@@ -466,6 +470,7 @@ ij_php_spaces_around_equality_operators = true
 ij_php_spaces_around_logical_operators = true
 ij_php_spaces_around_multiplicative_operators = true
 ij_php_spaces_around_null_coalesce_operator = true
+ij_php_spaces_around_pipe_in_union_type = false
 ij_php_spaces_around_relational_operators = true
 ij_php_spaces_around_shift_operators = true
 ij_php_spaces_around_unary_operator = false
@@ -540,7 +545,6 @@ ij_html_space_after_tag_name = false
 ij_html_space_around_equality_in_attribute = false
 ij_html_space_inside_empty_tag = false
 ij_html_text_wrap = normal
-ij_html_uniform_ident = false
 
 [{*.markdown,*.md}]
 ij_visual_guides = none

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -804,12 +804,11 @@ abstract class LogAPI
 		}
 
 		// Protect against reentrance
-		static $aWriteToDbReentrance = array();
-		$sKey = $sChannel.$sMessage;
-		if (array_key_exists($sKey, $aWriteToDbReentrance)) {
+		static $bWriteToDbReentrance;
+		if ($bWriteToDbReentrance === true) {
 			return;
 		}
-		$aWriteToDbReentrance[$sKey] = true;
+		$bWriteToDbReentrance = true;
 
 		try {
 			self::$oLastEventIssue = static::GetEventIssue($sMessage, $sChannel, $aContext);
@@ -823,7 +822,7 @@ abstract class LogAPI
 			]);
 		}
 		finally {
-			unset($aWriteToDbReentrance[$sKey]);
+			$bWriteToDbReentrance = false;
 		}
 	}
 

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -648,7 +648,7 @@ abstract class LogAPI
 		}
 
 		if (
-			(false === is_null(static::$m_oFileLog))
+			(null !== static::$m_oFileLog)
 			&& static::IsLogLevelEnabled($sLevel, $sChannel, static::ENUM_CONFIG_PARAM_FILE)
 		) {
 			static::$m_oFileLog->$sLevel($sMessage, $sChannel, $aContext);

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -1330,7 +1330,7 @@ class ExceptionLog extends LogAPI
 			$aContext['line'] = $oException->getLine();
 		}
 
-		self::Log($sLevel, $oException->getMessage(), $sExceptionClass, $aContext);
+		parent::Log($sLevel, $oException->getMessage(), $sExceptionClass, $aContext);
 	}
 
 	/** @noinspection PhpUnhandledExceptionInspection */

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -848,11 +848,13 @@ abstract class LogAPI
 	 */
 	protected static function GetLevelDefault(string $sConfigKey): string
 	{
-		if ($sConfigKey === self::ENUM_CONFIG_PARAM_DB) {
-			return static::LEVEL_DEFAULT_DB;
+		switch ($sConfigKey) {
+			case static::ENUM_CONFIG_PARAM_DB:
+				return static::LEVEL_DEFAULT_DB;
+			case static::ENUM_CONFIG_PARAM_FILE:
+			default:
+				return static::LEVEL_DEFAULT;
 		}
-
-		return static::LEVEL_DEFAULT;
 	}
 }
 

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -1065,17 +1065,28 @@ class DeprecatedCallsLog extends LogAPI
 		return true;
 	}
 
+	/**
+	 * Override so that :
+	 * - if we are in dev mode ({@see \utils::IsDevelopmentEnvironment()}), the level for file will be DEBUG
+	 * - else call parent method
+	 *
+	 * In other words, when in dev mode all deprecated calls will be logged to file
+	 *
+	 * @param string $sLogConfigKey
+	 *
+	 * @return string
+	 */
 	protected static function GetLevelDefault(string $sLogConfigKey): string
 	{
 		if ($sLogConfigKey === self::ENUM_CONFIG_PARAM_DB) {
-			return static::LEVEL_DEFAULT_DB;
+			return parent::GetLevelDefault($sLogConfigKey);
 		}
 
 		if (utils::IsDevelopmentEnvironment()) {
 			return static::LEVEL_DEBUG;
 		}
 
-		return static::LEVEL_DEFAULT;
+		return parent::GetLevelDefault($sLogConfigKey);
 	}
 
 	/**

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -504,7 +504,7 @@ class FileLog
 	{
 		$sTextPrefix = empty($sLevel) ? '' : (str_pad($sLevel, 7));
 		$sTextPrefix .= ' | ';
-		$sTextPrefix .= str_pad(UserRights::GetUserId(), 5)." | ";
+		$sTextPrefix .= str_pad(LogAPI::GetUserInfo(), 5)." | ";
 
 		$sTextSuffix = ' | '.(empty($sChannel) ? '' : $sChannel);
 		$sTextSuffix .= ' |||';
@@ -676,6 +676,16 @@ abstract class LogAPI
 		}
 	}
 
+	public static function GetUserInfo(): ?string
+	{
+		$oConnectedUser = UserRights::GetUserObject();
+		if (is_null($oConnectedUser)) {
+			return 'null';
+		}
+
+		return $oConnectedUser->GetKey();
+	}
+
 	/**
 	 * @throws \ConfigException if log wrongly configured
 	 * @uses GetMinLogLevel
@@ -832,7 +842,7 @@ abstract class LogAPI
 		$oEventIssue->Set('issue', $sMessage);
 		$oEventIssue->Set('message', $sMessage);
 		$oEventIssue->Set('date', $sDate);
-		$oEventIssue->Set('userinfo', UserRights::GetUserFriendlyName());
+		$oEventIssue->Set('userinfo', static::GetUserInfo());
 		$oEventIssue->Set('callstack', $sCurrentCallStack);
 		$oEventIssue->Set('data', $aContext);
 
@@ -889,6 +899,16 @@ class SetupLog extends LogAPI
 	const LEVEL_DEFAULT = self::LEVEL_INFO;
 
 	protected static $m_oFileLog = null;
+
+	/**
+	 * In the setup there is no user logged...
+	 *
+	 * @return string|null
+	 */
+	public static function GetUserInfo(): ?string
+	{
+		return 'SETUP';
+	}
 }
 
 class IssueLog extends LogAPI

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -1292,7 +1292,7 @@ class ExceptionLog extends LogAPI
 			(null !== static::$m_oFileLog)
 			&& static::IsLogLevelEnabled($sLevel, $sExceptionClass, static::ENUM_CONFIG_PARAM_FILE)
 		) {
-			$sExceptionClassConfiguredForFile = static::GetExceptionClassInConfig($sExceptionClass, static::ENUM_CONFIG_PARAM_FILE);
+			$sExceptionClassConfiguredForFile = static::ExceptionClassFromHierarchy($sExceptionClass, static::ENUM_CONFIG_PARAM_FILE);
 			if (null === $sExceptionClassConfiguredForFile) {
 				$sExceptionClassConfiguredForFile = $sExceptionClass;
 			}
@@ -1304,7 +1304,7 @@ class ExceptionLog extends LogAPI
 		}
 
 		if (static::IsLogLevelEnabled($sLevel, $sExceptionClass, static::ENUM_CONFIG_PARAM_DB)) {
-			$sExceptionClassConfiguredForDb = static::GetExceptionClassInConfig($sExceptionClass, static::ENUM_CONFIG_PARAM_DB);
+			$sExceptionClassConfiguredForDb = static::ExceptionClassFromHierarchy($sExceptionClass, static::ENUM_CONFIG_PARAM_DB);
 			if (null === $sExceptionClassConfiguredForDb) {
 				$sExceptionClassConfiguredForDb = $sExceptionClass;
 			}
@@ -1313,7 +1313,7 @@ class ExceptionLog extends LogAPI
 	}
 
 	/**
-	 * Will seek for the configuration based on the exception class, using {@see \ExceptionLog::GetExceptionClassInConfig()}
+	 * Will seek for the configuration based on the exception class, using {@see \ExceptionLog::ExceptionClassFromHierarchy()}
 	 *
 	 * @param string $sExceptionClass
 	 * @param string $sLogConfigKey
@@ -1324,7 +1324,7 @@ class ExceptionLog extends LogAPI
 	protected static function GetMinLogLevel($sExceptionClass, $sLogConfigKey = self::ENUM_CONFIG_PARAM_FILE)
 	{
 		$sLogLevelMin = static::GetLogConfig($sLogConfigKey);
-		$sExceptionClassInConfig = static::GetExceptionClassInConfig($sExceptionClass, $sLogConfigKey);
+		$sExceptionClassInConfig = static::ExceptionClassFromHierarchy($sExceptionClass, $sLogConfigKey);
 
 		if (null !== $sExceptionClassInConfig) {
 			return $sLogConfigKey[$sExceptionClassInConfig];
@@ -1349,7 +1349,7 @@ class ExceptionLog extends LogAPI
 	 *
 	 * @return string|null the current or parent class name defined in the config, otherwise null if no class of the hierarchy found in the config
 	 */
-	protected static function GetExceptionClassInConfig($sExceptionClass, $sLogConfigKey = self::ENUM_CONFIG_PARAM_FILE)
+	protected static function ExceptionClassFromHierarchy($sExceptionClass, $sLogConfigKey = self::ENUM_CONFIG_PARAM_FILE)
 	{
 		$sLogLevelMin = static::GetLogConfig($sLogConfigKey);
 

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -1135,12 +1135,12 @@ class LogFileRotationProcess implements iScheduledProcess
  *
  * Please use {@see ExceptionLog::LogException()} to log exceptions
  *
- * @since 3.0.0
+ * @since 3.0.0 N°4261 class creation to allow to easier logging when exception occurs
  */
 class ExceptionLog extends LogAPI
 {
-	const CHANNEL_DEFAULT = 'Exception';
-	const CONTEXT_EXCEPTION = '__exception';
+	public const CHANNEL_DEFAULT = 'Exception';
+	public const CONTEXT_EXCEPTION = '__exception';
 
 	private static $oLastEventIssue = null;
 
@@ -1152,7 +1152,7 @@ class ExceptionLog extends LogAPI
 	 * As it encapsulate the operations performed using the Exception, you should prefer it to the standard API inherited from LogApi `ExceptionLog::Error($oException->getMessage(), get_class($oException), ['__exception' => $oException]);`
 	 * The parameter order is not standard, but in our use case, the resulting API is way more convenient this way.
 	 */
-	public static function LogException(Exception $oException, $aContext = array(), $sLevel = self::LEVEL_WARNING)
+	public static function LogException(Exception $oException, $aContext = array(), $sLevel = self::LEVEL_WARNING): void
 	{
 		if (empty($aContext[self::CONTEXT_EXCEPTION])) {
 			$aContext[self::CONTEXT_EXCEPTION] = $oException;
@@ -1196,10 +1196,10 @@ class ExceptionLog extends LogAPI
 		}
 
 		$sDbChannel = self::FindClassChannel($sClass, 'log_level_min.write_in_db');
+		//TODO pull up in LogAPI
 		if (static::IsLogLevelEnabled($sLevel, $sDbChannel, 'log_level_min.write_in_db')) {
 			self::WriteToDb($aContext);
 		}
-
 	}
 
 	protected static function FindClassChannel($sClass, $sCode = 'log_level_min')

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -664,8 +664,6 @@ abstract class LogAPI
 		}
 		if (static::IsLogLevelEnabled($sLevel, $sChannel, static::ENUM_CONFIG_PARAM_DB)) {
 			self::WriteToDb($sMessage, $sChannel, $aContext);
-		} else {
-			static::$oLastEventIssue = null;
 		}
 	}
 

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -671,9 +671,9 @@ abstract class LogAPI
 	 * @throws \ConfigException if log wrongly configured
 	 * @uses GetMinLogLevel
 	 */
-	final public static function IsLogLevelEnabled(string $sLevel, string $sChannel, string $sLogConfigKey = self::ENUM_CONFIG_PARAM_FILE): bool
+	final public static function IsLogLevelEnabled(string $sLevel, string $sChannel, string $sConfigKey = self::ENUM_CONFIG_PARAM_FILE): bool
 	{
-		$sMinLogLevel = self::GetMinLogLevel($sChannel, $sLogConfigKey);
+		$sMinLogLevel = self::GetMinLogLevel($sChannel, $sConfigKey);
 
 		// the is_bool call is to remove a IDE O:) warning as $sMinLogLevel is typed as string
 		if ((is_bool($sMinLogLevel) && ($sMinLogLevel === false)) || $sMinLogLevel === 'false') {
@@ -694,7 +694,7 @@ abstract class LogAPI
 
 	/**
 	 * @param string $sChannel
-	 * @param string $sLogConfigKey
+	 * @param string $sConfigKey
 	 *
 	 * @return string one of the LEVEL_* const value : the one configured it if exists, otherwise default log level for this channel
 	 *       Config can be set :
@@ -715,39 +715,39 @@ abstract class LogAPI
 	 *
 	 * @link https://www.itophub.io/wiki/page?id=3_0_0%3Aadmin%3Alog iTop log reference
 	 */
-	protected static function GetMinLogLevel($sChannel, $sLogConfigKey = self::ENUM_CONFIG_PARAM_FILE)
+	protected static function GetMinLogLevel($sChannel, $sConfigKey = self::ENUM_CONFIG_PARAM_FILE)
 	{
-		$sLogLevelMin = static::GetLogConfig($sLogConfigKey);
+		$sLogLevelMin = static::GetLogConfig($sConfigKey);
 
-		$sConfiguredLevelForChannel = static::GetMinLogLevelFromChannel($sLogLevelMin, $sChannel, $sLogConfigKey);
+		$sConfiguredLevelForChannel = static::GetMinLogLevelFromChannel($sLogLevelMin, $sChannel, $sConfigKey);
 		if (!is_null($sConfiguredLevelForChannel)) {
 			return $sConfiguredLevelForChannel;
 		}
 
-		return static::GetMinLogLevelFromDefault($sLogLevelMin, $sChannel, $sLogConfigKey);
+		return static::GetMinLogLevelFromDefault($sLogLevelMin, $sChannel, $sConfigKey);
 	}
 
-	final protected static function GetLogConfig($sLogConfigKey)
+	final protected static function GetLogConfig($sConfigKey)
 	{
 		$oConfig = static::GetConfig();
 		if (!$oConfig instanceof Config) {
-			return static::GetLevelDefault($sLogConfigKey);
+			return static::GetLevelDefault($sConfigKey);
 		}
 
-		return $oConfig->Get($sLogConfigKey);
+		return $oConfig->Get($sConfigKey);
 	}
 
 	/**
 	 * @param string|array $sLogLevelMin log config parameter value
 	 * @param string $sChannel
-	 * @param string $sLogConfigKey config option key
+	 * @param string $sConfigKey config option key
 	 *
 	 * @return string|null null if not defined
 	 */
-	protected static function GetMinLogLevelFromChannel($sLogLevelMin, $sChannel, $sLogConfigKey)
+	protected static function GetMinLogLevelFromChannel($sLogLevelMin, $sChannel, $sConfigKey)
 	{
 		if (empty($sLogLevelMin)) {
-			return static::GetLevelDefault($sLogConfigKey);
+			return static::GetLevelDefault($sConfigKey);
 		}
 
 		if (!is_array($sLogLevelMin)) {
@@ -761,7 +761,7 @@ abstract class LogAPI
 		return null;
 	}
 
-	protected static function GetMinLogLevelFromDefault($sLogLevelMin, $sChannel, $sLogConfigKey)
+	protected static function GetMinLogLevelFromDefault($sLogLevelMin, $sChannel, $sConfigKey)
 	{
 		if (isset($sLogLevelMin[static::CHANNEL_DEFAULT])) {
 			return $sLogLevelMin[static::CHANNEL_DEFAULT];
@@ -772,7 +772,7 @@ abstract class LogAPI
 			return $sLogLevelMin[''];
 		}
 
-		return static::GetLevelDefault($sLogConfigKey);
+		return static::GetLevelDefault($sConfigKey);
 	}
 
 	protected static function WriteToDb(string $sMessage, string $sChannel, array $aContext): void
@@ -836,7 +836,7 @@ abstract class LogAPI
 	 *
 	 * @used-by GetMinLogLevel
 	 *
-	 * @param string $sLogConfigKey config key used for log
+	 * @param string $sConfigKey config key used for log
 	 *
 	 * @return string
 	 *
@@ -846,9 +846,9 @@ abstract class LogAPI
 	 * @since 3.0.0 N°3731
 	 * @since 3.0.0 N°4261 add specific default level for DB write
 	 */
-	protected static function GetLevelDefault(string $sLogConfigKey): string
+	protected static function GetLevelDefault(string $sConfigKey): string
 	{
-		if ($sLogConfigKey === self::ENUM_CONFIG_PARAM_DB) {
+		if ($sConfigKey === self::ENUM_CONFIG_PARAM_DB) {
 			return static::LEVEL_DEFAULT_DB;
 		}
 
@@ -1072,21 +1072,21 @@ class DeprecatedCallsLog extends LogAPI
 	 *
 	 * In other words, when in dev mode all deprecated calls will be logged to file
 	 *
-	 * @param string $sLogConfigKey
+	 * @param string $sConfigKey
 	 *
 	 * @return string
 	 */
-	protected static function GetLevelDefault(string $sLogConfigKey): string
+	protected static function GetLevelDefault(string $sConfigKey): string
 	{
-		if ($sLogConfigKey === self::ENUM_CONFIG_PARAM_DB) {
-			return parent::GetLevelDefault($sLogConfigKey);
+		if ($sConfigKey === self::ENUM_CONFIG_PARAM_DB) {
+			return parent::GetLevelDefault($sConfigKey);
 		}
 
 		if (utils::IsDevelopmentEnvironment()) {
 			return static::LEVEL_DEBUG;
 		}
 
-		return parent::GetLevelDefault($sLogConfigKey);
+		return parent::GetLevelDefault($sConfigKey);
 	}
 
 	/**
@@ -1327,21 +1327,21 @@ class ExceptionLog extends LogAPI
 	 * Will seek for the configuration based on the exception class, using {@see \ExceptionLog::ExceptionClassFromHierarchy()}
 	 *
 	 * @param string $sExceptionClass
-	 * @param string $sLogConfigKey
+	 * @param string $sConfigKey
 	 *
 	 * @return string
 	 * @noinspection PhpParameterNameChangedDuringInheritanceInspection
 	 */
-	protected static function GetMinLogLevel($sExceptionClass, $sLogConfigKey = self::ENUM_CONFIG_PARAM_FILE)
+	protected static function GetMinLogLevel($sExceptionClass, $sConfigKey = self::ENUM_CONFIG_PARAM_FILE)
 	{
-		$sLogLevelMin = static::GetLogConfig($sLogConfigKey);
-		$sExceptionClassInConfig = static::ExceptionClassFromHierarchy($sExceptionClass, $sLogConfigKey);
+		$sLogLevelMin = static::GetLogConfig($sConfigKey);
+		$sExceptionClassInConfig = static::ExceptionClassFromHierarchy($sExceptionClass, $sConfigKey);
 
 		if (null !== $sExceptionClassInConfig) {
-			return $sLogConfigKey[$sExceptionClassInConfig];
+			return $sConfigKey[$sExceptionClassInConfig];
 		}
 
-		return static::GetMinLogLevelFromDefault($sLogLevelMin, $sExceptionClass, $sLogConfigKey);
+		return static::GetMinLogLevelFromDefault($sLogLevelMin, $sExceptionClass, $sConfigKey);
 	}
 
 	/**
@@ -1356,13 +1356,13 @@ class ExceptionLog extends LogAPI
 	 * 5. Exception
 	 *
 	 * @param string $sExceptionClass
-	 * @param string $sLogConfigKey
+	 * @param string $sConfigKey
 	 *
 	 * @return string|null the current or parent class name defined in the config, otherwise null if no class of the hierarchy found in the config
 	 */
-	protected static function ExceptionClassFromHierarchy($sExceptionClass, $sLogConfigKey = self::ENUM_CONFIG_PARAM_FILE)
+	protected static function ExceptionClassFromHierarchy($sExceptionClass, $sConfigKey = self::ENUM_CONFIG_PARAM_FILE)
 	{
-		$sLogLevelMin = static::GetLogConfig($sLogConfigKey);
+		$sLogLevelMin = static::GetLogConfig($sConfigKey);
 
 		if (false === is_array($sLogLevelMin)) {
 			return null;
@@ -1370,7 +1370,7 @@ class ExceptionLog extends LogAPI
 
 		$sExceptionClassInHierarchy = $sExceptionClass;
 		while ($sExceptionClassInHierarchy !== false) {
-			$sConfiguredLevelForExceptionClass = static::GetMinLogLevelFromChannel($sLogLevelMin, $sExceptionClassInHierarchy, $sLogConfigKey);
+			$sConfiguredLevelForExceptionClass = static::GetMinLogLevelFromChannel($sLogLevelMin, $sExceptionClassInHierarchy, $sConfigKey);
 			if (!is_null($sConfiguredLevelForExceptionClass)) {
 				break;
 			}

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -1286,7 +1286,11 @@ class ExceptionLog extends LogAPI
 			if (null === $sExceptionClassConfiguredForFile) {
 				$sExceptionClassConfiguredForFile = $sExceptionClass;
 			}
-			static::$m_oFileLog->$sLevel($sMessage, $sExceptionClassConfiguredForFile, $aContext);
+
+			// clearing the Exception object as it is too verbose to write to a file !
+			$aContextForFile = array_diff_key($aContext, [self::CONTEXT_EXCEPTION => null]);
+
+			static::$m_oFileLog->$sLevel($sMessage, $sExceptionClassConfiguredForFile, $aContextForFile);
 		}
 
 		if (static::IsLogLevelEnabled($sLevel, $sExceptionClass, static::ENUM_CONFIG_PARAM_DB)) {

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -656,12 +656,21 @@ abstract class LogAPI
 			$sChannel = static::CHANNEL_DEFAULT;
 		}
 
+		static::WriteLog($sLevel, $sMessage, $sChannel, $aContext);
+	}
+
+	/**
+	 * @throws \ConfigException
+	 */
+	protected static function WriteLog(string $sLevel, string $sMessage, ?string $sChannel = null, ?array $aContext = array()): void
+	{
 		if (
 			(null !== static::$m_oFileLog)
 			&& static::IsLogLevelEnabled($sLevel, $sChannel, static::ENUM_CONFIG_PARAM_FILE)
 		) {
 			static::$m_oFileLog->$sLevel($sMessage, $sChannel, $aContext);
 		}
+
 		if (static::IsLogLevelEnabled($sLevel, $sChannel, static::ENUM_CONFIG_PARAM_DB)) {
 			self::WriteToDb($sMessage, $sChannel, $aContext);
 		}
@@ -1305,12 +1314,14 @@ class ExceptionLog extends LogAPI
 		self::Log($sLevel, $oException->getMessage(), $sExceptionClass, $aContext);
 	}
 
-	/**
-	 * Do not call this method directly as you do in other LogAPI impl ! Prefer calling {@see \ExceptionLog::LogException()} instead, providing your exception instance !
-	 *
-	 * @noinspection PhpParameterNameChangedDuringInheritanceInspection
-	 */
-	public static function Log($sLevel, $sMessage, $sExceptionClass = null, $aContext = array())
+	/** @noinspection PhpUnhandledExceptionInspection */
+	public static function Log($sLevel, $sMessage, $sChannel = null, $aContext = array())
+	{
+		throw new ApplicationException('Do not call this directly, prefer using ExceptionLog::LogException() instead');
+	}
+
+	/** @noinspection PhpParameterNameChangedDuringInheritanceInspection */
+	protected static function WriteLog(string $sLevel, string $sMessage, ?string $sExceptionClass = null, ?array $aContext = array()): void
 	{
 		if (
 			(null !== static::$m_oFileLog)

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -1252,7 +1252,7 @@ class ExceptionLog extends LogAPI
 	 * As it encapsulate the operations performed using the Exception, you should prefer it to the standard API inherited from LogApi `ExceptionLog::Error($oException->getMessage(), get_class($oException), ['__exception' => $oException]);`
 	 * The parameter order is not standard, but in our use case, the resulting API is way more convenient this way !
 	 */
-	public static function LogException(Exception $oException, $aContext = array(), $sLevel = self::LEVEL_WARNING): void
+	public static function LogException(Throwable $oException, $aContext = array(), $sLevel = self::LEVEL_WARNING): void
 	{
 		if (!isset(self::$aLevelsPriority[$sLevel])) {
 			IssueLog::Error("invalid log level '{$sLevel}'");

--- a/test/core/Log/ExceptionLogTest.php
+++ b/test/core/Log/ExceptionLogTest.php
@@ -203,7 +203,7 @@ class ExceptionLogTest extends ItopDataTestCase
 	/**
 	 * @dataProvider exceptionClassProvider
 	 */
-	public function testGetExceptionClassInConfig($aLogConfig, $sActualExceptionClass, $sExpectedExceptionClass)
+	public function testExceptionClassFromHierarchy($aLogConfig, $sActualExceptionClass, $sExpectedExceptionClass)
 	{
 		$oMockConfig = $this->createMock('Config');
 
@@ -212,7 +212,7 @@ class ExceptionLogTest extends ItopDataTestCase
 			->willReturn($aLogConfig);
 
 		ExceptionLog::MockStaticObjects(null, $oMockConfig);
-		$sReturnedExceptionClass = $this->InvokeNonPublicStaticMethod(ExceptionLog::class, 'GetExceptionClassInConfig', [$sActualExceptionClass]);
+		$sReturnedExceptionClass = $this->InvokeNonPublicStaticMethod(ExceptionLog::class, 'ExceptionClassFromHierarchy', [$sActualExceptionClass]);
 
 		static::assertEquals($sExpectedExceptionClass, $sReturnedExceptionClass, 'Not getting correct exception in hierarchy !');
 	}

--- a/test/core/Log/ExceptionLogTest.php
+++ b/test/core/Log/ExceptionLogTest.php
@@ -83,7 +83,6 @@ class ExceptionLogTest extends ItopDataTestCase
 					'exception class'               => get_class($oException),
 					'file'                          => $sExpectedFile,
 					'line'                          => $sExpectedLine,
-					ExceptionLog::CONTEXT_EXCEPTION => $oException,
 				]
 			); //The context is preserved, and, if the key 'exception class' is not yet in the array, it is added
 			$mockFileLog->expects($this->exactly($iExpectedWriteNumber))

--- a/test/core/Log/ExceptionLogTest.php
+++ b/test/core/Log/ExceptionLogTest.php
@@ -170,7 +170,7 @@ class ExceptionLogTest extends ItopDataTestCase
 				'iExpectedDbWriteNumber' => [0],
 				'logLevelMinWriteInDb' =>  ['Exception' => 'Error'],
 			],
-			'default channel, default conf' => [
+			'default channel, default conf'                          => [
 				'aLevels' => ['Warning'],
 				'aExceptions' => [\Exception::class],
 				'sChannel' => 'Exception',
@@ -179,7 +179,7 @@ class ExceptionLogTest extends ItopDataTestCase
 				'iExpectedDbWriteNumber' => [0],
 				'logLevelMinWriteInDb' => null,
 			],
-			'enabled' => [
+			'enabled'                                                => [
 				'aLevels' => ['Debug'],
 				'aExceptions' => [\Exception::class],
 				'sChannel' => 'Exception',
@@ -196,6 +196,15 @@ class ExceptionLogTest extends ItopDataTestCase
 				'logLevelMin'            => null,
 				'iExpectedDbWriteNumber' => [0, 0, 0, 1],
 				'logLevelMinWriteInDb'   => null,
+			],
+			'Simple Error (testing Throwable signature)'             => [
+				'aLevels'                => ['Debug'],
+				'aExceptions'            => [\Error::class],
+				'sChannel'               => 'Error',
+				'aExpectedWriteNumber'   => [1],
+				'logLevelMin'            => 'Debug',
+				'iExpectedDbWriteNumber' => [1],
+				'logLevelMinWriteInDb'   => 'Debug',
 			],
 		];
 	}

--- a/test/core/Log/ExceptionLogTest.php
+++ b/test/core/Log/ExceptionLogTest.php
@@ -72,17 +72,23 @@ class ExceptionLogTest extends ItopDataTestCase
 		$aContext = ['contextKey1' => 'value'];
 
 		foreach ($aLevels as $i => $sLevel) {
-
 			$sExpectedFile = __FILE__;
+			// @formatter:off
 			$oException = new $aExceptions[$i]("Iteration number $i"); $sExpectedLine = __LINE__; //Both should remain on the same line
+			// @formatter:on
 
 			$iExpectedWriteNumber = $aExpectedWriteNumber[$i];
 			$iExpectedDbWriteNumber = $aExpectedDbWriteNumber[$i];
-			$aExpectedFileContext = array_merge($aContext, ['exception class' => get_class($oException), 'file' => $sExpectedFile, 'line' => $sExpectedLine]); //The context is preserved, and, if the key 'exception class' is not yet in the array, it is added
+			$aExpectedFileContext = array_merge($aContext, [
+					'exception class'               => get_class($oException),
+					'file'                          => $sExpectedFile,
+					'line'                          => $sExpectedLine,
+					ExceptionLog::CONTEXT_EXCEPTION => $oException,
+				]
+			); //The context is preserved, and, if the key 'exception class' is not yet in the array, it is added
 			$mockFileLog->expects($this->exactly($iExpectedWriteNumber))
 				->method($sLevel)
-				->with($oException->GetMessage(), $sChannel, $aExpectedFileContext)
-			;
+				->with($oException->GetMessage(), $sChannel, $aExpectedFileContext);
 
 			ExceptionLog::MockStaticObjects($mockFileLog, $oMockConfig);
 
@@ -184,17 +190,75 @@ class ExceptionLogTest extends ItopDataTestCase
 				'logLevelMinWriteInDb' => ['Exception' => 'Debug'],
 			],
 			'file: 2 enabled, 2 filtered, db: 1 enabled, 3 filtered' => [
-				'aLevels' => ['Debug', 'Trace', 'Warning', 'Error'],
-				'aExceptions' => [\Exception::class, \Exception::class, \Exception::class, \Exception::class],
-				'sChannel' => 'Exception',
-				'aExpectedWriteNumber' => [0, 0, 1, 1],
-				'logLevelMin' => null,
+				'aLevels'                => ['Debug', 'Trace', 'Warning', 'Error'],
+				'aExceptions'            => [\Exception::class, \Exception::class, \Exception::class, \Exception::class],
+				'sChannel'               => 'Exception',
+				'aExpectedWriteNumber'   => [0, 0, 1, 1],
+				'logLevelMin'            => null,
 				'iExpectedDbWriteNumber' => [0, 0, 0, 1],
-				'logLevelMinWriteInDb' => null,
+				'logLevelMinWriteInDb'   => null,
 			],
 		];
 	}
 
+	/**
+	 * @dataProvider exceptionClassProvider
+	 */
+	public function testGetExceptionClassInConfig($aLogConfig, $sActualExceptionClass, $sExpectedExceptionClass)
+	{
+		$oMockConfig = $this->createMock('Config');
+
+		$oMockConfig
+			->method('Get')
+			->willReturn($aLogConfig);
+
+		ExceptionLog::MockStaticObjects(null, $oMockConfig);
+		$sReturnedExceptionClass = $this->InvokeNonPublicStaticMethod(ExceptionLog::class, 'GetExceptionClassInConfig', [$sActualExceptionClass]);
+
+		static::assertEquals($sExpectedExceptionClass, $sReturnedExceptionClass, 'Not getting correct exception in hierarchy !');
+	}
+
+	public function exceptionClassProvider()
+	{
+		// WARNING : cannot use Exception::class or LogAPI constants for levels :/
+		return [
+			'Exception, defined in config'                          => [
+				'aLogConfig'              => ['Exception' => 'Debug'],
+				'sActualExceptionClass'   => 'Exception',
+				'sExpectedExceptionClass' => 'Exception',
+			],
+			'Child of Exception, Exception defined in config'       => [
+				'aLogConfig'              => ['Exception' => 'Debug'],
+				'sActualExceptionClass'   => 'ChildException',
+				'sExpectedExceptionClass' => 'Exception',
+			],
+			'Grand child of Exception, Exception defined in config' => [
+				'aLogConfig'              => ['Exception' => 'Debug'],
+				'sActualExceptionClass'   => 'GrandChildException',
+				'sExpectedExceptionClass' => 'Exception',
+			],
+			'Exception, just a default level defined in config'     => [
+				'aLogConfig'              => 'Debug',
+				'sActualExceptionClass'   => 'Exception',
+				'sExpectedExceptionClass' => null,
+			],
+			'Exception, no exception class defined in config'       => [
+				'aLogConfig'              => ['IssueLog' => 'Debug'],
+				'sActualExceptionClass'   => 'Exception',
+				'sExpectedExceptionClass' => null,
+			],
+			'Exception, just the child defined in config'           => [
+				'aLogConfig'              => ['ChildException' => 'Debug'],
+				'sActualExceptionClass'   => 'Exception',
+				'sExpectedExceptionClass' => null,
+			],
+			'Exception, Exception and the child defined in config'  => [
+				'aLogConfig'              => ['Exception' => 'Debug', 'ChildException' => 'Debug'],
+				'sActualExceptionClass'   => 'Exception',
+				'sExpectedExceptionClass' => 'Exception',
+			],
+		];
+	}
 }
 
 

--- a/test/core/Log/LogAPITest.php
+++ b/test/core/Log/LogAPITest.php
@@ -15,6 +15,7 @@ namespace Combodo\iTop\Test\UnitTest\Core\Log;
 
 
 use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use MetaModel;
 
 /**
  * @runTestsInSeparateProcesses
@@ -35,7 +36,7 @@ class LogAPITest extends ItopDataTestCase
 		// disabling devenv is easier than changing log config O:)
 		$oConfig = MetaModel::GetConfig();
 		$oConfig->Set('developer_mode.enabled', false);
-		
+
 		$this->mockFileLog = $this->createMock('FileLog');
 		$this->oMetaModelConfig = $this->createMock('Config');
 	}

--- a/test/core/Log/LogAPITest.php
+++ b/test/core/Log/LogAPITest.php
@@ -29,6 +29,13 @@ class LogAPITest extends ItopDataTestCase
 	protected function setUp()
 	{
 		parent::setUp();
+
+		// We are using PHPUnit\Framework\MockObject\Generator::generateMock that is throwing notice !
+		// Changing config so that those won't be caught by \DeprecatedCallsLog::DeprecatedNoticesErrorHandler
+		// disabling devenv is easier than changing log config O:)
+		$oConfig = MetaModel::GetConfig();
+		$oConfig->Set('developer_mode.enabled', false);
+		
 		$this->mockFileLog = $this->createMock('FileLog');
 		$this->oMetaModelConfig = $this->createMock('Config');
 	}

--- a/test/core/Log/LogAPITest.php
+++ b/test/core/Log/LogAPITest.php
@@ -1,4 +1,8 @@
 <?php
+/*
+ * @copyright   Copyright (C) 2010-2021 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
 
 /**
  * Created by PhpStorm.
@@ -7,7 +11,7 @@
  * Time: 17:03
  */
 
-namespace Combodo\iTop\Test\UnitTest\Core;
+namespace Combodo\iTop\Test\UnitTest\Core\Log;
 
 
 use Combodo\iTop\Test\UnitTest\ItopTestCase;

--- a/test/core/Log/LogAPITest.php
+++ b/test/core/Log/LogAPITest.php
@@ -67,8 +67,10 @@ class LogAPITest extends ItopTestCase
 	{
 		$this->oMetaModelConfig
 			->method("Get")
-			->with('log_level_min')
-			->willReturn($ConfigReturnedObject);
+			->willReturnMap([
+				[\LogAPI::ENUM_CONFIG_PARAM_FILE, $ConfigReturnedObject],
+				[\LogAPI::ENUM_CONFIG_PARAM_DB, $ConfigReturnedObject],
+			]);
 
 		\IssueLog::MockStaticObjects($this->mockFileLog, $this->oMetaModelConfig);
 
@@ -115,8 +117,10 @@ class LogAPITest extends ItopTestCase
 	{
 		$this->oMetaModelConfig
 			->method("Get")
-			->with('log_level_min')
-			->willReturn($ConfigReturnedObject);
+			->willReturnMap([
+				[\LogAPI::ENUM_CONFIG_PARAM_FILE, $ConfigReturnedObject],
+				[\LogAPI::ENUM_CONFIG_PARAM_DB, $ConfigReturnedObject],
+			]);
 
 		\IssueLog::MockStaticObjects($this->mockFileLog, $this->oMetaModelConfig);
 
@@ -124,17 +128,14 @@ class LogAPITest extends ItopTestCase
 			->method($sExpectedLevel)
 			->with("log msg", "GaBuZoMeuChannel");
 
-		try{
+		try {
 			\IssueLog::Ok("log msg", "GaBuZoMeuChannel");
-			if ($bExceptionRaised)
-			{
+			if ($bExceptionRaised) {
 				$this->fail("raised should have been raised");
 			}
 		}
-		catch(\Exception $e)
-		{
-			if (!$bExceptionRaised)
-			{
+		catch (\Exception $e) {
+			if (!$bExceptionRaised) {
 				$this->fail("raised should NOT have been raised");
 			}
 		}

--- a/test/core/Log/LogAPITest.php
+++ b/test/core/Log/LogAPITest.php
@@ -63,6 +63,7 @@ class LogAPITest extends ItopDataTestCase
 		return [
 			[$this->oMetaModelConfig, "log msg", '', "Error", "log msg"],
 			[$this->oMetaModelConfig, "log msg", 'PoudlardChannel', "Error", "log msg", 'PoudlardChannel'],
+			[null, "log msg", '', "Error", "log msg"],
 		];
 	}
 

--- a/test/core/Log/LogFileNameBuilderTest.php
+++ b/test/core/Log/LogFileNameBuilderTest.php
@@ -1,7 +1,10 @@
 <?php
+/*
+ * @copyright   Copyright (C) 2010-2021 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
 
-
-namespace Combodo\iTop\Test\UnitTest\Core;
+namespace Combodo\iTop\Test\UnitTest\Core\Log;
 
 
 use Combodo\iTop\Test\UnitTest\ItopTestCase;


### PR DESCRIPTION
N°4261 was a way to : 

* Log more info on user portal exceptions (this is done in \Combodo\iTop\Portal\EventListener\ExceptionListener::onKernelException) : before we only logged the exception message using IssueLog
* Allow to log as EventIssue objects so that we can query those. Default level to log as EventIssue objects must be ERROR
* Configuration is done by class hierarchy. For example, defining Trace level for CoreException hierarchy (this class and all of its children)
* When logging, the channel used is the one defined in the configuration. The exception class is logged but in aContext data.

Doing a code review with Bruno, we agreed to do some little refactoring : 

* Level per exception class
  - Before the whole ExceptionLog::Log method was a total rewrite of its parent, with some code duplicates... not a good idea : we should better improve LogAPI to make other similar uses possible in the future !
  - The logic to get level from config must be in a GetMinLogLevel override
* Write to DB
  - Pull up this functionnality in LogAPI
  - Add a sCode parameter in GetLevelDefault

Doing this refactoring, I also improved : 

* Test the attributes set when creating the EventIssue object : during my dev I had crashes because I didn't filled all the mandatory fields... Having a PHPUnit test checking this will prevent future bugs to happen if attributes are modified in the class or in the object creation method
* Use Throwable instead of Exception : this was added in PHP 7.0 and will allow to catch both Exception and Error
* Because we need to have 2 statements on the same line in \Combodo\iTop\Test\UnitTest\Core\Log\ExceptionLogTest::testLogInFile, I modified the editorConfig file to allow disabling the formatter using comments.