### PR TITLE
Restore prototypes of cmdbAbstractObject methods in which we added $sMode to preserve compatibility with existing extensions

### DIFF
--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -101,6 +101,12 @@ abstract class cmdbAbstractObject extends CMDBObject implements iDisplay
 	 * @since 3.0.0
 	 */
 	public const ENUM_DISPLAY_MODE_PRINT = 'print';
+	/**
+	 * @var string
+	 * @see static::$sDisplayMode
+	 * @since 3.0.0
+	 */
+	public const ENUM_DISPLAY_MODE_BULK_EDIT = self::ENUM_DISPLAY_MODE_EDIT;
 
 	// N°3750 rendering used
 	/** @var string */
@@ -201,6 +207,8 @@ abstract class cmdbAbstractObject extends CMDBObject implements iDisplay
 			static::ENUM_DISPLAY_MODE_EDIT,
 			static::ENUM_DISPLAY_MODE_CREATE,
 			static::ENUM_DISPLAY_MODE_STIMULUS,
+			static::ENUM_DISPLAY_MODE_PRINT,
+			static::ENUM_DISPLAY_MODE_BULK_EDIT,
 		];
 	}
 
@@ -4971,7 +4979,7 @@ HTML
 			// Now create an object that has values for the homogeneous values only
 			/** @var \cmdbAbstractObject $oDummyObj */
 			$oDummyObj = new $sClass(); // @@ What if the class is abstract ?
-			$oDummyObj->SetDisplayMode(static::ENUM_DISPLAY_MODE_EDIT);
+			$oDummyObj->SetDisplayMode(static::ENUM_DISPLAY_MODE_BULK_EDIT);
 			$aComments = array();
 			function MyComparison($a, $b) // Sort descending
 			{

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -2766,7 +2766,7 @@ JS
 		$this->SetDisplayMode(($iKey > 0) ? static::ENUM_DISPLAY_MODE_EDIT : static::ENUM_DISPLAY_MODE_CREATE);
 		$sDisplayMode = $this->GetDisplayMode();
 
-		if ($sDisplayMode === static::ENUM_DISPLAY_MODE_EDIT)
+		if ($this->GetDisplayMode() === static::ENUM_DISPLAY_MODE_EDIT)
 		{
 			// The concurrent access lock makes sense only for already existing objects
 			$LockEnabled = MetaModel::GetConfig()->Get('concurrent_lock_enabled');
@@ -2816,7 +2816,7 @@ JS
 		if (isset($aExtraParams['custom_button'])) {
 			$sApplyButton = $aExtraParams['custom_button'];
 		} else {
-			if ($sDisplayMode === static::ENUM_DISPLAY_MODE_EDIT) {
+			if ($this->GetDisplayMode() === static::ENUM_DISPLAY_MODE_EDIT) {
 				$sApplyButton = Dict::S('UI:Button:Apply');
 			} else {
 				$sApplyButton = Dict::S('UI:Button:Create');
@@ -2826,7 +2826,7 @@ JS
 		if (isset($aExtraParams['custom_operation'])) {
 			$sOperation = $aExtraParams['custom_operation'];
 		} else {
-			if ($sDisplayMode === static::ENUM_DISPLAY_MODE_EDIT) {
+			if ($this->GetDisplayMode() === static::ENUM_DISPLAY_MODE_EDIT) {
 				$sOperation = 'apply_modify';
 			} else {
 				$sOperation = 'apply_new';
@@ -2841,7 +2841,7 @@ JS
 			->SetOnSubmitJsCode("return OnSubmit('form_{$this->m_iFormId}');");
 		$oContentBlock->AddSubBlock($oForm);
 
-		if ($sDisplayMode === static::ENUM_DISPLAY_MODE_EDIT) {
+		if ($this->GetDisplayMode() === static::ENUM_DISPLAY_MODE_EDIT) {
 			// The object already exists in the database, it's a modification
 			$oForm->AddSubBlock(InputUIBlockFactory::MakeForHidden('id', $iKey, "{$sPrefix}_id"));
 		}
@@ -2856,7 +2856,7 @@ JS
 		// TODO 3.0.0: Is this (the if condition, not the code inside) still necessary?
 		if (isset($aExtraParams['wizard_container']) && $aExtraParams['wizard_container']) {
 			$sClassLabel = MetaModel::GetName($sClass);
-			if ($sDisplayMode == static::ENUM_DISPLAY_MODE_CREATE) {
+			if ($this->GetDisplayMode() == static::ENUM_DISPLAY_MODE_CREATE) {
 				$oPage->set_title(Dict::Format('UI:CreationPageTitle_Class', $sClassLabel)); // Set title will take care of the encoding
 			} else {
 				$oPage->set_title(Dict::Format('UI:ModificationPageTitle_Object_Class', $this->GetRawName(), $sClassLabel)); // Set title will take care of the encoding
@@ -2966,7 +2966,7 @@ EOF
 			$oObjectDetails->SetIcon($sClassIcon);
 			$oToolbarButtons->AddCSSClass('ibo-toolbar--button');
 		} else {
-			$oObjectDetails = ObjectFactory::MakeDetails($this, $sDisplayMode);
+			$oObjectDetails = ObjectFactory::MakeDetails($this, $this->GetDisplayMode());
 			$oToolbarButtons->AddCSSClass('ibo-toolbar-top');
 			$oObjectDetails->AddToolbarBlock($oToolbarButtons);
 		}
@@ -2997,7 +2997,7 @@ EOF
 		if (!is_array($aFieldsMap)) {
 			$aFieldsMap = array();
 		}
-		if ($sDisplayMode === static::ENUM_DISPLAY_MODE_EDIT) {
+		if ($this->GetDisplayMode() === static::ENUM_DISPLAY_MODE_EDIT) {
 			$aFieldsMap['id'] = $sPrefix.'_id';
 		}
 		// Now display the relations, one tab per relation

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -129,6 +129,11 @@ abstract class cmdbAbstractObject extends CMDBObject implements iDisplay
 
 	protected $m_iFormId; // The ID of the form used to edit the object (when in edition mode !)
 	protected static $iGlobalFormId = 1;
+	/**
+	 * @var string Mode in which the object is displayed {@see static::ENUM_OBJECT_MODE_VIEW}, ...)
+	 * @since 3.0.0
+	 */
+	protected $sDisplayMode;
 	protected $aFieldsMap;
 
 	/**
@@ -155,6 +160,7 @@ abstract class cmdbAbstractObject extends CMDBObject implements iDisplay
 	public function __construct($aRow = null, $sClassAlias = '', $aAttToLoad = null, $aExtendedDataSpec = null)
 	{
 		parent::__construct($aRow, $sClassAlias, $aAttToLoad, $aExtendedDataSpec);
+		$this->sDisplayMode = static::DEFAULT_OBJECT_MODE;
 		$this->bAllowWrite = false;
 		$this->bAllowDelete = false;
 	}
@@ -175,6 +181,30 @@ abstract class cmdbAbstractObject extends CMDBObject implements iDisplay
 			static::ENUM_OBJECT_MODE_CREATE,
 			static::ENUM_OBJECT_MODE_STIMULUS,
 		];
+	}
+
+	/**
+	 * @see static::$sDisplayMode
+	 * @return string
+	 * @since 3.0.0
+	 */
+	public function GetDisplayMode(): string
+	{
+		return $this->sDisplayMode;
+	}
+
+	/**
+	 * @param string $sMode
+	 *
+	 * @see static::$sDisplayMode
+	 * @return $this
+	 * @since 3.0.0
+	 */
+	public function SetDisplayMode(string $sMode)
+	{
+		$this->sDisplayMode = $sMode;
+
+		return $this;
 	}
 
 	/**
@@ -285,8 +315,7 @@ JS
 	 * To insert something IN the panel, we now need to add UIBlocks in either the "subtitle" or "toolbar" sections of the array that will be returned.
 	 *
 	 * @param \WebPage $oPage
-	 * @param bool $bEditMode
-	 * @param string $sMode Mode in which the object is displayed (see static::ENUM_OBJECT_MODE_XXX)
+	 * @param bool $bEditMode Note that this parameter is no longer used in this method, {@see static::$sDisplayMode} is used instead
 	 *
 	 * @return array UIBlocks to be inserted in the "subtitle" and the "toolbar" sections of the ObjectDetails block. eg. ['subtitle' => [<BLOCK1>, <BLOCK2>], 'toolbar' => [<BLOCK3>]]
 	 *
@@ -296,10 +325,10 @@ JS
 	 * @throws \CoreUnexpectedValue
 	 * @throws \MySQLException
 	 * @throws \OQLException
-	 * @todo 3.0.0: This has to be discussed within the R&D when I come back in 10 days
 	 *
+	 * @since 3.0.0 $bEditMode is deprecated and no longer used
 	 */
-	public function DisplayBareHeader(WebPage $oPage, $bEditMode = false, $sMode = self::ENUM_OBJECT_MODE_VIEW)
+	public function DisplayBareHeader(WebPage $oPage, $bEditMode = false)
 	{
 		$aHeaderBlocks = [
 			'subtitle' => [],
@@ -327,7 +356,7 @@ JS
 			$oPage->AddSessionMessages($sMessageKey, $aRanks, $aMessages);
 		}
 
-		if (!$oPage->IsPrintableVersion() && ($sMode === static::ENUM_OBJECT_MODE_VIEW)) {
+		if (!$oPage->IsPrintableVersion() && ($this->GetDisplayMode() === static::ENUM_OBJECT_MODE_VIEW)) {
 			// action menu
 			$oSingletonFilter = new DBObjectSearch(get_class($this));
 			$oSingletonFilter->AddCondition('id', $this->GetKey(), '=');
@@ -479,12 +508,14 @@ HTML
 	 * Display properties tab of an object
 	 *
 	 * @param \WebPage $oPage
-	 * @param bool $bEditMode
+	 * @param bool $bEditMode Note that this parameter is no longer used in this method, {@see static::$sDisplayMode} is used instead
 	 * @param string $sPrefix
 	 * @param array $aExtraParams
 	 *
 	 * @return array
 	 * @throws \CoreException
+	 *
+	 * @since 3.0.0 $bEditMode is deprecated and no longer used
 	 */
 	public function DisplayBareProperties(WebPage $oPage, $bEditMode = false, $sPrefix = '', $aExtraParams = array())
 	{
@@ -557,7 +588,7 @@ HTML
 
 	/**
 	 * @param \WebPage $oPage
-	 * @param bool $bEditMode
+	 * @param bool $bEditMode Note that this parameter is no longer used in this method, {@see static::$sDisplayMode} is used instead
 	 *
 	 * @throws \CoreException
 	 * @throws \CoreUnexpectedValue
@@ -567,6 +598,8 @@ HTML
 	 * @throws \MySQLHasGoneAwayException
 	 * @throws \OQLException
 	 * @throws \Exception
+	 *
+	 * @since 3.0.0 $bEditMode is deprecated and no longer used
 	 */
 	public function DisplayBareRelations(WebPage $oPage, $bEditMode = false)
 	{
@@ -849,7 +882,7 @@ HTML
 
 	/**
 	 * @param \WebPage $oPage
-	 * @param bool $bEditMode
+	 * @param bool $bEditMode Note that this parameter is no longer used in this method, {@see static::$sDisplayMode} is used instead
 	 * @param string $sPrefix
 	 * @param array $aExtraParams
 	 *
@@ -861,6 +894,8 @@ HTML
 	 * @throws \MySQLException
 	 * @throws \OQLException
 	 * @throws \Exception
+	 *
+	 * @since 3.0.0 $bEditMode is deprecated and no longer used
 	 */
 	public function GetBareProperties(WebPage $oPage, $bEditMode, $sPrefix, $aExtraParams = array())
 	{
@@ -1042,8 +1077,7 @@ HTML
 
 	/**
 	 * @param \WebPage $oPage
-	 * @param bool $bEditMode Note that this parameter is no longer used in ths method, $sMode is used instead, but we cannot remove it as it part of the base interface (iDisplay)...
-	 * @param string $sMode Mode in which the object will be displayed (see static::ENUM_OBJECT_MODE_XXX)
+	 * @param bool $bEditMode Note that this parameter is no longer used in this method, {@see static::$sDisplayMode} is used instead, but we cannot remove it as it part of the base interface (iDisplay)...
 	 *
 	 * @throws \ApplicationException
 	 * @throws \ArchivedObjectException
@@ -1054,8 +1088,10 @@ HTML
 	 * @throws \MySQLException
 	 * @throws \MySQLHasGoneAwayException
 	 * @throws \OQLException
+	 *
+	 * @since 3.0.0 $bEditMode is deprecated and no longer used
 	 */
-	public function DisplayDetails(WebPage $oPage, $bEditMode = false, $sMode = self::ENUM_OBJECT_MODE_VIEW)
+	public function DisplayDetails(WebPage $oPage, $bEditMode = false)
 	{
 		// N°3786: As this can now be call recursively from the self::ReloadAndDisplay(), we need to make sure we don't fall into an infinite loop
 		static $bBlockReentrance = false;
@@ -1063,7 +1099,7 @@ HTML
 		$sClass = get_class($this);
 		$iKey = $this->GetKey();
 
-		if ($sMode === static::ENUM_OBJECT_MODE_VIEW) {
+		if ($this->GetDisplayMode() === static::ENUM_OBJECT_MODE_VIEW) {
 			// The concurrent access lock makes sense only for already existing objects
 			$LockEnabled = MetaModel::GetConfig()->Get('concurrent_lock_enabled');
 			if ($LockEnabled) {
@@ -1081,14 +1117,14 @@ HTML
 		}
 
 		// Object's details
-		$oObjectDetails = ObjectFactory::MakeDetails($this);
+		$oObjectDetails = ObjectFactory::MakeDetails($this, $this->GetDisplayMode());
 		if ($oPage->IsPrintableVersion()) {
 			$oObjectDetails->SetIsHeaderVisibleOnScroll(false);
 		}
 
 		// Note: DisplayBareHeader is called before adding $oObjectDetails to the page, so it can inject HTML before it through $oPage.
 		/** @var \iTopWebPage $oPage */
-		$aHeadersBlocks = $this->DisplayBareHeader($oPage, $bEditMode, $sMode);
+		$aHeadersBlocks = $this->DisplayBareHeader($oPage, $bEditMode);
 		if (false === empty($aHeadersBlocks['subtitle'])) {
 			$oObjectDetails->AddSubTitleBlocks($aHeadersBlocks['subtitle']);
 		}
@@ -2697,10 +2733,11 @@ JS
 		$sOwnershipToken = null;
 		$iKey = $this->GetKey();
 		$sClass = get_class($this);
-		$sMode = ($iKey > 0) ? static::ENUM_OBJECT_MODE_EDIT : static::ENUM_OBJECT_MODE_CREATE;
 
+		$this->SetDisplayMode(($iKey > 0) ? static::ENUM_OBJECT_MODE_EDIT : static::ENUM_OBJECT_MODE_CREATE);
+		$sDisplayMode = $this->GetDisplayMode();
 
-		if ($sMode === static::ENUM_OBJECT_MODE_EDIT)
+		if ($sDisplayMode === static::ENUM_OBJECT_MODE_EDIT)
 		{
 			// The concurrent access lock makes sense only for already existing objects
 			$LockEnabled = MetaModel::GetConfig()->Get('concurrent_lock_enabled');
@@ -2750,7 +2787,7 @@ JS
 		if (isset($aExtraParams['custom_button'])) {
 			$sApplyButton = $aExtraParams['custom_button'];
 		} else {
-			if ($sMode === static::ENUM_OBJECT_MODE_EDIT) {
+			if ($sDisplayMode === static::ENUM_OBJECT_MODE_EDIT) {
 				$sApplyButton = Dict::S('UI:Button:Apply');
 			} else {
 				$sApplyButton = Dict::S('UI:Button:Create');
@@ -2760,7 +2797,7 @@ JS
 		if (isset($aExtraParams['custom_operation'])) {
 			$sOperation = $aExtraParams['custom_operation'];
 		} else {
-			if ($sMode === static::ENUM_OBJECT_MODE_EDIT) {
+			if ($sDisplayMode === static::ENUM_OBJECT_MODE_EDIT) {
 				$sOperation = 'apply_modify';
 			} else {
 				$sOperation = 'apply_new';
@@ -2775,7 +2812,7 @@ JS
 			->SetOnSubmitJsCode("return OnSubmit('form_{$this->m_iFormId}');");
 		$oContentBlock->AddSubBlock($oForm);
 
-		if ($sMode === static::ENUM_OBJECT_MODE_EDIT) {
+		if ($sDisplayMode === static::ENUM_OBJECT_MODE_EDIT) {
 			// The object already exists in the database, it's a modification
 			$oForm->AddSubBlock(InputUIBlockFactory::MakeForHidden('id', $iKey, "{$sPrefix}_id"));
 		}
@@ -2790,7 +2827,7 @@ JS
 		// TODO 3.0.0: Is this (the if condition, not the code inside) still necessary?
 		if (isset($aExtraParams['wizard_container']) && $aExtraParams['wizard_container']) {
 			$sClassLabel = MetaModel::GetName($sClass);
-			if ($sMode == static::ENUM_OBJECT_MODE_CREATE) {
+			if ($sDisplayMode == static::ENUM_OBJECT_MODE_CREATE) {
 				$oPage->set_title(Dict::Format('UI:CreationPageTitle_Class', $sClassLabel)); // Set title will take care of the encoding
 			} else {
 				$oPage->set_title(Dict::Format('UI:ModificationPageTitle_Object_Class', $this->GetRawName(), $sClassLabel)); // Set title will take care of the encoding
@@ -2900,7 +2937,7 @@ EOF
 			$oObjectDetails->SetIcon($sClassIcon);
 			$oToolbarButtons->AddCSSClass('ibo-toolbar--button');
 		} else {
-			$oObjectDetails = ObjectFactory::MakeDetails($this, $sMode);
+			$oObjectDetails = ObjectFactory::MakeDetails($this, $sDisplayMode);
 			$oToolbarButtons->AddCSSClass('ibo-toolbar-top');
 			$oObjectDetails->AddToolbarBlock($oToolbarButtons);
 		}
@@ -2931,7 +2968,7 @@ EOF
 		if (!is_array($aFieldsMap)) {
 			$aFieldsMap = array();
 		}
-		if ($sMode === static::ENUM_OBJECT_MODE_EDIT) {
+		if ($sDisplayMode === static::ENUM_OBJECT_MODE_EDIT) {
 			$aFieldsMap['id'] = $sPrefix.'_id';
 		}
 		// Now display the relations, one tab per relation
@@ -3122,6 +3159,7 @@ EOF
 		} else {
 			$oObj = clone $oSourceObject;
 		}
+		$oObj->SetDisplayMode(static::ENUM_OBJECT_MODE_CREATE);
 
 		// Pre-fill the object with default values, when there is only on possible choice
 		// AND the field is mandatory (otherwise there is always the possiblity to let it empty)
@@ -3177,10 +3215,10 @@ EOF
 	}
 
 	/**
-	 * @param \WebPage $oPage
-	 * @param string   $sStimulus
-	 * @param null     $aPrefillFormParam
-	 * @param bool     $bDisplayBareProperties Whether to display the object details or not
+	 * @param \WebPage      $oPage
+	 * @param string        $sStimulus
+	 * @param array|null    $aPrefillFormParam
+	 * @param bool          $bDisplayBareProperties Whether to display the object details or not
 	 *
 	 * @throws \ApplicationException
 	 * @throws \ArchivedObjectException
@@ -3194,9 +3232,11 @@ EOF
 	 */
 	public function DisplayStimulusForm(WebPage $oPage, $sStimulus, $aPrefillFormParam = null, $bDisplayBareProperties = true)
 	{
+		$this->SetDisplayMode(static::ENUM_OBJECT_MODE_STIMULUS);
+
 		$sClass = get_class($this);
 		$iKey = $this->GetKey();
-		$sMode = static::ENUM_OBJECT_MODE_STIMULUS;
+		$sDisplayMode = $this->GetDisplayMode();
 		$iTransactionId = utils::GetNewTransactionId();
 
 		$aTransitions = $this->EnumTransitions();
@@ -3352,7 +3392,7 @@ EOF
 			$oPage->set_title($sActionLabel);
 			$oPage->add(<<<HTML
 	<!-- Beginning of object-transition -->
-	<div class="object-transition" data-object-class="$sClass" data-object-id="$iKey" data-object-mode="$sMode" data-object-current-state="$sCurrentState" data-object-target-state="$sTargetState">
+	<div class="object-transition" data-object-class="$sClass" data-object-id="$iKey" data-object-mode="$sDisplayMode" data-object-current-state="$sCurrentState" data-object-target-state="$sTargetState">
 HTML
 			);
 
@@ -4910,6 +4950,7 @@ HTML
 			// Now create an object that has values for the homogeneous values only
 			/** @var \cmdbAbstractObject $oDummyObj */
 			$oDummyObj = new $sClass(); // @@ What if the class is abstract ?
+			$oDummyObj->SetDisplayMode(static::ENUM_OBJECT_MODE_EDIT);
 			$aComments = array();
 			function MyComparison($a, $b) // Sort descending
 			{

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -71,16 +71,36 @@ require_once(APPROOT.'sources/application/search/criterionconversion/criterionto
  */
 abstract class cmdbAbstractObject extends CMDBObject implements iDisplay
 {
-	/** @var string ENUM_OBJECT_MODE_VIEW */
-	public const ENUM_OBJECT_MODE_VIEW = 'view';
-	/** @var string ENUM_OBJECT_MODE_EDIT */
-	public const ENUM_OBJECT_MODE_EDIT = 'edit';
-	/** @var string ENUM_OBJECT_MODE_CREATE */
-	public const ENUM_OBJECT_MODE_CREATE = 'create';
-	/** @var string ENUM_OBJECT_MODE_STIMULUS */
-	public const ENUM_OBJECT_MODE_STIMULUS = 'stimulus';
-	/** @var string ENUM_OBJECT_MODE_PRINT */
-	public const ENUM_OBJECT_MODE_PRINT = 'print';
+	/**
+	 * @var string
+	 * @see static::$sDisplayMode
+	 * @since 3.0.0
+	 */
+	public const ENUM_DISPLAY_MODE_VIEW = 'view';
+	/**
+	 * @var string
+	 * @see static::$sDisplayMode
+	 * @since 3.0.0
+	 */
+	public const ENUM_DISPLAY_MODE_EDIT = 'edit';
+	/**
+	 * @var string
+	 * @see static::$sDisplayMode
+	 * @since 3.0.0
+	 */
+	public const ENUM_DISPLAY_MODE_CREATE = 'create';
+	/**
+	 * @var string
+	 * @see static::$sDisplayMode
+	 * @since 3.0.0
+	 */
+	public const ENUM_DISPLAY_MODE_STIMULUS = 'stimulus';
+	/**
+	 * @var string
+	 * @see static::$sDisplayMode
+	 * @since 3.0.0
+	 */
+	public const ENUM_DISPLAY_MODE_PRINT = 'print';
 
 	// N°3750 rendering used
 	/** @var string */
@@ -115,10 +135,11 @@ abstract class cmdbAbstractObject extends CMDBObject implements iDisplay
 	public const ENUM_INPUT_TYPE_LINKEDSET = 'linkedset';
 
 	/**
-	 * @var string DEFAULT_OBJECT_MODE
+	 * @var string DEFAULT_DISPLAY_MODE
+	 * @see static::$sDisplayMode
 	 * @since 3.0.0
 	 */
-	public const DEFAULT_OBJECT_MODE = self::ENUM_OBJECT_MODE_VIEW;
+	public const DEFAULT_DISPLAY_MODE = self::ENUM_DISPLAY_MODE_VIEW;
 
 	/**
 	 * @var string Prefix for tags in the subtitle, allows to identify them more easily
@@ -130,7 +151,7 @@ abstract class cmdbAbstractObject extends CMDBObject implements iDisplay
 	protected $m_iFormId; // The ID of the form used to edit the object (when in edition mode !)
 	protected static $iGlobalFormId = 1;
 	/**
-	 * @var string Mode in which the object is displayed {@see static::ENUM_OBJECT_MODE_VIEW}, ...)
+	 * @var string Mode in which the object is displayed {@see static::ENUM_DISPLAY_MODE_VIEW}, ...)
 	 * @since 3.0.0
 	 */
 	protected $sDisplayMode;
@@ -160,7 +181,7 @@ abstract class cmdbAbstractObject extends CMDBObject implements iDisplay
 	public function __construct($aRow = null, $sClassAlias = '', $aAttToLoad = null, $aExtendedDataSpec = null)
 	{
 		parent::__construct($aRow, $sClassAlias, $aAttToLoad, $aExtendedDataSpec);
-		$this->sDisplayMode = static::DEFAULT_OBJECT_MODE;
+		$this->sDisplayMode = static::DEFAULT_DISPLAY_MODE;
 		$this->bAllowWrite = false;
 		$this->bAllowDelete = false;
 	}
@@ -168,7 +189,7 @@ abstract class cmdbAbstractObject extends CMDBObject implements iDisplay
 	/**
 	 * Return the allowed object modes
 	 *
-	 * @see static::ENUM_OBJECT_MODE_XXX
+	 * @see static::ENUM_DISPLAY_MODE_XXX
 	 *
 	 * @return string[]
 	 * @since 3.0.0
@@ -176,10 +197,10 @@ abstract class cmdbAbstractObject extends CMDBObject implements iDisplay
 	public static function EnumObjectModes(): array
 	{
 		return [
-			static::ENUM_OBJECT_MODE_VIEW,
-			static::ENUM_OBJECT_MODE_EDIT,
-			static::ENUM_OBJECT_MODE_CREATE,
-			static::ENUM_OBJECT_MODE_STIMULUS,
+			static::ENUM_DISPLAY_MODE_VIEW,
+			static::ENUM_DISPLAY_MODE_EDIT,
+			static::ENUM_DISPLAY_MODE_CREATE,
+			static::ENUM_DISPLAY_MODE_STIMULUS,
 		];
 	}
 
@@ -315,7 +336,7 @@ JS
 	 * To insert something IN the panel, we now need to add UIBlocks in either the "subtitle" or "toolbar" sections of the array that will be returned.
 	 *
 	 * @param \WebPage $oPage
-	 * @param bool $bEditMode Note that this parameter is no longer used in this method, {@see static::$sDisplayMode} is used instead
+	 * @param bool $bEditMode Note that this parameter is no longer used in this method. Use {@see static::$sDisplayMode} instead
 	 *
 	 * @return array UIBlocks to be inserted in the "subtitle" and the "toolbar" sections of the ObjectDetails block. eg. ['subtitle' => [<BLOCK1>, <BLOCK2>], 'toolbar' => [<BLOCK3>]]
 	 *
@@ -356,7 +377,7 @@ JS
 			$oPage->AddSessionMessages($sMessageKey, $aRanks, $aMessages);
 		}
 
-		if (!$oPage->IsPrintableVersion() && ($this->GetDisplayMode() === static::ENUM_OBJECT_MODE_VIEW)) {
+		if (!$oPage->IsPrintableVersion() && ($this->GetDisplayMode() === static::ENUM_DISPLAY_MODE_VIEW)) {
 			// action menu
 			$oSingletonFilter = new DBObjectSearch(get_class($this));
 			$oSingletonFilter->AddCondition('id', $this->GetKey(), '=');
@@ -508,7 +529,7 @@ HTML
 	 * Display properties tab of an object
 	 *
 	 * @param \WebPage $oPage
-	 * @param bool $bEditMode Note that this parameter is no longer used in this method, {@see static::$sDisplayMode} is used instead
+	 * @param bool $bEditMode Note that this parameter is no longer used in this method. Use {@see static::$sDisplayMode} instead
 	 * @param string $sPrefix
 	 * @param array $aExtraParams
 	 *
@@ -588,7 +609,7 @@ HTML
 
 	/**
 	 * @param \WebPage $oPage
-	 * @param bool $bEditMode Note that this parameter is no longer used in this method, {@see static::$sDisplayMode} is used instead
+	 * @param bool $bEditMode Note that this parameter is no longer used in this method. Use {@see static::$sDisplayMode} instead
 	 *
 	 * @throws \CoreException
 	 * @throws \CoreUnexpectedValue
@@ -882,7 +903,7 @@ HTML
 
 	/**
 	 * @param \WebPage $oPage
-	 * @param bool $bEditMode Note that this parameter is no longer used in this method, {@see static::$sDisplayMode} is used instead
+	 * @param bool $bEditMode Note that this parameter is no longer used in this method. Use {@see static::$sDisplayMode} instead
 	 * @param string $sPrefix
 	 * @param array $aExtraParams
 	 *
@@ -1099,7 +1120,7 @@ HTML
 		$sClass = get_class($this);
 		$iKey = $this->GetKey();
 
-		if ($this->GetDisplayMode() === static::ENUM_OBJECT_MODE_VIEW) {
+		if ($this->GetDisplayMode() === static::ENUM_DISPLAY_MODE_VIEW) {
 			// The concurrent access lock makes sense only for already existing objects
 			$LockEnabled = MetaModel::GetConfig()->Get('concurrent_lock_enabled');
 			if ($LockEnabled) {
@@ -2734,10 +2755,10 @@ JS
 		$iKey = $this->GetKey();
 		$sClass = get_class($this);
 
-		$this->SetDisplayMode(($iKey > 0) ? static::ENUM_OBJECT_MODE_EDIT : static::ENUM_OBJECT_MODE_CREATE);
+		$this->SetDisplayMode(($iKey > 0) ? static::ENUM_DISPLAY_MODE_EDIT : static::ENUM_DISPLAY_MODE_CREATE);
 		$sDisplayMode = $this->GetDisplayMode();
 
-		if ($sDisplayMode === static::ENUM_OBJECT_MODE_EDIT)
+		if ($sDisplayMode === static::ENUM_DISPLAY_MODE_EDIT)
 		{
 			// The concurrent access lock makes sense only for already existing objects
 			$LockEnabled = MetaModel::GetConfig()->Get('concurrent_lock_enabled');
@@ -2787,7 +2808,7 @@ JS
 		if (isset($aExtraParams['custom_button'])) {
 			$sApplyButton = $aExtraParams['custom_button'];
 		} else {
-			if ($sDisplayMode === static::ENUM_OBJECT_MODE_EDIT) {
+			if ($sDisplayMode === static::ENUM_DISPLAY_MODE_EDIT) {
 				$sApplyButton = Dict::S('UI:Button:Apply');
 			} else {
 				$sApplyButton = Dict::S('UI:Button:Create');
@@ -2797,7 +2818,7 @@ JS
 		if (isset($aExtraParams['custom_operation'])) {
 			$sOperation = $aExtraParams['custom_operation'];
 		} else {
-			if ($sDisplayMode === static::ENUM_OBJECT_MODE_EDIT) {
+			if ($sDisplayMode === static::ENUM_DISPLAY_MODE_EDIT) {
 				$sOperation = 'apply_modify';
 			} else {
 				$sOperation = 'apply_new';
@@ -2812,7 +2833,7 @@ JS
 			->SetOnSubmitJsCode("return OnSubmit('form_{$this->m_iFormId}');");
 		$oContentBlock->AddSubBlock($oForm);
 
-		if ($sDisplayMode === static::ENUM_OBJECT_MODE_EDIT) {
+		if ($sDisplayMode === static::ENUM_DISPLAY_MODE_EDIT) {
 			// The object already exists in the database, it's a modification
 			$oForm->AddSubBlock(InputUIBlockFactory::MakeForHidden('id', $iKey, "{$sPrefix}_id"));
 		}
@@ -2827,7 +2848,7 @@ JS
 		// TODO 3.0.0: Is this (the if condition, not the code inside) still necessary?
 		if (isset($aExtraParams['wizard_container']) && $aExtraParams['wizard_container']) {
 			$sClassLabel = MetaModel::GetName($sClass);
-			if ($sDisplayMode == static::ENUM_OBJECT_MODE_CREATE) {
+			if ($sDisplayMode == static::ENUM_DISPLAY_MODE_CREATE) {
 				$oPage->set_title(Dict::Format('UI:CreationPageTitle_Class', $sClassLabel)); // Set title will take care of the encoding
 			} else {
 				$oPage->set_title(Dict::Format('UI:ModificationPageTitle_Object_Class', $this->GetRawName(), $sClassLabel)); // Set title will take care of the encoding
@@ -2968,7 +2989,7 @@ EOF
 		if (!is_array($aFieldsMap)) {
 			$aFieldsMap = array();
 		}
-		if ($sDisplayMode === static::ENUM_OBJECT_MODE_EDIT) {
+		if ($sDisplayMode === static::ENUM_DISPLAY_MODE_EDIT) {
 			$aFieldsMap['id'] = $sPrefix.'_id';
 		}
 		// Now display the relations, one tab per relation
@@ -3159,7 +3180,7 @@ EOF
 		} else {
 			$oObj = clone $oSourceObject;
 		}
-		$oObj->SetDisplayMode(static::ENUM_OBJECT_MODE_CREATE);
+		$oObj->SetDisplayMode(static::ENUM_DISPLAY_MODE_CREATE);
 
 		// Pre-fill the object with default values, when there is only on possible choice
 		// AND the field is mandatory (otherwise there is always the possiblity to let it empty)
@@ -3232,7 +3253,7 @@ EOF
 	 */
 	public function DisplayStimulusForm(WebPage $oPage, $sStimulus, $aPrefillFormParam = null, $bDisplayBareProperties = true)
 	{
-		$this->SetDisplayMode(static::ENUM_OBJECT_MODE_STIMULUS);
+		$this->SetDisplayMode(static::ENUM_DISPLAY_MODE_STIMULUS);
 
 		$sClass = get_class($this);
 		$iKey = $this->GetKey();
@@ -4950,7 +4971,7 @@ HTML
 			// Now create an object that has values for the homogeneous values only
 			/** @var \cmdbAbstractObject $oDummyObj */
 			$oDummyObj = new $sClass(); // @@ What if the class is abstract ?
-			$oDummyObj->SetDisplayMode(static::ENUM_OBJECT_MODE_EDIT);
+			$oDummyObj->SetDisplayMode(static::ENUM_DISPLAY_MODE_EDIT);
 			$aComments = array();
 			function MyComparison($a, $b) // Sort descending
 			{

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -414,7 +414,7 @@ try
 
 					$sClassLabel = MetaModel::GetName($sClass);
 					$oP->set_title(Dict::Format('UI:DetailsPageTitle', $oObj->GetRawName(), $sClassLabel)); // Set title will take care of the encoding
-					$oP->SetContentLayout(PageContentFactory::MakeForObjectDetails($oObj, $oP->IsPrintableVersion() ? cmdbAbstractObject::ENUM_OBJECT_MODE_PRINT : cmdbAbstractObject::ENUM_OBJECT_MODE_VIEW));
+					$oP->SetContentLayout(PageContentFactory::MakeForObjectDetails($oObj, $oP->IsPrintableVersion() ? cmdbAbstractObject::ENUM_DISPLAY_MODE_PRINT : cmdbAbstractObject::ENUM_DISPLAY_MODE_VIEW));
 					$oObj->DisplayDetails($oP);
 				}
 			}
@@ -435,7 +435,7 @@ try
 			iTopOwnershipLock::ReleaseLock($sClass, $id, $sToken);
 		}
 
-		$oP->SetContentLayout(PageContentFactory::MakeForObjectDetails($oObj, cmdbAbstractObject::ENUM_OBJECT_MODE_VIEW));
+		$oP->SetContentLayout(PageContentFactory::MakeForObjectDetails($oObj, cmdbAbstractObject::ENUM_DISPLAY_MODE_VIEW));
 		cmdbAbstractObject::ReloadAndDisplay($oP, $oObj, array('operation' => 'details'));
 		break;
 	
@@ -668,7 +668,7 @@ EOF
 				if (UserRights::IsActionAllowed($sClass, UR_ACTION_MODIFY, $oSet) == UR_ALLOWED_NO) {
 					throw new SecurityException('User not allowed to modify this object', array('class' => $sClass, 'id' => $id));
 				}
-				$oP->SetContentLayout(PageContentFactory::MakeForObjectDetails($oObj, cmdbAbstractObject::ENUM_OBJECT_MODE_EDIT));
+				$oP->SetContentLayout(PageContentFactory::MakeForObjectDetails($oObj, cmdbAbstractObject::ENUM_DISPLAY_MODE_EDIT));
 				// Note: code duplicated to the case 'apply_modify' when a data integrity issue has been found
 				$oObj->DisplayModifyForm($oP, array('wizard_container' => 1)); // wizard_container: Display the title above the form
 			}
@@ -760,7 +760,7 @@ EOF
 				$sHeaderTitle = Dict::Format('UI:CreationTitle_Class', $sClassLabel);
 				// Note: some code has been duplicated to the case 'apply_new' when a data integrity issue has been found
 				$oP->set_title(Dict::Format('UI:CreationPageTitle_Class', $sClassLabel));
-				$oP->SetContentLayout(PageContentFactory::MakeForObjectDetails($oObjToClone, cmdbAbstractObject::ENUM_OBJECT_MODE_CREATE));
+				$oP->SetContentLayout(PageContentFactory::MakeForObjectDetails($oObjToClone, cmdbAbstractObject::ENUM_DISPLAY_MODE_CREATE));
 				cmdbAbstractObject::DisplayCreationForm($oP, $sRealClass, $oObjToClone, array(), array('wizard_container' => 1, 'keep_source_object' => true)); // wizard_container: Display the title above the form
 			} else {
 				// Select the derived class to create

--- a/sources/application/UI/Base/Layout/ActivityPanel/ActivityPanel.php
+++ b/sources/application/UI/Base/Layout/ActivityPanel/ActivityPanel.php
@@ -62,11 +62,11 @@ class ActivityPanel extends UIBlock
 	/** @var \DBObject $oObject The object for which the activity panel is for */
 	protected $oObject;
 	/**
-	 * @see \cmdbAbstractObject::ENUM_OBJECT_MODE_XXX
+	 * @see \cmdbAbstractObject::ENUM_DISPLAY_MODE_XXX
 	 * @var string $sObjectMode Display mode of $oObject (create, edit, view, ...)
 	 */
 	protected $sObjectMode;
-	/** @var null|string $sTransactionId Only when $sObjectMode is set to \cmdbAbstractObject::ENUM_OBJECT_MODE_VIEW */
+	/** @var null|string $sTransactionId Only when $sObjectMode is set to \cmdbAbstractObject::ENUM_DISPLAY_MODE_VIEW */
 	protected $sTransactionId;
 	/** @var array $aCaseLogs Metadata of the case logs (att. code, color, ...), will be use to make the tabs and identify them easily */
 	protected $aCaseLogs;
@@ -107,7 +107,7 @@ class ActivityPanel extends UIBlock
 		$this->InitializeCaseLogTabs();
 		$this->InitializeCaseLogTabsEntryForms();
 		$this->InitializeComposeMenu();
-		$this->SetObjectMode(cmdbAbstractObject::DEFAULT_OBJECT_MODE);
+		$this->SetObjectMode(cmdbAbstractObject::DEFAULT_DISPLAY_MODE);
 		$this->SetObject($oObject);
 		$this->SetEntries($aEntries);
 		$this->bAreEntriesSorted = false;
@@ -184,7 +184,7 @@ class ActivityPanel extends UIBlock
 	 * Set the display mode of the $oObject
 	 *
 	 * @param string $sMode
-	 * @see cmdbAbstractObject::ENUM_OBJECT_MODE_XXX
+	 * @see cmdbAbstractObject::ENUM_DISPLAY_MODE_XXX
 	 *
 	 * @return $this
 	 * @throws \Exception
@@ -204,7 +204,7 @@ class ActivityPanel extends UIBlock
 	/**
 	 * Return the display mode of the $oObject
 	 *
-	 * @see cmdbAbstractObject::ENUM_OBJECT_MODE_XXX
+	 * @see cmdbAbstractObject::ENUM_DISPLAY_MODE_XXX
 	 * @return string
 	 */
 	public function GetObjectMode(): string
@@ -260,13 +260,13 @@ class ActivityPanel extends UIBlock
 
 	/**
 	 * @return bool True if the lock mechanism has to be enabled
-	 * @uses \cmdbAbstractObject::ENUM_OBJECT_MODE_VIEW
+	 * @uses \cmdbAbstractObject::ENUM_DISPLAY_MODE_VIEW
 	 * @uses static::HasAnEditableCaseLogTab()
 	 * @uses "concurrent_lock_enabled" config. param.
 	 */
 	public function IsLockEnabled(): bool
 	{
-		return (cmdbAbstractObject::ENUM_OBJECT_MODE_VIEW === $this->sObjectMode) && (MetaModel::GetConfig()->Get('concurrent_lock_enabled')) && (true === $this->HasAnEditableCaseLogTab());
+		return (cmdbAbstractObject::ENUM_DISPLAY_MODE_VIEW === $this->sObjectMode) && (MetaModel::GetConfig()->Get('concurrent_lock_enabled')) && (true === $this->HasAnEditableCaseLogTab());
 	}
 
 	/**
@@ -567,8 +567,8 @@ class ActivityPanel extends UIBlock
 				// - There is a least 1 *writable* case log
 				// - And object is in view mode (in edit mode, it will be handled by the general form)
 				// Otherwise we generate unnecessary transaction IDs that could saturate the system
-				if ((false === $bIsReadOnly) && (false === $this->HasTransactionId()) && (cmdbAbstractObject::ENUM_OBJECT_MODE_VIEW === $this->sObjectMode)) {
-					$this->sTransactionId = (cmdbAbstractObject::ENUM_OBJECT_MODE_VIEW === $this->sObjectMode) ? utils::GetNewTransactionId() : null;
+				if ((false === $bIsReadOnly) && (false === $this->HasTransactionId()) && (cmdbAbstractObject::ENUM_DISPLAY_MODE_VIEW === $this->sObjectMode)) {
+					$this->sTransactionId = (cmdbAbstractObject::ENUM_DISPLAY_MODE_VIEW === $this->sObjectMode) ? utils::GetNewTransactionId() : null;
 				}
 
 				// Add log to compose button menu only if it is editable

--- a/sources/application/UI/Base/Layout/ActivityPanel/ActivityPanelFactory.php
+++ b/sources/application/UI/Base/Layout/ActivityPanel/ActivityPanelFactory.php
@@ -43,7 +43,7 @@ class ActivityPanelFactory
 	/**
 	 * Make an activity panel for an object details layout, meaning that it should contain the case logs and the activity.
 	 *
-	 * @see cmdbAbstractObject::ENUM_OBJECT_MODE_XXX
+	 * @see cmdbAbstractObject::ENUM_DISPLAY_MODE_XXX
 	 *
 	 * @param \DBObject $oObject
 	 * @param string $sMode Mode the object is being displayed (view, edit, create, ...), default is view.
@@ -56,14 +56,14 @@ class ActivityPanelFactory
 	 * @throws \MySQLException
 	 * @throws \OQLException
 	 */
-	public static function MakeForObjectDetails(DBObject $oObject, string $sMode = cmdbAbstractObject::DEFAULT_OBJECT_MODE)
+	public static function MakeForObjectDetails(DBObject $oObject, string $sMode = cmdbAbstractObject::DEFAULT_DISPLAY_MODE)
 	{
 		$sObjClass = get_class($oObject);
 		$sObjId = $oObject->GetKey();
 
-		if ($sMode == cmdbAbstractObject::ENUM_OBJECT_MODE_PRINT) {
+		if ($sMode == cmdbAbstractObject::ENUM_DISPLAY_MODE_PRINT) {
 			$oActivityPanel = new ActivityPanelPrint($oObject, [], ActivityPanel::BLOCK_CODE);
-			$sMode = cmdbAbstractObject::ENUM_OBJECT_MODE_VIEW;
+			$sMode = cmdbAbstractObject::ENUM_DISPLAY_MODE_VIEW;
 		} else {
 			$oActivityPanel = new ActivityPanel($oObject, [], ActivityPanel::BLOCK_CODE);
 		}

--- a/sources/application/UI/Base/Layout/ActivityPanel/CaseLogEntryForm/CaseLogEntryForm.php
+++ b/sources/application/UI/Base/Layout/ActivityPanel/CaseLogEntryForm/CaseLogEntryForm.php
@@ -143,20 +143,20 @@ class CaseLogEntryForm extends UIContentBlock
 	 *
 	 * @param string $sObjectMode
 	 * @see $sSubmitMode
-	 * @see cmdbAbstractObject::ENUM_OBJECT_MODE_XXX
+	 * @see cmdbAbstractObject::ENUM_DISPLAY_MODE_XXX
 	 *
 	 * @return $this
 	 */
 	public function SetSubmitModeFromHostObjectMode($sObjectMode)
 	{
 		switch ($sObjectMode){
-			case cmdbAbstractObject::ENUM_OBJECT_MODE_CREATE:
-			case cmdbAbstractObject::ENUM_OBJECT_MODE_EDIT:
+			case cmdbAbstractObject::ENUM_DISPLAY_MODE_CREATE:
+			case cmdbAbstractObject::ENUM_DISPLAY_MODE_EDIT:
 				$sSubmitMode = static::ENUM_SUBMIT_MODE_BRIDGED;
 				break;
 
-			case cmdbAbstractObject::ENUM_OBJECT_MODE_VIEW:
-			case cmdbAbstractObject::ENUM_OBJECT_MODE_STIMULUS:
+			case cmdbAbstractObject::ENUM_DISPLAY_MODE_VIEW:
+			case cmdbAbstractObject::ENUM_DISPLAY_MODE_STIMULUS:
 			default:
 				$sSubmitMode = static::ENUM_SUBMIT_MODE_AUTONOMOUS;
 				break;

--- a/sources/application/UI/Base/Layout/ActivityPanel/CaseLogEntryForm/CaseLogEntryFormFactory.php
+++ b/sources/application/UI/Base/Layout/ActivityPanel/CaseLogEntryForm/CaseLogEntryFormFactory.php
@@ -33,7 +33,7 @@ use UserRights;
  */
 class CaseLogEntryFormFactory
 {
-	public static function MakeForCaselogTab(DBObject $oObject, string $sCaseLogAttCode, string $sObjectMode = cmdbAbstractObject::DEFAULT_OBJECT_MODE)
+	public static function MakeForCaselogTab(DBObject $oObject, string $sCaseLogAttCode, string $sObjectMode = cmdbAbstractObject::DEFAULT_DISPLAY_MODE)
 	{
 		$oCaseLogEntryForm = new CaseLogEntryForm($oObject, $sCaseLogAttCode);
 		$oCaseLogEntryForm->SetSubmitModeFromHostObjectMode($sObjectMode)

--- a/sources/application/UI/Base/Layout/Object/ObjectDetails.php
+++ b/sources/application/UI/Base/Layout/Object/ObjectDetails.php
@@ -54,7 +54,7 @@ class ObjectDetails extends Panel implements iKeyboardShortcut
 	protected $sObjectName;
 	/**
 	 * @var string The mode in which the object should be displayed (read, edit, create, ...)
-	 * @see \cmdbAbstractObject::ENUM_OBJECT_MODE_XXX
+	 * @see \cmdbAbstractObject::ENUM_DISPLAY_MODE_XXX
 	 */
 	protected $sObjectMode;
 	/** @var string */
@@ -70,14 +70,14 @@ class ObjectDetails extends Panel implements iKeyboardShortcut
 	 * ObjectDetails constructor.
 	 *
 	 * @param \DBObject $oObject The object for which we display the details
-	 * @param string $sMode See \cmdbAbstractObject::ENUM_OBJECT_MODE_XXX
+	 * @param string $sMode See \cmdbAbstractObject::ENUM_DISPLAY_MODE_XXX
 	 * @param string|null $sId ID of the block itself, not the $oObject ID
 	 *
 	 * @throws \ArchivedObjectException
 	 * @throws \CoreException
 	 * @throws \DictExceptionMissingString
 	 */
-	public function __construct(DBObject $oObject, string $sMode = cmdbAbstractObject::DEFAULT_OBJECT_MODE, ?string $sId = null)
+	public function __construct(DBObject $oObject, string $sMode = cmdbAbstractObject::DEFAULT_DISPLAY_MODE, ?string $sId = null)
 	{
 		$this->sClassName = get_class($oObject);
 		$this->sClassLabel = MetaModel::GetName($this->GetClassName());
@@ -252,7 +252,7 @@ class ObjectDetails extends Panel implements iKeyboardShortcut
 	 */
 	protected function ComputeObjectName(DBObject $oObject): void
 	{
-		if ($this->sObjectMode === cmdbAbstractObject::ENUM_OBJECT_MODE_CREATE) {
+		if ($this->sObjectMode === cmdbAbstractObject::ENUM_DISPLAY_MODE_CREATE) {
 			$this->sObjectName = Dict::Format('UI:CreationTitle_Class', $this->sClassLabel);
 		} else {
 			$this->sObjectName = $oObject->GetRawName();

--- a/sources/application/UI/Base/Layout/Object/ObjectFactory.php
+++ b/sources/application/UI/Base/Layout/Object/ObjectFactory.php
@@ -29,7 +29,7 @@ class ObjectFactory
 	 * @return \Combodo\iTop\Application\UI\Base\Layout\Object\ObjectDetails
 	 * @throws \CoreException
 	 */
-	public static function MakeDetails(DBObject $oObject, ?string $sMode = cmdbAbstractObject::DEFAULT_OBJECT_MODE)
+	public static function MakeDetails(DBObject $oObject, ?string $sMode = cmdbAbstractObject::DEFAULT_DISPLAY_MODE)
 	{
 		$oObjectDetails = new ObjectDetails($oObject, $sMode);
 		$oObjectDetails->SetIsHeaderVisibleOnScroll(true);

--- a/sources/application/UI/Base/Layout/PageContent/PageContentFactory.php
+++ b/sources/application/UI/Base/Layout/PageContent/PageContentFactory.php
@@ -51,12 +51,12 @@ class PageContentFactory
 	 * @param \DBObject   $oObject
 	 * @param string      $sMode Mode the object is being displayed (view, edit, create, ...), default is view.
 	 *
-	 * @see cmdbAbstractObject::ENUM_OBJECT_MODE_XXX
+	 * @see cmdbAbstractObject::ENUM_DISPLAY_MODE_XXX
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Layout\PageContent\PageContentWithSideContent
 	 * @throws \CoreException
 	 */
-	public static function MakeForObjectDetails(DBObject $oObject, string $sMode = cmdbAbstractObject::DEFAULT_OBJECT_MODE)
+	public static function MakeForObjectDetails(DBObject $oObject, string $sMode = cmdbAbstractObject::DEFAULT_DISPLAY_MODE)
 	{
 		$oLayout = new PageContentWithSideContent();
 

--- a/templates/base/layouts/object/object-details/layout.js.twig
+++ b/templates/base/layouts/object/object-details/layout.js.twig
@@ -50,11 +50,11 @@
                 }
             }
         });
-        {% if oUIBlock.GetObjectMode() == constant('cmdbAbstractObject::ENUM_OBJECT_MODE_EDIT') or oUIBlock.GetObjectMode() == constant('cmdbAbstractObject::ENUM_OBJECT_MODE_CREATE') %}
+        {% if oUIBlock.GetObjectMode() == constant('cmdbAbstractObject::ENUM_DISPLAY_MODE_EDIT') or oUIBlock.GetObjectMode() == constant('cmdbAbstractObject::ENUM_DISPLAY_MODE_CREATE') %}
             $('#{{ oUIBlock.GetId() }}').on('save_object', function(){
                 $(this).find('button[type="submit"][name=""][value=""]').click();
             });
-        {% elseif oUIBlock.GetObjectMode() == constant('cmdbAbstractObject::ENUM_OBJECT_MODE_STIMULUS') %}
+        {% elseif oUIBlock.GetObjectMode() == constant('cmdbAbstractObject::ENUM_DISPLAY_MODE_STIMULUS') %}
             $('#{{ oUIBlock.GetId() }}').on('save_object', function(){
                 $(this).find('button[type="submit"][name="submit"][value="submit"]').click();
             });


### PR DESCRIPTION
During 3.0.0 development I added an $sMode parameter to some of the cmdbAbstractObject class' methods.
It broke the compatibility with some extensions that were overloading the methods in their DM classes.

When discussed a few months ago, we decided to put that "display mode" in a class property instead, this PR aims at that.