### PR TITLE
Add uniqueness rule to lnkContactToFunctionalCI

### DIFF
--- a/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
+++ b/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
@@ -4443,6 +4443,14 @@
 						<attribute id="contact_id"/>
 					</attributes>
 				</reconciliation>
+				<uniqueness_rules>
+					<rule id="unique_link" _delta="define">
+						<attributes>
+							<attribute id="functionalci_id"/>
+							<attribute id="contact_id"/>
+						</attributes>
+					</rule>
+				</uniqueness_rules>
 			</properties>
 			<fields>
 				<field id="functionalci_id" xsi:type="AttributeExternalKey">


### PR DESCRIPTION
While the UI for both `FunctionalCI` and `Contact` dictate there can be no duplicates for the linked list, it is still possible to create duplicates by using workarounds like for example import.

By adding a rule, this will be prevented and doesn't confuse users.