### PR TITLE
Table selectable lines : compatibility with iTop 3.0.0

### DIFF
--- a/css/backoffice/components/_datatable.scss
+++ b/css/backoffice/components/_datatable.scss
@@ -91,13 +91,34 @@ $ibo-fieldsorter--selected--background-color: $ibo-color-blue-200 !default;
   &.ibo-is-ascending::after{
     content: '\f0de';
   }
-  &.ibo-is-none::after{
+
+  &.ibo-is-none::after {
     content: '\f0dc';
   }
 }
 
-.itop-fieldsorter{
-  >.selected{
+.itop-fieldsorter {
+  > .selected {
     background-color: $ibo-fieldsorter--selected--background-color;
+  }
+}
+
+
+.ibo-datatable {
+  tbody > tr.selected > * {
+    background-color: $ibo-color-orange-600;
+  }
+
+  tbody > tr > * {
+    transition: background-color 400ms linear;
+  }
+
+  tbody > tr:hover > * {
+    cursor: pointer;
+  }
+
+  tbody > tr.selected:hover > * {
+    /* hover on lines is currently done toggling td.hover, and having a rule for links */
+    background-color: lighten($ibo-color-orange-600, 20%);
   }
 }

--- a/css/backoffice/components/_datatable.scss
+++ b/css/backoffice/components/_datatable.scss
@@ -95,13 +95,13 @@ $ibo-fieldsorter--selected--background-color: $ibo-color-blue-200 !default;
     content: '\f0de';
   }
 
-  &.ibo-is-none::after {
+  &.ibo-is-none::after{
     content: '\f0dc';
   }
 }
 
-.itop-fieldsorter {
-  > .selected {
+.itop-fieldsorter{
+  >.selected{
     background-color: $ibo-fieldsorter--selected--background-color;
   }
 }

--- a/css/backoffice/components/_datatable.scss
+++ b/css/backoffice/components/_datatable.scss
@@ -14,6 +14,9 @@ $ibo-datatable-header--text-color: $ibo-base-variable--text-color !default;
 $ibo-datatable-panel--table-spacing: 48px !default;
 $ibo-datatable-panel--body--padding: $ibo-panel--body--padding-top 0px $ibo-panel--body--padding-bottom !default;
 
+$ibo-datatable--row--background-color--is-hover: $ibo-color-primary-200 !default;
+$ibo-datatable--row--background-color--is-selected: $ibo-color-primary-300 !default;
+
 $ibo-datatable--selection-validation-buttons-toolbar--margin-top: 10px !default;
 $ibo-list-column--max-height: 150px !default;
 
@@ -105,20 +108,16 @@ $ibo-fieldsorter--selected--background-color: $ibo-color-blue-200 !default;
 
 
 .ibo-datatable {
-  tbody > tr.selected > * {
-    background-color: $ibo-color-orange-600;
-  }
-
-  tbody > tr > * {
+  tbody > tr {
     transition: background-color 400ms linear;
-  }
 
-  tbody > tr:hover > * {
-    cursor: pointer;
-  }
+    &:hover, &.selected:hover {
+      cursor: pointer;
+      background-color: $ibo-datatable--row--background-color--is-hover;
+    }
 
-  tbody > tr.selected:hover > * {
-    /* hover on lines is currently done toggling td.hover, and having a rule for links */
-    background-color: lighten($ibo-color-orange-600, 20%);
+    &.selected {
+      background-color: $ibo-datatable--row--background-color--is-selected;
+    }
   }
 }

--- a/sources/application/UI/Base/Component/DataTable/StaticTable/FormTable/FormTable.php
+++ b/sources/application/UI/Base/Component/DataTable/StaticTable/FormTable/FormTable.php
@@ -19,11 +19,14 @@ use Combodo\iTop\Application\UI\Base\iUIBlock;
 class FormTable extends StaticTable
 {
 	// Overloaded constants
-	public const BLOCK_CODE = 'ibo-formtable';
-	public const REQUIRES_ANCESTORS_DEFAULT_JS_FILES = true;
-	public const REQUIRES_ANCESTORS_DEFAULT_CSS_FILES = true;
-	public const DEFAULT_HTML_TEMPLATE_REL_PATH = 'base/components/datatable/static/formtable/layout';
+	public const BLOCK_CODE                            = 'ibo-formtable';
+	public const REQUIRES_ANCESTORS_DEFAULT_JS_FILES   = true;
+	public const REQUIRES_ANCESTORS_DEFAULT_CSS_FILES  = true;
+	public const DEFAULT_HTML_TEMPLATE_REL_PATH        = 'base/components/datatable/static/formtable/layout';
 	public const DEFAULT_JS_ON_READY_TEMPLATE_REL_PATH = 'base/components/datatable/static/formtable/layout';
+	public const DEFAULT_JS_FILES_REL_PATH             = [
+		'js/table-selectable-lines.js',
+	];
 
 	/** @var string */
 	private $sRef;

--- a/sources/application/UI/Base/Component/DataTable/StaticTable/FormTable/FormTable.php
+++ b/sources/application/UI/Base/Component/DataTable/StaticTable/FormTable/FormTable.php
@@ -19,10 +19,10 @@ use Combodo\iTop\Application\UI\Base\iUIBlock;
 class FormTable extends StaticTable
 {
 	// Overloaded constants
-	public const BLOCK_CODE                            = 'ibo-formtable';
-	public const REQUIRES_ANCESTORS_DEFAULT_JS_FILES   = true;
-	public const REQUIRES_ANCESTORS_DEFAULT_CSS_FILES  = true;
-	public const DEFAULT_HTML_TEMPLATE_REL_PATH        = 'base/components/datatable/static/formtable/layout';
+	public const BLOCK_CODE = 'ibo-formtable';
+	public const REQUIRES_ANCESTORS_DEFAULT_JS_FILES = true;
+	public const REQUIRES_ANCESTORS_DEFAULT_CSS_FILES = true;
+	public const DEFAULT_HTML_TEMPLATE_REL_PATH = 'base/components/datatable/static/formtable/layout';
 	public const DEFAULT_JS_ON_READY_TEMPLATE_REL_PATH = 'base/components/datatable/static/formtable/layout';
 
 	/** @var string */

--- a/sources/application/UI/Base/Component/DataTable/StaticTable/FormTable/FormTable.php
+++ b/sources/application/UI/Base/Component/DataTable/StaticTable/FormTable/FormTable.php
@@ -24,9 +24,6 @@ class FormTable extends StaticTable
 	public const REQUIRES_ANCESTORS_DEFAULT_CSS_FILES  = true;
 	public const DEFAULT_HTML_TEMPLATE_REL_PATH        = 'base/components/datatable/static/formtable/layout';
 	public const DEFAULT_JS_ON_READY_TEMPLATE_REL_PATH = 'base/components/datatable/static/formtable/layout';
-	public const DEFAULT_JS_FILES_REL_PATH             = [
-		'js/table-selectable-lines.js',
-	];
 
 	/** @var string */
 	private $sRef;

--- a/sources/application/UI/Base/Component/DataTable/StaticTable/StaticTable.php
+++ b/sources/application/UI/Base/Component/DataTable/StaticTable/StaticTable.php
@@ -30,6 +30,7 @@ class StaticTable extends UIContentBlock
 		'node_modules/datatables.net-scroller/js/dataTables.scroller.min.js',
 		'node_modules/datatables.net-select/js/dataTables.select.min.js',
 		'js/field_sorter.js',
+		'js/table-selectable-lines.js',
 		'js/dataTables.main.js',
 		'js/dataTables.settings.js',
 		'js/dataTables.pipeline.js',


### PR DESCRIPTION
Things to fix : 

* N°4420 CSS :
  * [X] restore pointer cursor when hovering selectable lines
  * [x] choose which color to apply on hovered and selected lines
* N°4421 JS file inclusion : 
  * [x] restore `js/table-selectable-lines.js` inclusion when needed (included in \NiceWebPage::COMPATIBILITY_MOVED_LINKED_SCRIPTS_REL_PATH but not printed by default)