### PR TITLE
N°4498 - Introduce new APIs due to iPageUIExtension deprecation

### DIFF
--- a/application/applicationextension.inc.php
+++ b/application/applicationextension.inc.php
@@ -1278,7 +1278,7 @@ interface iBackofficeLinkedScriptsExtension
  * @api
  * @since 3.0.0
  */
-interface iBackofficeEarlyScriptExtension
+interface iBackofficeEarlyScriptsExtension
 {
 	/**
 	 * @see \iTopWebPage::$a_early_scripts

--- a/application/applicationextension.inc.php
+++ b/application/applicationextension.inc.php
@@ -1101,7 +1101,9 @@ class JSButtonItem extends JSPopupMenuItem
  * @api
  * @package     Extensibility
  * @since 2.0
- * @deprecated since 3.0.0 use iPageUIBlockExtension instead
+ * @deprecated 3.0.0
+ *   * If you need to include JS/CSS files/snippets use {@see \iBackofficeLinkedScriptsExtension}, {@see \iBackofficeLinkedStylesheetsExtension}, etc instead
+ *   * If you need to include HTML (and optionally JS/CSS) use {@see \iPageUIBlockExtension} to manipulate {@see \Combodo\iTop\Application\UI\Base\UIBlock} instead
  */
 interface iPageUIExtension
 {
@@ -1250,6 +1252,119 @@ abstract class AbstractPageUIBlockExtension implements iPageUIBlockExtension
 	{
 		return null;
 	}
+}
+
+/**
+ * Implement this interface to add script (JS) files to the backoffice pages
+ *
+ * @see \iTopWebPage::$a_linked_scripts
+ * @api
+ * @since 3.0.0
+ */
+interface iBackofficeLinkedScriptsExtension
+{
+	/**
+	 * @see \iTopWebPage::$a_linked_scripts
+	 * @return array An array of absolute URLs to the files to include
+	 */
+	public function GetLinkedScriptsAbsUrls(): array;
+}
+
+/**
+ * Implement this interface to add inline script (JS) to the backoffice pages' head.
+ * Will be executed first, BEFORE the DOM interpretation.
+ *
+ * @see \iTopWebPage::$a_early_scripts
+ * @api
+ * @since 3.0.0
+ */
+interface iBackofficeEarlyScriptExtension
+{
+	/**
+	 * @see \iTopWebPage::$a_early_scripts
+	 * @return string
+	 */
+	public function GetEarlyScript(): string;
+}
+
+/**
+ * Implement this interface to add inline script (JS) to the backoffice pages that will be executed immediately, without waiting for the DOM to be ready.
+ *
+ * @see \iTopWebPage::$a_scripts
+ * @api
+ * @since 3.0.0
+ */
+interface iBackofficeScriptsExtension
+{
+	/**
+	 * @see \iTopWebPage::$a_scripts
+	 * @return string
+	 */
+	public function GetScript(): string;
+}
+
+/**
+ * Implement this interface to add inline script (JS) to the backoffice pages that will be executed right when the DOM is ready.
+ *
+ * @see \iTopWebPage::$a_init_scripts
+ * @api
+ * @since 3.0.0
+ */
+interface iBackofficeInitScriptsExtension
+{
+	/**
+	 * @see \iTopWebPage::$a_init_scripts
+	 * @return string
+	 */
+	public function GetInitScript(): string;
+}
+
+/**
+ * Implement this interface to add inline script (JS) to the backoffice pages that will be executed slightly AFTER the DOM is ready (just after the init. scripts).
+ *
+ * @see \iTopWebPage::$a_ready_scripts
+ * @api
+ * @since 3.0.0
+ */
+interface iBackofficeReadyScriptsExtension
+{
+	/**
+	 * @see \iTopWebPage::$a_ready_scripts
+	 * @return string
+	 */
+	public function GetReadyScript(): string;
+}
+
+/**
+ * Implement this interface to add stylesheets (CSS) to the backoffice pages
+ *
+ * @see \iTopWebPage::$a_linked_stylesheets
+ * @api
+ * @since 3.0.0
+ */
+interface iBackofficeLinkedStylesheetsExtension
+{
+	/**
+	 * @see \iTopWebPage::$a_linked_stylesheets
+	 * @return array An array of absolute URLs to the files to include
+	 */
+	public function GetLinkedStylesheetsAbsUrls(): array;
+}
+
+/**
+ * Implement this interface to add inline style (CSS) to the backoffice pages' head.
+ *
+ * @see \iTopWebPage::$a_styles
+ * @api
+ * @since 3.0.0
+ */
+interface iBackofficeStylesExtension
+{
+	/**
+	 * @see \iTopWebPage::$a_styles
+	 * @return string
+	 */
+	public function GetStyle(): string;
 }
 
 /**

--- a/application/applicationextension.inc.php
+++ b/application/applicationextension.inc.php
@@ -1101,9 +1101,9 @@ class JSButtonItem extends JSPopupMenuItem
  * @api
  * @package     Extensibility
  * @since 2.0
- * @deprecated 3.0.0
- *   * If you need to include JS/CSS files/snippets use {@see \iBackofficeLinkedScriptsExtension}, {@see \iBackofficeLinkedStylesheetsExtension}, etc instead
- *   * If you need to include HTML (and optionally JS/CSS) use {@see \iPageUIBlockExtension} to manipulate {@see \Combodo\iTop\Application\UI\Base\UIBlock} instead
+ * @deprecated 3.0.0 If you need to include:
+ *   * JS/CSS files/snippets, use {@see \iBackofficeLinkedScriptsExtension}, {@see \iBackofficeLinkedStylesheetsExtension}, etc instead
+ *   * HTML (and optionally JS/CSS), use {@see \iPageUIBlockExtension} to manipulate {@see \Combodo\iTop\Application\UI\Base\UIBlock} instead
  */
 interface iPageUIExtension
 {
@@ -1264,7 +1264,7 @@ abstract class AbstractPageUIBlockExtension implements iPageUIBlockExtension
 interface iBackofficeLinkedScriptsExtension
 {
 	/**
-	 * @see \iTopWebPage::$a_linked_scripts
+	 * @see \iTopWebPage::$a_linked_scripts Each script will be included using this property
 	 * @return array An array of absolute URLs to the files to include
 	 */
 	public function GetLinkedScriptsAbsUrls(): array;
@@ -1278,7 +1278,7 @@ interface iBackofficeLinkedScriptsExtension
  * @api
  * @since 3.0.0
  */
-interface iBackofficeEarlyScriptsExtension
+interface iBackofficeEarlyScriptExtension
 {
 	/**
 	 * @see \iTopWebPage::$a_early_scripts
@@ -1294,7 +1294,7 @@ interface iBackofficeEarlyScriptsExtension
  * @api
  * @since 3.0.0
  */
-interface iBackofficeScriptsExtension
+interface iBackofficeScriptExtension
 {
 	/**
 	 * @see \iTopWebPage::$a_scripts
@@ -1310,7 +1310,7 @@ interface iBackofficeScriptsExtension
  * @api
  * @since 3.0.0
  */
-interface iBackofficeInitScriptsExtension
+interface iBackofficeInitScriptExtension
 {
 	/**
 	 * @see \iTopWebPage::$a_init_scripts
@@ -1326,7 +1326,7 @@ interface iBackofficeInitScriptsExtension
  * @api
  * @since 3.0.0
  */
-interface iBackofficeReadyScriptsExtension
+interface iBackofficeReadyScriptExtension
 {
 	/**
 	 * @see \iTopWebPage::$a_ready_scripts
@@ -1358,7 +1358,7 @@ interface iBackofficeLinkedStylesheetsExtension
  * @api
  * @since 3.0.0
  */
-interface iBackofficeStylesExtension
+interface iBackofficeStyleExtension
 {
 	/**
 	 * @see \iTopWebPage::$a_styles

--- a/sources/application/WebPage/iTopWebPage.php
+++ b/sources/application/WebPage/iTopWebPage.php
@@ -801,6 +801,45 @@ HTML;
 		$oPrintHeader = null;
 
 		// Prepare internal parts (js files, css files, js snippets, css snippets, ...)
+		// - API: External script files
+		/** @var \iBackofficeLinkedScriptsExtension $oExtensionInstance */
+		foreach (MetaModel::EnumPlugins('iBackofficeLinkedScriptsExtension') as $oExtensionInstance) {
+			foreach ($oExtensionInstance->GetLinkedScriptsAbsUrls() as $sScriptUrl) {
+				$this->add_linked_script($sScriptUrl);
+			}
+		}
+		// - API: Early inline scripts
+		/** @var \iBackofficeEarlyScriptExtension $oExtensionInstance */
+		foreach (MetaModel::EnumPlugins('iBackofficeEarlyScriptExtension') as $oExtensionInstance) {
+			$this->add_early_script($oExtensionInstance->GetEarlyScript());
+		}
+		// - API: Inline scripts
+		/** @var \iBackofficeScriptsExtension $oExtensionInstance */
+		foreach (MetaModel::EnumPlugins('iBackofficeScriptsExtension') as $oExtensionInstance) {
+			$this->add_early_script($oExtensionInstance->GetScript());
+		}
+		// - API: Init. scripts
+		/** @var \iBackofficeInitScriptsExtension $oExtensionInstance */
+		foreach (MetaModel::EnumPlugins('iBackofficeInitScriptsExtension') as $oExtensionInstance) {
+			$this->add_init_script($oExtensionInstance->GetInitScript());
+		}
+		// - API: Ready scripts
+		/** @var \iBackofficeReadyScriptsExtension $oExtensionInstance */
+		foreach (MetaModel::EnumPlugins('iBackofficeReadyScriptsExtension') as $oExtensionInstance) {
+			$this->add_ready_script($oExtensionInstance->GetReadyScript());
+		}
+		// - API: External stylesheet files
+		/** @var \iBackofficeLinkedStylesheetsExtension $oExtensionInstance */
+		foreach (MetaModel::EnumPlugins('iBackofficeLinkedStylesheetsExtension') as $oExtensionInstance) {
+			foreach ($oExtensionInstance->GetLinkedStylesheetsAbsUrls() as $sStylesheetUrl) {
+				$this->add_linked_stylesheet($sStylesheetUrl);
+			}
+		}
+		// - API: Inline style
+		/** @var \iBackofficeStylesExtension $oExtensionInstance */
+		foreach (MetaModel::EnumPlugins('iBackofficeStylesExtension') as $oExtensionInstance) {
+			$this->add_style($oExtensionInstance->GetStyle());
+		}
 		// - Generate necessary dict. files
 		if ($this->bAddJSDict) {
 			$this->output_dict_entries();

--- a/sources/application/WebPage/iTopWebPage.php
+++ b/sources/application/WebPage/iTopWebPage.php
@@ -814,18 +814,18 @@ HTML;
 			$this->add_early_script($oExtensionInstance->GetEarlyScript());
 		}
 		// - API: Inline scripts
-		/** @var \iBackofficeScriptsExtension $oExtensionInstance */
-		foreach (MetaModel::EnumPlugins('iBackofficeScriptsExtension') as $oExtensionInstance) {
+		/** @var \iBackofficeScriptExtension $oExtensionInstance */
+		foreach (MetaModel::EnumPlugins('iBackofficeScriptExtension') as $oExtensionInstance) {
 			$this->add_early_script($oExtensionInstance->GetScript());
 		}
 		// - API: Init. scripts
-		/** @var \iBackofficeInitScriptsExtension $oExtensionInstance */
-		foreach (MetaModel::EnumPlugins('iBackofficeInitScriptsExtension') as $oExtensionInstance) {
+		/** @var \iBackofficeInitScriptExtension $oExtensionInstance */
+		foreach (MetaModel::EnumPlugins('iBackofficeInitScriptExtension') as $oExtensionInstance) {
 			$this->add_init_script($oExtensionInstance->GetInitScript());
 		}
 		// - API: Ready scripts
-		/** @var \iBackofficeReadyScriptsExtension $oExtensionInstance */
-		foreach (MetaModel::EnumPlugins('iBackofficeReadyScriptsExtension') as $oExtensionInstance) {
+		/** @var \iBackofficeReadyScriptExtension $oExtensionInstance */
+		foreach (MetaModel::EnumPlugins('iBackofficeReadyScriptExtension') as $oExtensionInstance) {
 			$this->add_ready_script($oExtensionInstance->GetReadyScript());
 		}
 		// - API: External stylesheet files
@@ -836,8 +836,8 @@ HTML;
 			}
 		}
 		// - API: Inline style
-		/** @var \iBackofficeStylesExtension $oExtensionInstance */
-		foreach (MetaModel::EnumPlugins('iBackofficeStylesExtension') as $oExtensionInstance) {
+		/** @var \iBackofficeStyleExtension $oExtensionInstance */
+		foreach (MetaModel::EnumPlugins('iBackofficeStyleExtension') as $oExtensionInstance) {
 			$this->add_style($oExtensionInstance->GetStyle());
 		}
 		// - Generate necessary dict. files


### PR DESCRIPTION
Since we deprecated the \iPageUIExtension API in iTop 3.0.0, there is no simple way to add JS/CSS files/snippets to a backoffice page anymore. The only way is to use the \iPageUIBlockExtension but it requires to make a UIBlock which is not intuitive when you only want to include some files as a UIBlock is designed to be a specific UI element.

Unlike the previous interface, we decided to make more atomic one to improve evolution through the upcoming versions and avoid the necessity to implement all methods when you only need a few.