### PR TITLE
:bug: fix cmdbAbstractObject::GetSetAsHTMLSpreadsheet() missing <tr>

### DIFF
--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -1925,6 +1925,7 @@ HTML
 					}
 				}
 			}
+			$sHtml .= "<tr>";
 			$sHtml .= implode("\n", $aRow);
 			$sHtml .= "</tr>\n";
 		}


### PR DESCRIPTION
fix `cmdbAbstractObject::GetSetAsHTMLSpreadsheet` missing `<tr>`

use this script to test.
```php
<?php
if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
require_once(__DIR__.'/approot.inc.php');
require_once(APPROOT.'/application/application.inc.php');
require_once(APPROOT.'/application/startup.inc.php');


$oSearch = DBObjectSearch::FromOQL_AllData("SELECT Server");
$oSet = new CMDBObjectSet($oSearch, array(), array());

print_r(cmdbAbstractObject::GetSetAsHTMLSpreadsheet($oSet, ['fields'=>'name,serialnumber']));
```

run
```
# php test.php
<table border="1">
<tr>
<td>name</td><td>serialnumber</td>
</tr>
<td>Server1</td>
<td>sn0333</td></tr>
<td>Server3</td>
<td>sn01</td></tr>
</table>
```