### PR TITLE
:bug: N°4665 - Fix notice in logs when uploading an SVG image in an AttributeImage

### DIFF
--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -4222,7 +4222,7 @@ HTML;
 				if (!is_null($oImage->GetData()))
 				{
 					$aSize = utils::GetImageSize($oImage->GetData());
-					if (is_array($aSize) && count($aSize) > 1)
+					if (is_array($aSize) && $aSize[0] > 0 && $aSize[1] > 0)
 					{
 						$oImage = utils::ResizeImageToFit(
 							$oImage,

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -4219,16 +4219,19 @@ HTML;
 			case 'Image':
 				$value = null;
 				$oImage = utils::ReadPostedDocument("attr_{$sFormPrefix}{$sAttCode}", 'fcontents');
-				if (!is_null($oImage->GetData()) && $oImage->GetMimeType() != "image/svg+xml")
+				if (!is_null($oImage->GetData()))
 				{
 					$aSize = utils::GetImageSize($oImage->GetData());
-					$oImage = utils::ResizeImageToFit(
-						$oImage,
-						$aSize[0],
-						$aSize[1],
-						$oAttDef->Get('storage_max_width'),
-						$oAttDef->Get('storage_max_height')
-					);
+					if (is_array($aSize))
+					{
+						$oImage = utils::ResizeImageToFit(
+							$oImage,
+							$aSize[0],
+							$aSize[1],
+							$oAttDef->Get('storage_max_width'),
+							$oAttDef->Get('storage_max_height')
+						);
+					}
 				}
 				$aOtherData = utils::ReadPostedParam("attr_{$sFormPrefix}{$sAttCode}", null, 'raw_data');
 				if (is_array($aOtherData))

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -4219,7 +4219,7 @@ HTML;
 			case 'Image':
 				$value = null;
 				$oImage = utils::ReadPostedDocument("attr_{$sFormPrefix}{$sAttCode}", 'fcontents');
-				if (!is_null($oImage->GetData()))
+				if (!is_null($oImage->GetData()) && $oImage->GetMimeType() != "image/svg+xml")
 				{
 					$aSize = utils::GetImageSize($oImage->GetData());
 					$oImage = utils::ResizeImageToFit(

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -4234,7 +4234,7 @@ HTML;
 					}
 					else
 					{
-						IssueLog::Warning($sClass . ":" . $this->GetKey() . '/' . $sAttCode . ': Image could not be resized. Mimetype: ' . $oImage->GetMimeType());
+						IssueLog::Warning($sClass . ':' . $this->GetKey() . '/' . $sAttCode . ': Image could not be resized. Mimetype: ' . $oImage->GetMimeType() . ', filename: ' . $oImage->GetFileName());
 					}
 				}
 				$aOtherData = utils::ReadPostedParam("attr_{$sFormPrefix}{$sAttCode}", null, 'raw_data');

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -4222,7 +4222,7 @@ HTML;
 				if (!is_null($oImage->GetData()))
 				{
 					$aSize = utils::GetImageSize($oImage->GetData());
-					if (is_array($aSize))
+					if (is_array($aSize) && count($aSize) > 1)
 					{
 						$oImage = utils::ResizeImageToFit(
 							$oImage,
@@ -4231,6 +4231,10 @@ HTML;
 							$oAttDef->Get('storage_max_width'),
 							$oAttDef->Get('storage_max_height')
 						);
+					}
+					else
+					{
+						IssueLog::Warning($sClass . ":" . $this->GetKey() . '/' . $sAttCode . ': Image could not be resized. Mimetype: ' . $oImage->GetMimeType());
 					}
 				}
 				$aOtherData = utils::ReadPostedParam("attr_{$sFormPrefix}{$sAttCode}", null, 'raw_data');


### PR DESCRIPTION
Try to fix notice log when upload svg image to `AttributeImage` field.

version: 2.7.5-1
this is the log
```
[03-Dec-2021 10:15:24 Asia/Shanghai] PHP Notice:  Trying to access array offset on value of type bool in /var/www/itop/application/cmdbabstract.class.inc.php on line 3802
[03-Dec-2021 10:15:24 Asia/Shanghai] PHP Stack trace:
[03-Dec-2021 10:15:24 Asia/Shanghai] PHP   1. {main}() /var/www/itop/pages/UI.php:0
[03-Dec-2021 10:15:24 Asia/Shanghai] PHP   2. Server->UpdateObjectFromPostedForm($sFormPrefix = *uninitialized*, $aAttList = *uninitialized*, $aAttFlags = *uninitialized*) /var/www/itop/pages/UI.php:970
[03-Dec-2021 10:15:24 Asia/Shanghai] PHP   3. Server->PrepareValueFromPostedForm($sFormPrefix = '', $sAttCode = 'logo', $sClass = *uninitialized*, $aPostedData = *uninitialized*) /var/www/itop/application/cmdbabstract.class.inc.php:3732
[03-Dec-2021 10:15:24 Asia/Shanghai] PHP Notice:  Trying to access array offset on value of type bool in /var/www/itop/application/cmdbabstract.class.inc.php on line 3803
[03-Dec-2021 10:15:24 Asia/Shanghai] PHP Stack trace:
[03-Dec-2021 10:15:24 Asia/Shanghai] PHP   1. {main}() /var/www/itop/pages/UI.php:0
[03-Dec-2021 10:15:24 Asia/Shanghai] PHP   2. Server->UpdateObjectFromPostedForm($sFormPrefix = *uninitialized*, $aAttList = *uninitialized*, $aAttFlags = *uninitialized*) /var/www/itop/pages/UI.php:970
[03-Dec-2021 10:15:24 Asia/Shanghai] PHP   3. Server->PrepareValueFromPostedForm($sFormPrefix = '', $sAttCode = 'logo', $sClass = *uninitialized*, $aPostedData = *uninitialized*) /var/www/itop/application/cmdbabstract.class.inc.php:3732
```