### PR TITLE
:globe_with_meridians: Person Name for chinese user

### DIFF
--- a/datamodels/2.x/itop-structure/dictionaries/zh_cn.dict.itop-structure.php
+++ b/datamodels/2.x/itop-structure/dictionaries/zh_cn.dict.itop-structure.php
@@ -147,6 +147,7 @@ Dict::Add('ZH CN', 'Chinese', '简体中文', array(
 Dict::Add('ZH CN', 'Chinese', '简体中文', array(
 	'Class:Person' => '个人',
 	'Class:Person+' => '',
+	'Class:Person/Name' => '%2$s %1$s',
 	'Class:Person/Attribute:name' => '姓',
 	'Class:Person/Attribute:name+' => '',
 	'Class:Person/Attribute:first_name' => '名',


### PR DESCRIPTION
In Chinese it is customary to put the surname before the given name