### PR TITLE
:bug: Rack - missing relation to other objects

### DIFF
--- a/datamodels/2.x/itop-datacenter-mgmt/datamodel.itop-datacenter-mgmt.xml
+++ b/datamodels/2.x/itop-datacenter-mgmt/datamodel.itop-datacenter-mgmt.xml
@@ -184,6 +184,15 @@
           </items>
         </list>
       </presentation>
+      <relations>
+        <relation id="impacts">
+          <neighbours>
+            <neighbour id="device_list">
+              <attribute>device_list</attribute>
+            </neighbour>
+          </neighbours>
+        </relation>
+      </relations>
     </class>
     <class id="Enclosure" _delta="define">
       <parent>PhysicalDevice</parent>

--- a/datamodels/2.x/itop-datacenter-mgmt/datamodel.itop-datacenter-mgmt.xml
+++ b/datamodels/2.x/itop-datacenter-mgmt/datamodel.itop-datacenter-mgmt.xml
@@ -187,8 +187,11 @@
       <relations>
         <relation id="impacts">
           <neighbours>
-            <neighbour id="device_list">
+            <neighbour id="datacenterdevice">
               <attribute>device_list</attribute>
+            </neighbour>
+            <neighbour id="enclosure">
+              <attribute>enclosure_list</attribute>
             </neighbour>
           </neighbours>
         </relation>


### PR DESCRIPTION
There is a missing <relations> segment defined in Rack, resulting in a lack of relations to other objects in the rack - for examples Servers and subsequently other parts in iTop. This fixes it. See attached pictures please.

Before:
![rack_before](https://user-images.githubusercontent.com/44978845/147934082-0adcdf65-4ba1-40ee-8049-87eba95a01dd.png)

After:
![rack_after](https://user-images.githubusercontent.com/44978845/147934095-994ad44d-30a9-4316-9b25-3ecf26984341.png)
