### PR TITLE
N°4652 Better error message when XML node define fails from delta

### DIFF
--- a/setup/modelfactory.class.inc.php
+++ b/setup/modelfactory.class.inc.php
@@ -2178,7 +2178,7 @@ class MFElement extends Combodo\iTop\DesignElement
 				$sPath = MFDocument::GetItopNodePath($oNode);
 				$iLine = $oNode->getLineNo();
 				$sExistingPath = MFDocument::GetItopNodePath($oExisting);
-				$oExistingLine = $oExisting->getLineNo();
+				$iExistingLine = $oExisting->getLineNo();
 				throw new MFException($sPath.' at line '.$iLine.': could not be added (already exists) in '.$oExistingPath.' at line '.$oExistingLine, MFException::COULD_NOT_BE_ADDED,
 					$iLine, $sPath);
 			}

--- a/setup/modelfactory.class.inc.php
+++ b/setup/modelfactory.class.inc.php
@@ -2177,7 +2177,9 @@ class MFElement extends Combodo\iTop\DesignElement
 			if ($oExisting->getAttribute('_alteration') != 'removed') {
 				$sPath = MFDocument::GetItopNodePath($oNode);
 				$iLine = $oNode->getLineNo();
-				throw new MFException($sPath.' at line '.$iLine.": could not be added (already exists)", MFException::COULD_NOT_BE_ADDED,
+				$oExistingPath = MFDocument::GetItopNodePath($oExisting);
+				$oExistingLine = $oExisting->getLineNo();
+				throw new MFException($sPath.' at line '.$iLine.': could not be added (already exists) in '.$oExistingPath.' at line '.$oExistingLine, MFException::COULD_NOT_BE_ADDED,
 					$iLine, $sPath);
 			}
 			$oExisting->ReplaceWithSingleNode($oNode);

--- a/setup/modelfactory.class.inc.php
+++ b/setup/modelfactory.class.inc.php
@@ -2179,8 +2179,11 @@ class MFElement extends Combodo\iTop\DesignElement
 				$iLine = $oNode->getLineNo();
 				$sExistingPath = MFDocument::GetItopNodePath($oExisting);
 				$iExistingLine = $oExisting->getLineNo();
-				throw new MFException($sPath.' at line '.$iLine.': could not be added (already exists) in '.$sExistingPath.' at line '.$iExistingLine, MFException::COULD_NOT_BE_ADDED,
-					$iLine, $sPath);
+				
+				$sExceptionMessage = <<<EOF
+`{$sPath}` at line {$iLine} could not be added : already exists in `{$sExistingPath}` at line {$iExistingLine}
+EOF;
+				throw new MFException($sExceptionMessage, MFException::COULD_NOT_BE_ADDED, $iLine, $sPath);
 			}
 			$oExisting->ReplaceWithSingleNode($oNode);
 			$sFlag = 'replaced';

--- a/setup/modelfactory.class.inc.php
+++ b/setup/modelfactory.class.inc.php
@@ -2179,7 +2179,7 @@ class MFElement extends Combodo\iTop\DesignElement
 				$iLine = $oNode->getLineNo();
 				$sExistingPath = MFDocument::GetItopNodePath($oExisting);
 				$iExistingLine = $oExisting->getLineNo();
-				throw new MFException($sPath.' at line '.$iLine.': could not be added (already exists) in '.$oExistingPath.' at line '.$oExistingLine, MFException::COULD_NOT_BE_ADDED,
+				throw new MFException($sPath.' at line '.$iLine.': could not be added (already exists) in '.$sExistingPath.' at line '.$iExistingLine, MFException::COULD_NOT_BE_ADDED,
 					$iLine, $sPath);
 			}
 			$oExisting->ReplaceWithSingleNode($oNode);

--- a/setup/modelfactory.class.inc.php
+++ b/setup/modelfactory.class.inc.php
@@ -2177,7 +2177,7 @@ class MFElement extends Combodo\iTop\DesignElement
 			if ($oExisting->getAttribute('_alteration') != 'removed') {
 				$sPath = MFDocument::GetItopNodePath($oNode);
 				$iLine = $oNode->getLineNo();
-				$oExistingPath = MFDocument::GetItopNodePath($oExisting);
+				$sExistingPath = MFDocument::GetItopNodePath($oExisting);
 				$oExistingLine = $oExisting->getLineNo();
 				throw new MFException($sPath.' at line '.$iLine.': could not be added (already exists) in '.$oExistingPath.' at line '.$oExistingLine, MFException::COULD_NOT_BE_ADDED,
 					$iLine, $sPath);


### PR DESCRIPTION
This pull request adds more details to the error message displayed when an XML (inside a XML must_exist most of the time) fails in production.delta.xml.
This error message then contains very low exploitable information:

![Screenshot from 2022-01-12 10-17-50](https://user-images.githubusercontent.com/5959857/149099192-b0058248-af91-4d38-8df0-296c32b94d1a.png)

- No module (indeed it's from production.delta.xml)
- No xml node path
- And sometimes a line number (not always though)

This PR adds information on the existing node in order to ease debugging: 

![Screenshot from 2022-01-12 10-19-53](https://user-images.githubusercontent.com/5959857/149100079-4a289631-2282-4c21-99ab-5d0e1f86d4fa.png)

 