### PR TITLE
:bug: N°4662 - Fix broken display of portal service catalog when a description is defined for a service (Service Provider module)

### DIFF
--- a/datamodels/2.x/itop-portal-base/portal/templates/bricks/browse/mode_list.html.twig
+++ b/datamodels/2.x/itop-portal-base/portal/templates/bricks/browse/mode_list.html.twig
@@ -79,7 +79,7 @@
 							// Building tooltip for the node
 							// We have to concatenate the HTML as we return the raw HTML of the cell. If we did a jQuery.insertAfter, the tooltip would not be returned.
 							// For the same reason, tooltip widget is created in "drawCallback" instead of here.
-							if( (data.tooltip !== undefined) && ($(data.tooltip).text() !== ''))
+							if( (data.tooltip !== undefined) && (data.tooltip !== ''))
 							{
 								cellElem.html( $('<span></span>').attr('title', data.tooltip).attr('data-toggle', 'tooltip').html(data.name).prop('outerHTML') );
 							}

--- a/datamodels/2.x/itop-portal-base/portal/templates/bricks/browse/mode_mosaic.html.twig
+++ b/datamodels/2.x/itop-portal-base/portal/templates/bricks/browse/mode_mosaic.html.twig
@@ -215,7 +215,7 @@
 				itemElem.append(aElem);
 				
 				// Building tooltip for the node
-				if( (item.tooltip !== undefined) && ($(item.tooltip).text() !== '') )
+				if( (item.tooltip !== undefined) && (item.tooltip !== '') )
 				{
 					aElem.attr('title', item.tooltip).attr('data-toggle', 'tooltip').tooltip({html: true, trigger: 'hover', placement: 'top'});
 				}

--- a/datamodels/2.x/itop-portal-base/portal/templates/bricks/browse/mode_tree.html.twig
+++ b/datamodels/2.x/itop-portal-base/portal/templates/bricks/browse/mode_tree.html.twig
@@ -204,7 +204,7 @@
 				liElem.append(aElem);
 				
 				// Building tooltip for the node
-				if( (item.tooltip !== undefined) && ($(item.tooltip).text() !== '') )
+				if( (item.tooltip !== undefined) && (item.tooltip !== '') )
 				{
 					nameElem.attr('title', item.tooltip).attr('data-toggle', 'tooltip').tooltip({html: true, trigger: 'hover', placement: 'right'});
 				}


### PR DESCRIPTION
In September a change was made to the list, mosaic and tree twigs for rendering the service catalog. It caused the rendering of the service catalog to throw an exception when a description was filled in for a service which blocked the entire rendering of the catalog. 