### PR TITLE
N°4761 Fix license.xml content not displayed in setup with multi modules extensions

### DIFF
--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -1878,9 +1878,9 @@ JS
 		$aLicenceFiles = glob(APPROOT.'setup/licenses/*.xml');
 		if (empty($sEnv))
 		{
-			$aLicenceFiles = array_merge($aLicenceFiles, glob(APPROOT.'datamodels/*/{*,*/*}/license.*.xml', GLOB_BRACE));
+			$aLicenceFiles = array_merge($aLicenceFiles, glob(APPROOT.'datamodels/*/*/license.*.xml'));
 			$aLicenceFiles = array_merge($aLicenceFiles, glob(APPROOT.'extensions/{*,*/*}/license.*.xml', GLOB_BRACE));
-			$aLicenceFiles = array_merge($aLicenceFiles, glob(APPROOT.'data/*-modules/*/license.*.xml'));
+			$aLicenceFiles = array_merge($aLicenceFiles, glob(APPROOT.'data/*-modules/{*,*/*}/license.*.xml', GLOB_BRACE));
 		}
 		else
 		{

--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -1878,8 +1878,8 @@ JS
 		$aLicenceFiles = glob(APPROOT.'setup/licenses/*.xml');
 		if (empty($sEnv))
 		{
-			$aLicenceFiles = array_merge($aLicenceFiles, glob(APPROOT.'datamodels/*/*/license.*.xml'));
-			$aLicenceFiles = array_merge($aLicenceFiles, glob(APPROOT.'extensions/*/license.*.xml'));
+			$aLicenceFiles = array_merge($aLicenceFiles, glob(APPROOT.'datamodels/*/{*,*/*}/license.*.xml', GLOB_BRACE));
+			$aLicenceFiles = array_merge($aLicenceFiles, glob(APPROOT.'extensions/{*,*/*}/license.*.xml', GLOB_BRACE));
 			$aLicenceFiles = array_merge($aLicenceFiles, glob(APPROOT.'data/*-modules/*/license.*.xml'));
 		}
 		else


### PR DESCRIPTION
Extensions can contain a `license.<module_code>.xml` file to specify licenses for embedded resources (libraries, images, fonts, ...)
The setup was displaying this file content only if the file was directly one level below `/extensions` or `/data/*`. This wasn't the case for multi module extensions, for example TeemIP where we have `/extensions/teemip-core-ip-mgmt/teemip-ip-mgmt/license.teemip-ip-mgmt.xml`

Note the problem isn't present when displaying licenses in the about box in the console : in such scenario the files are searched in the env-* folder, where every modules are copied on the first level.

This PR changed the glob patterns used in \SetupUtils::GetLicenses so that we are now also searching at the second level.