### PR TITLE
:bug: Fix CAS authentication

### DIFF
--- a/datamodels/2.x/authent-cas/src/CASLoginExtension.php
+++ b/datamodels/2.x/authent-cas/src/CASLoginExtension.php
@@ -174,7 +174,7 @@ class CASLoginExtension extends AbstractLoginFSMExtension implements iLogoutExte
 		}
 	}
 
-	private function DoUserProvisioning($sLogin)
+	private static function DoUserProvisioning($sLogin)
 	{
 		$bCASUserSynchro = Config::Get('cas_user_synchro');
 		if (!$bCASUserSynchro)

--- a/datamodels/2.x/authent-cas/src/CASLoginExtension.php
+++ b/datamodels/2.x/authent-cas/src/CASLoginExtension.php
@@ -160,6 +160,8 @@ class CASLoginExtension extends AbstractLoginFSMExtension implements iLogoutExte
 		$iCASPort = Config::Get('cas_port');
 		$sCASContext = Config::Get('cas_context');
 		phpCAS::client($sCASVersion, $sCASHost, $iCASPort, $sCASContext, false /* session already started */);
+        // Avoid automatic redirect from phpCAS, let iTop do his thing
+        phpCAS::setNoClearTicketsFromUrl();
 		$sCASCACertPath = Config::Get('cas_server_ca_cert_path');
 		if (empty($sCASCACertPath))
 		{


### PR DESCRIPTION
CAS authentication is broken on a fresh 3.0.0 install. 
These commits avoid automatic redirection done by phpCAS avoiding the session to be written by iTop and allow the automatic redirection to CAS server which is the intended behavior.