### PR TITLE
N°4698 setup/phpinfo.php : when no valid iTop installation, display a comprehensive message instead of an exception

### DIFF
--- a/setup/phpinfo.php
+++ b/setup/phpinfo.php
@@ -17,11 +17,27 @@
  * You should have received a copy of the GNU Affero General Public License
  */
 
+/**
+ * Since N°1934 this page is accessible only to iTop admin users
+ * @since 2.5.2 2.6.1 2.7.0 N°1934 must login as admin user to use
+ *        to check if PHP is up and running, use phpcheck.php !
+ */
 require_once('../approot.inc.php');
 
-require_once(APPROOT.'/application/startup.inc.php');
+try {
+	require_once(APPROOT.'/application/startup.inc.php');
+} catch (Exception $e) {
+	// This means we don't have a valid iTop installation running
+	echo <<<EOF
+No valid installation found, cannot continue !<br>
+If you need to check that PHP is running, use <a href="phpcheck.php">phpcheck.php</a>
+EOF;
+	die(-1);
+}
 
 require_once(APPROOT.'/application/loginwebpage.class.inc.php');
-LoginWebPage::DoLogin(true); // Check user rights and prompt if needed
+LoginWebPage::DoLogin(true); // Check user rights and prompt if needed (N°1934)
+
+/** @noinspection ForgottenDebugOutputInspection */
 phpinfo();
 ?>


### PR DESCRIPTION
When calling the `setup/phpinfo.php` page on a iTop that has not been installed yet, you're getting this exception: 

![image](https://user-images.githubusercontent.com/8947448/152364405-baf25d67-1fc7-4a30-b609-d042b1e735a4.png)

Indeed due to security reasons this page is only accessible to admin users, and this authentication needs a valid iTop instance...
In such a scenario, there is still the `setup/phpcheck.php` page (thanks @BenGrenoble !) that can be used though, but you'll need to know it...

This PR adds a comprehensive message when calling the page in such scenario: 

![image](https://user-images.githubusercontent.com/8947448/152364330-18f178d8-8d5c-4992-b0bd-76d3d2577d0b.png)

Also a comment was added to the file beginning to recall the existence of `setup/phpcheck.php`