### PR TITLE
N°4921 - Add support for attcode & attvalue parameters in URL to access an object

### DIFF
--- a/core/metamodel.class.php
+++ b/core/metamodel.class.php
@@ -7145,20 +7145,28 @@ abstract class MetaModel
 	/**
 	 * @param string $sClass
 	 * @param string $sAttCode
-	 * @param $value
+	 * @param mixed $value
 	 * @param bool $bMustBeFoundUnique
+	 * @param bool $bAllowAllData
 	 *
-	 * @return \DBObject
+	 * @return \DBObject if $bMustBeFoundUnique=true and no object or multiple objects found will throw a CoreException
+	 *                  else will return null
+	 *
 	 * @throws \CoreException
-	 * @throws \Exception
+	 * @throws \CoreUnexpectedValue
+	 * @throws \MissingQueryArgument
+	 * @throws \MySQLException
+	 * @throws \MySQLHasGoneAwayException
+	 *
+	 * @since 2.7.7 Add new $bAllowAllData parameter
 	 */
-	public static function GetObjectByColumn($sClass, $sAttCode, $value, $bMustBeFoundUnique = true)
+	public static function GetObjectByColumn($sClass, $sAttCode, $value, $bMustBeFoundUnique = true, $bAllowAllData = false)
 	{
-		if (!isset(self::$m_aCacheObjectByColumn[$sClass][$sAttCode][$value]))
-		{
+		if (!isset(self::$m_aCacheObjectByColumn[$sClass][$sAttCode][$value])) {
 			self::_check_subclass($sClass);
 
 			$oObjSearch = new DBObjectSearch($sClass);
+			$oObjSearch->AllowAllData($bAllowAllData);
 			$oObjSearch->AddCondition($sAttCode, $value, '=');
 			$oSet = new DBObjectSet($oObjSearch);
 			if ($oSet->Count() == 1)

--- a/datamodels/2.x/itop-portal-base/portal/config/routes/object_brick.yaml
+++ b/datamodels/2.x/itop-portal-base/portal/config/routes/object_brick.yaml
@@ -35,6 +35,11 @@ p_object_view:
   defaults:
     _controller: 'Combodo\iTop\Portal\Controller\ObjectController::ViewAction'
 
+p_object_view_from_attribute:
+  path: '/object/view/{sObjectClass}/{sObjectAttCode}/{sObjectAttValue}'
+  defaults:
+    _controller: 'Combodo\iTop\Portal\Controller\ObjectController::ViewFromAttributeAction'
+
 p_object_apply_stimulus:
   path: '/object/apply-stimulus/{sStimulusCode}/{sObjectClass}/{sObjectId}'
   defaults:

--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
@@ -66,7 +66,7 @@ class ObjectController extends BrickController
 	const DEFAULT_LIST_LENGTH = 10;
 
 	/**
-	 * Displays an cmdbAbstractObject if the connected user is allowed to.
+	 * Displays an cmdbAbstractObject (from its ID) if the connected user is allowed to.
 	 *
 	 * @param \Symfony\Component\HttpFoundation\Request $oRequest
 	 * @param string $sObjectClass (Class must be an instance of cmdbAbstractObject)

--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
@@ -113,6 +113,8 @@ class ObjectController extends BrickController
 	}
 
 	/**
+	 * Displays an cmdbAbstractObject (if the connected user is allowed to) from a specific attribute. If several or none objects are found with the attribute value, an exception is thrown.
+	 * 
 	 * @param \Symfony\Component\HttpFoundation\Request $oRequest
 	 * @param string $sObjectClass (Class must be an instance of cmdbAbstractObject)
 	 * @param string $sObjectAttCode

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -362,7 +362,7 @@ try
 				$sAttCode = utils::ReadParam('attcode', '');
 				$sAttValue = utils::ReadParam('attvalue', '');
 
-				if (empty($sAttCode) || empty($sAttValue)) {
+				if ((strlen($sAttCode) === 0) || (strlen($sAttValue) === 0)) {
 					throw new ApplicationException(Dict::Format('UI:Error:1ParametersMissing', 'id'));
 				}
 

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -363,7 +363,7 @@ try
 				$sAttValue = utils::ReadParam('attvalue', '');
 
 				if (empty($sAttCode) || empty($sAttValue)) {
-					throw new ApplicationException(Dict::Format('UI:Error:2ParametersMissing', 'attcode', 'attvalue'));
+					throw new ApplicationException(Dict::Format('UI:Error:1ParametersMissing', 'id'));
 				}
 
 				$oObj = MetaModel::GetObjectByColumn($sClass, $sAttCode, $sAttValue, true);

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -346,13 +346,19 @@ try
 		
 		case 'details': // Details of an object
 			$sClass = utils::ReadParam('class', '', false, 'class');
-			$id = utils::ReadParam('id', '');
 
 			if (empty($sClass)) {
 				throw new ApplicationException(Dict::Format('UI:Error:1ParametersMissing', 'class'));
 			}
 
-			if (($id === '') || (false === is_numeric($id))) {
+			$id = utils::ReadParam('id', null);
+			if (false === is_null($id)) {
+				if (is_numeric($id)) {
+					$oObj = MetaModel::GetObject($sClass, $id, false /* MustBeFound */);
+				} else {
+					$oObj = MetaModel::GetObjectByName($sClass, $id, false /* MustBeFound */);
+				}
+			} else {
 				$sAttCode = utils::ReadParam('attcode', '');
 				$sAttValue = utils::ReadParam('attvalue', '');
 
@@ -361,10 +367,6 @@ try
 				}
 
 				$oObj = MetaModel::GetObjectByColumn($sClass, $sAttCode, $sAttValue, true);
-			} else if (is_numeric($id)) {
-				$oObj = MetaModel::GetObject($sClass, $id, false /* MustBeFound */);
-			} else {
-				$oObj = MetaModel::GetObjectByName($sClass, $id, false /* MustBeFound */);
 			}
 
 			if (is_null($oObj)) {

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -357,7 +357,7 @@ try
 				$sAttValue = utils::ReadParam('attvalue', '');
 
 				if (empty($sAttCode) || empty($sAttValue)) {
-					throw new ApplicationException(Dict::Format('UI:Error:3ParametersMissing', 'class', 'attcode', 'attvalue'));
+					throw new ApplicationException(Dict::Format('UI:Error:2ParametersMissing', 'attcode', 'attvalue'));
 				}
 
 				$oObj = MetaModel::GetObjectByColumn($sClass, $sAttCode, $sAttValue, true);

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -347,21 +347,27 @@ try
 		case 'details': // Details of an object
 			$sClass = utils::ReadParam('class', '', false, 'class');
 			$id = utils::ReadParam('id', '');
-			if ( empty($sClass) || empty($id))
-			{
-				throw new ApplicationException(Dict::Format('UI:Error:2ParametersMissing', 'class', 'id'));
+
+			if (empty($sClass)) {
+				throw new ApplicationException(Dict::Format('UI:Error:1ParametersMissing', 'class'));
 			}
 
-			if (is_numeric($id))
-			{
+			if (($id === '') || (false === is_numeric($id))) {
+				$sAttCode = utils::ReadParam('attcode', '');
+				$sAttValue = utils::ReadParam('attvalue', '');
+
+				if (empty($sAttCode) || empty($sAttValue)) {
+					throw new ApplicationException(Dict::Format('UI:Error:3ParametersMissing', 'class', 'attcode', 'attvalue'));
+				}
+
+				$oObj = MetaModel::GetObjectByColumn($sClass, $sAttCode, $sAttValue, true);
+			} else if (is_numeric($id)) {
 				$oObj = MetaModel::GetObject($sClass, $id, false /* MustBeFound */);
-			}
-			else
-			{
+			} else {
 				$oObj = MetaModel::GetObjectByName($sClass, $id, false /* MustBeFound */);
 			}
-			if (is_null($oObj))
-			{
+
+			if (is_null($oObj)) {
 				// Check anyhow if there is a message for this object (like you've just created it)
 				$sMessageKey = $sClass.'::'.$id;
 				DisplayMessages($sMessageKey, $oP);
@@ -369,8 +375,7 @@ try
 
 				// Attempt to load the object in archive mode
 				utils::PushArchiveMode(true);
-				if (is_numeric($id))
-				{
+				if (is_numeric($id)) {
 					$oObj = MetaModel::GetObject($sClass, $id, false /* MustBeFound */);
 				}
 				else


### PR DESCRIPTION
## Problem

Since iTop 2.7.0, we are using a different method to init the ref field. Since then in certain cases we can have a different value stored in the reference and in the id field. For more technical details see [Ticket Ref generation](https://www.itophub.io/wiki/page?id=2_7_0%3Arelease%3A2_7_whats_new#ticket_ref_generation)

This can become problematic for the user when he has a ref field containing "R-000100" and an id=99
This means we cannot build an URL to access the object using the ref field value, as accessing object details is done using UI.php with parameters `class` and `id`. For example : `http://localhost/itop-27/pages/UI.php?operation=details&class=UserRequest&id=99`

## Existing workaround

A first workaround is already implemented : the id parameter can contain the friendly name value : in UI.php the object is then seeked using `\MetaModel::GetObjectByName`.
But in certain datamodels the friendlyname can be quite complex...

## New workaround

### Admin Console
This PR brings new `UI.php` URL parameters : `attcode` and `attvalue`.

With the previous example, that means the same object can be accessed using one of those URL : 
`http://localhost/itop-27/pages/UI.php?operation=details&class=UserRequest&id=99`
`http://localhost/itop-27/pages/UI.php?operation=details&class=UserRequest&attcode=ref&attvalue=R-000100`

When using the new URLs, the object retrieval is done using `\MetaModel::GetObjectByColumn`, with the `bMustBeFound` parameter set to `true` : in consequence an exception will be thrown if no object is found, as if multiple instances are.

### User portal
New route : `/object/view/{sObjectClass}/{sObjectAttCode}/{sObjectAttValue}`

For example : 
`http://localhost/itop-27/pages/exec.php/object/view/UserRequest/99?exec_module=itop-portal-base&exec_page=index.php&portal_id=itop-portal`
`http://localhost/itop-27/pages/exec.php/object/view/UserRequest/ref/R-000100?exec_module=itop-portal-base&exec_page=index.php&portal_id=itop-portal`

If none or multiple objects found, then we will get the standard 404 error page (as of the standard object view route).

## Error messages screenshots

### Admin Console : unchanged

- Invalid `class` param (`UI.php?operation=details&class=NotExistingClass&id=1`)
![image](https://user-images.githubusercontent.com/8947448/155511100-56ca535e-5a13-4d67-8748-9669df8ae205.png)

- Invalid `id` param : non existing id or friendlyname (`UI.php?operation=details&class=UserRequest&id=-1`)
![image](https://user-images.githubusercontent.com/8947448/155511182-d0e40b25-2c3f-4936-8bed-4f8f02959062.png)

### Admin Console : updated

- No `class` and `id` params (`UI.php?operation=details`)
Before PR : 
![image](https://user-images.githubusercontent.com/8947448/155511262-a044fefa-eece-49df-9d2f-60bb1bde7a01.png)
After PR : 
![image](https://user-images.githubusercontent.com/8947448/155511285-e2259624-2cf7-4861-9864-93a3f7e4ef52.png)

- No `id` param (`UI.php?operation=details&class=UserRequest`)
Before PR:
![image](https://user-images.githubusercontent.com/8947448/155512497-e52eb3c3-7424-4674-8655-2343316ab6d9.png)
After PR:
![image](https://user-images.githubusercontent.com/8947448/155512619-80ad433b-e954-46f7-b486-5cd0535e6136.png)


### Admin Console : new

- multiple matches when using `attcode` and `attvalue` params
![image](https://user-images.githubusercontent.com/8947448/155511615-bfb22381-eb98-4059-b0a5-63f77368b04b.png)

- no matches when using `attcode` and `attvalue` params
![image](https://user-images.githubusercontent.com/8947448/155511712-0f0e491f-9a62-4c1a-8be5-8d30c57ab15f.png)
