### PR TITLE
:bug: N°4834 - Add the 'pattern' parameter with the unicode Cyrillic block regex to the CKEditor mentions config

### DIFF
--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -2654,10 +2654,11 @@ HTML;
 				$aDefaultConf['mentions'][] = [
 					'feed' => $sMentionEndpoint,
 					'marker' => $sMentionMarker,
-					'minChars' => MetaModel::GetConfig()->Get('min_autocomplete_chars'),
+					'minChars' => $iMinChars = MetaModel::GetConfig()->Get('min_autocomplete_chars'),
 					'itemTemplate' => $sMentionItemTemplate,
 					'outputTemplate' => $sMentionOutputTemplate,
 					'throttle' => 500,
+					'pattern' => "\\{$sMentionMarker}[_a-zA-Z0-9À-žЀ-Ӿ]{{$iMinChars},}$"
 				];
 			}
 		}

--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -2654,11 +2654,10 @@ HTML;
 				$aDefaultConf['mentions'][] = [
 					'feed' => $sMentionEndpoint,
 					'marker' => $sMentionMarker,
-					'minChars' => $iMinChars = MetaModel::GetConfig()->Get('min_autocomplete_chars'),
+					'minChars' => MetaModel::GetConfig()->Get('min_autocomplete_chars'),
 					'itemTemplate' => $sMentionItemTemplate,
 					'outputTemplate' => $sMentionOutputTemplate,
 					'throttle' => 500,
-					'pattern' => "\\{$sMentionMarker}[_a-zA-Z0-9À-žЀ-Ӿ]{{$iMinChars},}$"
 				];
 			}
 		}

--- a/js/ckeditor.on-init.js
+++ b/js/ckeditor.on-init.js
@@ -21,3 +21,24 @@ if ((CKEDITOR !== undefined) && (CKEDITOR.plugins.registered['disabler'] === und
 
 		});
 }
+
+// Rewrite the CKEditor Mentions plugin regexp to make it suitable for all Unicode alphabets.
+if (CKEDITOR !== undefined && CKEDITOR.plugins.registered['mentions']) {
+	// from https://github.com/ckeditor/ckeditor4/blob/a3786007fb979d7d7bff3d10c34a2d422935baed/plugins/mentions/plugin.js#L147
+	function createPattern(marker, minChars) {
+		let pattern = marker + '[\\p{L}\\p{N}_-]';
+		if ( minChars ) {
+			pattern += '{' + minChars + ',}';
+		} else {
+			pattern += '*';
+		}
+		pattern += '$';
+		return new RegExp(pattern, 'u');
+	}
+
+	CKEDITOR.on('instanceLoaded', event => {
+		event.editor.config.mentions.forEach(config => {
+			config.pattern = createPattern(config.marker, config.minChars);
+		});
+	});
+}


### PR DESCRIPTION
So that mentions work with Russian, Ukrainian, Belarusian, Bulgarian and other languages.