### PR TITLE
N°4849 - Enable notification emails grouping in threads in email clients

### DIFF
--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -575,17 +575,16 @@ class ActionEmail extends ActionNotification
 				if ($sHeaderName === static::ENUM_HEADER_NAME_REFERENCES) {
 					$sIdentifier = "<$sIdentifier>";
 				}
-				break;
 
-			default:
-				$sErrorMessage = sprinf('%s: Could not generate identifier for header "%s", only %s are supported', static::class, $sHeaderName, implode(' / ', [static::ENUM_HEADER_NAME_MESSAGE_ID, static::ENUM_HEADER_NAME_REFERENCES]));
-				IssueLog::Error($sErrorMessage, LogChannels::NOTIFICATIONS, [
-					'Object' => $sObjClass.'::'.$sObjId.' ('.$oObject->GetRawName().')',
-					'Action' => get_class($this).'::'.$this->GetKey().' ('.$this->GetRawName().')',
-				]);
-				throw new Exception($sErrorMessage);
+				return $sIdentifier;
 		}
 
-		return $sIdentifier;
+		// Requested header name invalid
+		$sErrorMessage = sprinf('%s: Could not generate identifier for header "%s", only %s are supported', static::class, $sHeaderName, implode(' / ', [static::ENUM_HEADER_NAME_MESSAGE_ID, static::ENUM_HEADER_NAME_REFERENCES]));
+		IssueLog::Error($sErrorMessage, LogChannels::NOTIFICATIONS, [
+			'Object' => $sObjClass.'::'.$sObjId.' ('.$oObject->GetRawName().')',
+			'Action' => get_class($this).'::'.$this->GetKey().' ('.$this->GetRawName().')',
+		]);
+		throw new Exception($sErrorMessage);
 	}
 }

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -579,8 +579,8 @@ class ActionEmail extends ActionNotification
 			default:
 				$sErrorMessage = sprinf('%s: Could not generate identifier for header "%s", only %s are supported', static::class, $sHeaderName, implode(' / ', [static::ENUM_HEADER_NAME_MESSAGE_ID, static::ENUM_HEADER_NAME_REFERENCES]));
 				IssueLog::Error($sErrorMessage, LogChannels::ACTION, [
-					'Object' => $sObjClass.'::'.$sObjId.' ('.$oObject->Get('friendlyname').')',
-					'Action' => get_class($this).'::'.$this->GetKey().' ('.$this->Get('friendlyname').')',
+					'Object' => $sObjClass.'::'.$sObjId.' ('.$oObject->GetRawName().')',
+					'Action' => get_class($this).'::'.$this->GetKey().' ('.$this->GetRawName().')',
 				]);
 				throw new Exception($sErrorMessage);
 		}

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -579,7 +579,7 @@ class ActionEmail extends ActionNotification
 
 			default:
 				$sErrorMessage = sprinf('%s: Could not generate identifier for header "%s", only %s are supported', static::class, $sHeaderName, implode(' / ', [static::ENUM_HEADER_NAME_MESSAGE_ID, static::ENUM_HEADER_NAME_REFERENCES]));
-				IssueLog::Error($sErrorMessage, LogChannels::ACTION, [
+				IssueLog::Error($sErrorMessage, LogChannels::NOTIFICATIONS, [
 					'Object' => $sObjClass.'::'.$sObjId.' ('.$oObject->GetRawName().')',
 					'Action' => get_class($this).'::'.$this->GetKey().' ('.$this->GetRawName().')',
 				]);

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -565,7 +565,7 @@ class ActionEmail extends ActionNotification
 				// Prefix
 				$sPrefix = sprintf('iTop_%s_%d', $sObjClass, $sObjId);
 				if ($sHeaderName === static::ENUM_HEADER_NAME_MESSAGE_ID) {
-					$sPrefix .= sprintf('_%d', microtime(true /* get as float*/));
+					$sPrefix .= sprintf('_%f', microtime(true /* get as float*/));
 				}
 				// Suffix
 				$sSuffix = sprintf('@%s.openitop.org', MetaModel::GetEnvironmentId());

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -558,12 +558,13 @@ class ActionEmail extends ActionNotification
 	{
 		$sObjClass = get_class($oObject);
 		$sObjId = $oObject->GetKey();
+		$sAppName = utils::Sanitize(ITOP_APPLICATION_SHORT, '', utils::ENUM_SANITIZATION_FILTER_VARIABLE_NAME);
 
 		switch ($sHeaderName) {
 			case static::ENUM_HEADER_NAME_MESSAGE_ID:
 			case static::ENUM_HEADER_NAME_REFERENCES:
 				// Prefix
-				$sPrefix = sprintf('iTop_%s_%d', $sObjClass, $sObjId);
+				$sPrefix = sprintf('%s_%s_%d', $sAppName, $sObjClass, $sObjId);
 				if ($sHeaderName === static::ENUM_HEADER_NAME_MESSAGE_ID) {
 					$sPrefix .= sprintf('_%f', microtime(true /* get as float*/));
 				}

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -580,7 +580,7 @@ class ActionEmail extends ActionNotification
 		}
 
 		// Requested header name invalid
-		$sErrorMessage = sprinf('%s: Could not generate identifier for header "%s", only %s are supported', static::class, $sHeaderName, implode(' / ', [static::ENUM_HEADER_NAME_MESSAGE_ID, static::ENUM_HEADER_NAME_REFERENCES]));
+		$sErrorMessage = sprintf('%s: Could not generate identifier for header "%s", only %s are supported', static::class, $sHeaderName, implode(' / ', [static::ENUM_HEADER_NAME_MESSAGE_ID, static::ENUM_HEADER_NAME_REFERENCES]));
 		IssueLog::Error($sErrorMessage, LogChannels::NOTIFICATIONS, [
 			'Object' => $sObjClass.'::'.$sObjId.' ('.$oObject->GetRawName().')',
 			'Action' => get_class($this).'::'.$this->GetKey().' ('.$this->GetRawName().')',

--- a/core/email.class.inc.php
+++ b/core/email.class.inc.php
@@ -325,20 +325,33 @@ class EMail
 		// Note: Swift will add the angle brackets for you
 		// so let's remove the angle brackets if present, for historical reasons
 		$sId = str_replace(array('<', '>'), '', $sId);
-		
+
 		$oMsgId = $this->m_oMessage->getHeaders()->get('Message-ID');
 		$oMsgId->SetId($sId);
 	}
-	
+
 	public function SetReferences($sReferences)
 	{
 		$this->AddToHeader('References', $sReferences);
 	}
 
+	/**
+	 * Set the "In-Reply-To" header to allow emails to group as a conversation in modern mail clients (GMail, Outlook 2016+, ...)
+	 *
+	 * @link https://en.wikipedia.org/wiki/Email#Header_fields
+	 *
+	 * @param string $sMessageId
+	 *
+	 * @since 3.0.1 N°4849
+	 */
+	public function SetInReplyTo(string $sMessageId)
+	{
+		$this->AddToHeader('In-Reply-To', $sMessageId);
+	}
+
 	public function SetBody($sBody, $sMimeType = 'text/html', $sCustomStyles = null)
 	{
-		if (($sMimeType === 'text/html') && ($sCustomStyles !== null))
-		{
+		if (($sMimeType === 'text/html') && ($sCustomStyles !== null)) {
 			$oDomDocument = CssInliner::fromHtml($sBody)->inlineCss($sCustomStyles)->getDomDocument();
 			HtmlPruner::fromDomDocument($oDomDocument)->removeElementsWithDisplayNone();
 			$sBody = CssToAttributeConverter::fromDomDocument($oDomDocument)->convertCssToVisualAttributes()->render(); // Adds html/body tags if not already present

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -544,7 +544,13 @@ class LogChannels
 {
 	public const APC = 'apc';
 
-	public const CLI          = 'CLI';
+	/**
+	 * @var string
+	 * @since 3.0.1 N°4849
+	 */
+	public const ACTION = 'action';
+
+	public const CLI = 'CLI';
 
 	/**
 	 * @var string

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -548,7 +548,7 @@ class LogChannels
 	 * @var string
 	 * @since 3.0.1 N°4849
 	 */
-	public const NOTIFICATIONS = 'action';
+	public const NOTIFICATIONS = 'notifications';
 
 	public const CLI = 'CLI';
 

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -548,7 +548,7 @@ class LogChannels
 	 * @var string
 	 * @since 3.0.1 N°4849
 	 */
-	public const ACTION = 'action';
+	public const NOTIFICATIONS = 'action';
 
 	public const CLI = 'CLI';
 

--- a/test/core/ActionEmailTest.php
+++ b/test/core/ActionEmailTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Combodo\iTop\Test\UnitTest\Core;
+
+use ActionEmail;
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use Exception;
+use MetaModel;
+use utils;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ * @backupGlobals disabled
+ * @covers \ActionEmail
+ */
+class ActionEmailTest extends ItopDataTestCase
+{
+	/**
+	 * @inheritDoc
+	 */
+	const CREATE_TEST_ORG = true;
+
+	/** @var \ActionEmail|null Temp ActionEmail created for tests */
+	protected static $oActionEmail = null;
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		static::$oActionEmail = MetaModel::NewObject('ActionEmail', [
+			'name' => 'Test action',
+			'status' => 'disabled',
+			'from' => 'unit-test@openitop.org',
+			'subject' => 'Test subject',
+			'body' => 'Test body',
+		]);
+		static::$oActionEmail->DBInsert();
+	}
+
+	/**
+	 * @covers \ActionEmail::GenerateIdentifierForHeaders
+	 * @dataProvider GenerateIdentifierForHeadersProvider
+	 * @throws \Exception
+	 */
+	public function testGenerateIdentifierForHeaders(string $sHeaderName)
+	{
+		// Retrieve object
+		$oObject = MetaModel::GetObject('Organization', $this->getTestOrgId(), true, true);
+		$sObjClass = get_class($oObject);
+		$sObjId = $oObject->GetKey();
+
+		try {
+			$sTestedIdentifier = $this->InvokeNonPublicMethod('\ActionEmail', 'GenerateIdentifierForHeaders', static::$oActionEmail, [$oObject, $sHeaderName]);
+		} catch (Exception $oException) {
+			$sTestedIdentifier = null;
+		}
+
+		$sAppName = utils::Sanitize(ITOP_APPLICATION_SHORT, '', utils::ENUM_SANITIZATION_FILTER_VARIABLE_NAME);
+		$sEnvironmentHash = MetaModel::GetEnvironmentId();
+
+		switch ($sHeaderName) {
+			case ActionEmail::ENUM_HEADER_NAME_MESSAGE_ID:
+				// Note: For this test we can't use the more readable sprintf test as the generated timestamp will never be the same as the one generated during the call of the tested method
+				//   $sTimestamp = microtime(true /* get as float*/);
+				//   $sExpectedIdentifier = sprintf('%s_%s_%d_%f@%s.openitop.org', $sAppName, $sObjClass, $sObjId, $sTimestamp, $sEnvironmentHash);
+				$this->assertEquals(1, preg_match('/'.$sAppName.'_'.$sObjClass.'_'.$sObjId.'_[\d]+\.[\d]+@'.$sEnvironmentHash.'.openitop.org/', $sTestedIdentifier), "Identifier doesn't match regexp for header $sHeaderName, got $sTestedIdentifier");
+				break;
+
+			case ActionEmail::ENUM_HEADER_NAME_REFERENCES:
+				$sExpectedIdentifier = '<'.sprintf('%s_%s_%d@%s.openitop.org', $sAppName, $sObjClass, $sObjId, $sEnvironmentHash).'>';
+				$this->assertEquals($sExpectedIdentifier, $sTestedIdentifier);
+				break;
+
+			default:
+				$sExpectedIdentifier = null;
+				$this->assertEquals($sExpectedIdentifier, $sTestedIdentifier);
+				break;
+		}
+
+	}
+
+	public function GenerateIdentifierForHeadersProvider()
+	{
+		return [
+			'Message-ID' => ['Message-ID'],
+			'References' => ['References'],
+			'IncorrectHeaderName' => ['IncorrectHeaderName'],
+		];
+	}
+}


### PR DESCRIPTION
This PR is an attempt and a call for help 😁

### Issue
When we receive notification emails from iTop, they are displayed as different conversations in the email client (eg. Outlook) even though they have the same subject and are about the same iTop object. One of the main drawback is that the mailbox can feel spammed / flooded.

_The first 3 emails are notifications about the same object, but they are already flooding the mailbox folder_
![image](https://user-images.githubusercontent.com/5130468/155285216-424219fc-813e-4e01-a908-1606b2d94500.png)

### Expectation
Find a way to group notification emails for a same object in a thread like email clients do when receiving emails from other platforms.

_Example with comments on a PR on GitHub here_ 
![image](https://user-images.githubusercontent.com/5130468/155285481-adad7a3b-0671-4248-801b-795772fca154.png)

_Example of desired behavior with iTop notification emails_
![image](https://user-images.githubusercontent.com/5130468/155285539-a8716916-9d63-40c3-bfd1-3e06b80f33ef.png)

### What was done so far
#### Specs
From what I saw [here](https://en.wikipedia.org/wiki/Email#Header_fields) and on other sites, it seems that the email needs to have the `In-Reply-To` header, the spec says that it should contain the `Message-ID` of the email to chain to. But we can't do that when it comes to notifications as they are not replies, they have no previous `Message-ID`.

For instance, GitHub is using the same value as in the `References` header in the `In-Reply-To`, this seems to allow emails to group around the same "object", here a PR, but it can be an issue or a commit.
```
[...]

From: xxxx <notifications@github.com>
Reply-To: Combodo/iTop <noreply@github.com>
To: Combodo/iTop <iTop@noreply.github.com>
Cc: Push <push@noreply.github.com>
Message-ID: <Combodo/iTop/pull/262/push/9043873881@github.com>
In-Reply-To: <Combodo/iTop/pull/262@github.com>
References: <Combodo/iTop/pull/262@github.com>
Subject: =?UTF-8?Q?Re:_[Combodo/iTop]_=F0=9F=8C=90Updated_Dutch_transl?=
 =?UTF-8?Q?ations_=28PR_#262=29?=

[...]
```

It is pretty clear that the `Message-ID` is unique to the email, but that `References` and `In-Reply-To` are common to all emails regarding this PR.

#### Implementation
Previously, both `Message-ID` and `References` headers had the same value, it contained the object class, the object ID, the current timestamp and an identifier of the current instance.

```
[...]

Message-ID: <iTop_UserRequest_542_1645547692.537156@8c43a16d628776c7a7098fae22c1e880-production.openitop.org>
Date: Tue, 22 Feb 2022 17:35:00 +0100
Subject: The ticket R-000561 has been updated
From: <guillaume.lajarige@combodo.com>
To: <guillaume.lajarige@combodo.com>
References: <iTop_UserRequest_542_1645547692.537156@8c43a16d628776c7a7098fae22c1e880-production.openitop.org>

[...]
```

With this PR the following things have been done:
  * Change the `References` header so it is common to all emails about the triggering object by removing the timestamp part.
  * Add a `In-Reply-To` header with the same value as the `References`

```
Message-ID: <iTop_UserRequest_542_1645604682@8c43a16d628776c7a7098fae22c1e880-production.openitop.org>
Date: Wed, 23 Feb 2022 09:24:42 +0100
Subject: The ticket R-000561 has been updated
From: <guillaume.lajarige@combodo.com>
To: <guillaume.lajarige@combodo.com>
References: <iTop_UserRequest_542@8c43a16d628776c7a7098fae22c1e880-production.openitop.org>
In-Reply-To: <iTop_UserRequest_542@8c43a16d628776c7a7098fae22c1e880-production.openitop.org>
```

#### Results
  * Grouping works for same subject in GMail, but it was actually already working before as it seems to match on the subject anyway.
  * Grouping works for same subject in Evolution since the PR.
  * Grouping works for same subject in Apple's Mail since this PR.
  * Grouping does NOT works in Outlook 2013 or Outlook Online.
    * Workaround is to prefix notifications with "RE: "

### What's next
  - [X] Find why it's not working on Outlook
  - [x] Add a unit test for the \ActionEmail::GenerateIdentifierForHeaders() method