### PR TITLE
N°4947 Fix \EMail::LoadConfig

### DIFF
--- a/core/email.class.inc.php
+++ b/core/email.class.inc.php
@@ -161,8 +161,6 @@ class EMail
 		// If the body of the message is in HTML, embed all images based on attachments
 		$this->EmbedInlineImages();
 		
-		$this->LoadConfig();
-
 		$sTransport = self::$m_oConfig->Get('email_transport');
 		switch ($sTransport)
 		{

--- a/core/email.class.inc.php
+++ b/core/email.class.inc.php
@@ -54,7 +54,13 @@ class EMail
 	{
 		$this->m_aData = array();
 		$this->m_oMessage = Swift_Message::newInstance();
-		$this->SetRecipientFrom(MetaModel::GetConfig()->Get('email_default_sender_address'), MetaModel::GetConfig()->Get('email_default_sender_label'));
+
+		$this->LoadConfig();
+		$oConfig = self::$m_oConfig;
+		$this->SetRecipientFrom(
+			$oConfig->Get('email_default_sender_address'),
+			$oConfig->Get('email_default_sender_label')
+		);
 	}
 
 	/**

--- a/core/email.class.inc.php
+++ b/core/email.class.inc.php
@@ -41,11 +41,10 @@ class EMail
 	protected static $m_oConfig = null;
 	protected $m_aData; // For storing data to serialize
 
-	public function LoadConfig($sConfigFile = ITOP_DEFAULT_CONFIG_FILE)
+	public function LoadConfig()
 	{
-		if (is_null(self::$m_oConfig))
-		{
-			self::$m_oConfig = new Config($sConfigFile);
+		if (is_null(self::$m_oConfig)) {
+			self::$m_oConfig = utils::GetConfig();
 		}
 	}
 

--- a/core/email.class.inc.php
+++ b/core/email.class.inc.php
@@ -56,7 +56,7 @@ class EMail
 		$this->m_oMessage = Swift_Message::newInstance();
 
 		$this->LoadConfig();
-		$oConfig = self::$m_oConfig;
+		$oConfig = static::$m_oConfig;
 		$this->SetRecipientFrom(
 			$oConfig->Get('email_default_sender_address'),
 			$oConfig->Get('email_default_sender_label')
@@ -160,24 +160,23 @@ class EMail
 	{
 		// If the body of the message is in HTML, embed all images based on attachments
 		$this->EmbedInlineImages();
-		
-		$sTransport = self::$m_oConfig->Get('email_transport');
+
+		$sTransport = static::$m_oConfig->Get('email_transport');
 		switch ($sTransport)
 		{
-		case 'SMTP':
-			$sHost = self::$m_oConfig->Get('email_transport_smtp.host');
-			$sPort = self::$m_oConfig->Get('email_transport_smtp.port');
-			$sEncryption = self::$m_oConfig->Get('email_transport_smtp.encryption');
-			$sUserName = self::$m_oConfig->Get('email_transport_smtp.username');
-			$sPassword = self::$m_oConfig->Get('email_transport_smtp.password');
+			case 'SMTP':
+				$sHost = static::$m_oConfig->Get('email_transport_smtp.host');
+				$sPort = static::$m_oConfig->Get('email_transport_smtp.port');
+				$sEncryption = static::$m_oConfig->Get('email_transport_smtp.encryption');
+				$sUserName = static::$m_oConfig->Get('email_transport_smtp.username');
+				$sPassword = static::$m_oConfig->Get('email_transport_smtp.password');
 
-			$oTransport = Swift_SmtpTransport::newInstance($sHost, $sPort, $sEncryption);
-			if (strlen($sUserName) > 0)
-			{
-				$oTransport->setUsername($sUserName);
-				$oTransport->setPassword($sPassword);
-			}
-			break;
+				$oTransport = Swift_SmtpTransport::newInstance($sHost, $sPort, $sEncryption);
+				if (strlen($sUserName) > 0) {
+					$oTransport->setUsername($sUserName);
+					$oTransport->setPassword($sPassword);
+				}
+				break;
 
 		case 'Null':
 			$oTransport = Swift_NullTransport::newInstance();

--- a/core/email.class.inc.php
+++ b/core/email.class.inc.php
@@ -43,8 +43,8 @@ class EMail
 
 	public function LoadConfig()
 	{
-		if (is_null(self::$m_oConfig)) {
-			self::$m_oConfig = utils::GetConfig();
+		if (is_null(static::$m_oConfig)) {
+			static::$m_oConfig = utils::GetConfig();
 		}
 	}
 

--- a/core/email.class.inc.php
+++ b/core/email.class.inc.php
@@ -42,8 +42,13 @@ class EMail
 	protected $m_aData; // For storing data to serialize
 
 	/**
+	 * Sets {@see m_oConfig} if current attribute is null
+	 *
+	 * @returns \Config the current {@see m_oConfig} value
 	 * @throws \ConfigException
 	 * @throws \CoreException
+	 *
+	 * @uses utils::GetConfig()
 	 *
 	 * @since 2.7.8 3.0.2 3.1.0 N°4947
 	 */
@@ -52,6 +57,8 @@ class EMail
 		if (is_null(static::$m_oConfig)) {
 			static::$m_oConfig = utils::GetConfig();
 		}
+
+		return static::$m_oConfig;
 	}
 
 	protected $m_oMessage;
@@ -61,8 +68,7 @@ class EMail
 		$this->m_aData = array();
 		$this->m_oMessage = Swift_Message::newInstance();
 
-		$this->LoadConfig();
-		$oConfig = static::$m_oConfig;
+		$oConfig = $this->LoadConfig();
 		$this->SetRecipientFrom(
 			$oConfig->Get('email_default_sender_address'),
 			$oConfig->Get('email_default_sender_label')

--- a/core/email.class.inc.php
+++ b/core/email.class.inc.php
@@ -35,12 +35,18 @@ class EMail
 {
 	// Serialization formats
 	const ORIGINAL_FORMAT = 1; // Original format, consisting in serializing the whole object, inculding the Swift Mailer's object.
-							   // Did not work with attachements since their binary representation cannot be stored as a valid UTF-8 string
+	// Did not work with attachements since their binary representation cannot be stored as a valid UTF-8 string
 	const FORMAT_V2 = 2; // New format, only the raw data are serialized (base64 encoded if needed)
-	
+
 	protected static $m_oConfig = null;
 	protected $m_aData; // For storing data to serialize
 
+	/**
+	 * @throws \ConfigException
+	 * @throws \CoreException
+	 *
+	 * @since 2.7.8 3.0.2 3.1.0 N°4947
+	 */
 	public function LoadConfig()
 	{
 		if (is_null(static::$m_oConfig)) {


### PR DESCRIPTION
In `\EMail::SendSynchronous` we are calling `\EMail::LoadConfig`.
This method uses the `ITOP_DEFAULT_CONFIG_FILE` constant, and as a consequence is always loading config using the production environment.

This PR changes the loading and now uses the standard `\utils::GetConfig` method !

Config was saved in the `\EMail::$m_oConfig` attribute : it is only written there.
The `ITOP_DEFAULT_CONFIG_FILE` constant is only used in the toolkit and `sources/application/status/status.inc.php`.  All of those usages seems legit to me so I'm not changing them in this PR.

Thanks to @jbostoen for the bug report (see https://github.com/Combodo/iTop/pull/223#issuecomment-1064854430) !
