### PR TITLE
N°5072 - Fix default priority to undefined (null) or default value if not nullable

### DIFF
--- a/datamodels/2.x/itop-incident-mgmt-itil/datamodel.itop-incident-mgmt-itil.xml
+++ b/datamodels/2.x/itop-incident-mgmt-itil/datamodel.itop-incident-mgmt-itil.xml
@@ -1142,43 +1142,40 @@
 					<static>false</static>
 					<access>public</access>
 					<type>LifecycleAction</type>
-					<code><![CDATA[        public function ComputePriority()
-        {
-                // priority[impact][urgency]
-                $aPriorities = array(
-                        // single person
-                        1 => array(
-                                        1 => 1,
-                                        2 => 1,
-                                        3 => 2,
-                                        4 => 4,
-                        ),
-                        // a group
-                        2 => array(
-                                1 => 1,
-                                2 => 2,
-                                3 => 3,
-                                4 => 4,
-                        ),
-                        // a departement!
-                        3 => array(
-                                        1 => 2,
-                                        2 => 3,
-                                        3 => 3,
-                                        4 => 4,
-                        ),
-                );
-                $iPriority = null;
-                $oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
-				if (!$oAttDef->IsNullAllowed()) {
-					$iPriority = $oAttDef->GetDefaultValue();
-				}
+					<code><![CDATA[public function ComputePriority()
+	{
+		// priority[impact][urgency]
+		$aPriorities = array(
+			// single person
+			1 => array(
+				1 => 1,
+				2 => 1,
+				3 => 2,
+				4 => 4,
+			),
+			// a group
+			2 => array(
+				1 => 1,
+				2 => 2,
+				3 => 3,
+				4 => 4,
+			),
+			// a departement!
+			3 => array(
+				1 => 2,
+				2 => 3,
+				3 => 3,
+				4 => 4,
+			),
+		);
+		$oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
+		$iPriority = $oAttDef->IsNullAllowed() ? null : $oAttDef->GetDefaultValue();
 
-                if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')])) {
-                        $iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];
-                }
-                return $iPriority;              
-        }]]></code>
+		if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')])) {
+			$iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];
+		}
+		return $iPriority;
+	}]]></code>
 				</method>
 				<method id="ComputeValues">
 					<static>false</static>

--- a/datamodels/2.x/itop-incident-mgmt-itil/datamodel.itop-incident-mgmt-itil.xml
+++ b/datamodels/2.x/itop-incident-mgmt-itil/datamodel.itop-incident-mgmt-itil.xml
@@ -1168,7 +1168,7 @@
                                         4 => 4,
                         ),
                 );
-                $iPriority = 1;
+                $iPriority = null;
                 if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')]))
                 {
                         $iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];

--- a/datamodels/2.x/itop-incident-mgmt-itil/datamodel.itop-incident-mgmt-itil.xml
+++ b/datamodels/2.x/itop-incident-mgmt-itil/datamodel.itop-incident-mgmt-itil.xml
@@ -1169,8 +1169,12 @@
                         ),
                 );
                 $iPriority = null;
-                if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')]))
-                {
+                $oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
+				if (!$oAttDef->IsNullAllowed()) {
+					$iPriority = $oAttDef->GetDefaultValue();
+				}
+
+                if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')])) {
                         $iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];
                 }
                 return $iPriority;              
@@ -1184,12 +1188,7 @@
 	{
 
 		// Compute the priority of the ticket
-		$iPriority = $this->ComputePriority();
-		$oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
-		if(is_null($iPriority) && !$oAttDef->IsNullAllowed()){
-			$iPriority = $oAttDef->GetDefaultValue();
-		}
-		$this->Set('priority', $iPriority);
+		$this->Set('priority', $this->ComputePriority());
 
 		return parent::ComputeValues();
 	}]]></code>

--- a/datamodels/2.x/itop-incident-mgmt-itil/datamodel.itop-incident-mgmt-itil.xml
+++ b/datamodels/2.x/itop-incident-mgmt-itil/datamodel.itop-incident-mgmt-itil.xml
@@ -1184,7 +1184,12 @@
 	{
 
 		// Compute the priority of the ticket
-		$this->Set('priority', $this->ComputePriority());
+		$iPriority = $this->ComputePriority();
+		$oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
+		if(is_null($iPriority) && !$oAttDef->IsNullAllowed()){
+			$iPriority = $oAttDef->GetDefaultValue();
+		}
+		$this->Set('priority', $iPriority);
 
 		return parent::ComputeValues();
 	}]]></code>

--- a/datamodels/2.x/itop-problem-mgmt/datamodel.itop-problem-mgmt.xml
+++ b/datamodels/2.x/itop-problem-mgmt/datamodel.itop-problem-mgmt.xml
@@ -508,8 +508,12 @@
                         ),
                 );
                 $iPriority = null;
-                if (isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')]))
-                {
+                $oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
+				if (!$oAttDef->IsNullAllowed()) {
+					$iPriority = $oAttDef->GetDefaultValue();
+				}
+
+                if (isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')])) {
                         $iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];
                 }
                 return $iPriority;              
@@ -522,12 +526,7 @@
                     <code><![CDATA[	public function ComputeValues()
 	{
 		// Compute the priority of the ticket
-		$iPriority = $this->ComputePriority();
-		$oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
-		if(is_null($iPriority) && !$oAttDef->IsNullAllowed()){
-			$iPriority = $oAttDef->GetDefaultValue();
-		}
-		$this->Set('priority', $iPriority);
+		$this->Set('priority', $this->ComputePriority());
 	}]]></code>
                 </method>
                 <method id="OnInsert">

--- a/datamodels/2.x/itop-problem-mgmt/datamodel.itop-problem-mgmt.xml
+++ b/datamodels/2.x/itop-problem-mgmt/datamodel.itop-problem-mgmt.xml
@@ -510,8 +510,8 @@
 		$oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
 		$iPriority = $oAttDef->IsNullAllowed() ? null : $oAttDef->GetDefaultValue();
 
-		if (isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')])) {
-		$iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];
+		if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')])) {
+			$iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];
 		}
 		return $iPriority;
 	}]]></code>

--- a/datamodels/2.x/itop-problem-mgmt/datamodel.itop-problem-mgmt.xml
+++ b/datamodels/2.x/itop-problem-mgmt/datamodel.itop-problem-mgmt.xml
@@ -507,7 +507,7 @@
                                         4 => 4,
                         ),
                 );
-                $iPriority = 1;
+                $iPriority = null;
                 if (isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')]))
                 {
                         $iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];

--- a/datamodels/2.x/itop-problem-mgmt/datamodel.itop-problem-mgmt.xml
+++ b/datamodels/2.x/itop-problem-mgmt/datamodel.itop-problem-mgmt.xml
@@ -172,7 +172,7 @@
                         </value>
                     </values>
                     <sql>priority</sql>
-                    <default_value>1</default_value>
+                    <default_value>4</default_value>
                     <is_null_allowed>false</is_null_allowed>
                     <display_style>list</display_style>
                 </field>
@@ -522,7 +522,12 @@
                     <code><![CDATA[	public function ComputeValues()
 	{
 		// Compute the priority of the ticket
-		$this->Set('priority', $this->ComputePriority());
+		$iPriority = $this->ComputePriority();
+		$oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
+		if(is_null($iPriority) && !$oAttDef->IsNullAllowed()){
+			$iPriority = $oAttDef->GetDefaultValue();
+		}
+		$this->Set('priority', $iPriority);
 	}]]></code>
                 </method>
                 <method id="OnInsert">

--- a/datamodels/2.x/itop-problem-mgmt/datamodel.itop-problem-mgmt.xml
+++ b/datamodels/2.x/itop-problem-mgmt/datamodel.itop-problem-mgmt.xml
@@ -481,43 +481,40 @@
                     <static>false</static>
                     <access>public</access>
                     <type>LifecycleAction</type>
-                    <code><![CDATA[        public function ComputePriority()
-        {
-                // priority[impact][urgency]
-                $aPriorities = array(
-                        // single person
-                        1 => array(
-                                        1 => 1,
-                                        2 => 1,
-                                        3 => 2,
-                                        4 => 4,
-                        ),
-                        // a group
-                        2 => array(
-                                1 => 1,
-                                2 => 2,
-                                3 => 3,
-                                4 => 4,
-                        ),
-                        // a departement!
-                        3 => array(
-                                        1 => 2,
-                                        2 => 3,
-                                        3 => 3,
-                                        4 => 4,
-                        ),
-                );
-                $iPriority = null;
-                $oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
-				if (!$oAttDef->IsNullAllowed()) {
-					$iPriority = $oAttDef->GetDefaultValue();
-				}
+                    <code><![CDATA[public function ComputePriority()
+	{
+		// priority[impact][urgency]
+		$aPriorities = array(
+			// single person
+			1 => array(
+				1 => 1,
+				2 => 1,
+				3 => 2,
+				4 => 4,
+			),
+			// a group
+			2 => array(
+				1 => 1,
+				2 => 2,
+				3 => 3,
+				4 => 4,
+			),
+			// a departement!
+			3 => array(
+				1 => 2,
+				2 => 3,
+				3 => 3,
+				4 => 4,
+			),
+		);
+		$oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
+		$iPriority = $oAttDef->IsNullAllowed() ? null : $oAttDef->GetDefaultValue();
 
-                if (isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')])) {
-                        $iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];
-                }
-                return $iPriority;              
-        }]]></code>
+		if (isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')])) {
+		$iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];
+		}
+		return $iPriority;
+	}]]></code>
                 </method>
                 <method id="ComputeValues">
                     <static>false</static>

--- a/datamodels/2.x/itop-request-mgmt-itil/datamodel.itop-request-mgmt-itil.xml
+++ b/datamodels/2.x/itop-request-mgmt-itil/datamodel.itop-request-mgmt-itil.xml
@@ -1329,8 +1329,12 @@
                         ),
                 );
                 $iPriority = null;
-                if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')]))
-                {
+                $oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
+				if (!$oAttDef->IsNullAllowed()) {
+					$iPriority = $oAttDef->GetDefaultValue();
+				}
+
+                if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')])) {
                         $iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];
                 }
                 return $iPriority;              
@@ -1344,12 +1348,7 @@
 	{
 
 		// Compute the priority of the ticket
-		$iPriority = $this->ComputePriority();
-		$oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
-		if(is_null($iPriority) && !$oAttDef->IsNullAllowed()){
-			$iPriority = $oAttDef->GetDefaultValue();
-		}
-		$this->Set('priority', $iPriority);
+		$this->Set('priority', $this->ComputePriority());
 
 		return parent::ComputeValues();
 	}]]></code>

--- a/datamodels/2.x/itop-request-mgmt-itil/datamodel.itop-request-mgmt-itil.xml
+++ b/datamodels/2.x/itop-request-mgmt-itil/datamodel.itop-request-mgmt-itil.xml
@@ -1302,43 +1302,40 @@
 					<static>false</static>
 					<access>public</access>
 					<type>LifecycleAction</type>
-					<code><![CDATA[        public function ComputePriority()
-        {
-                // priority[impact][urgency]
-                $aPriorities = array(
-                        // a department
-                        1 => array(
-                                        1 => 1,
-                                        2 => 1,
-                                        3 => 2,
-                                        4 => 4,
-                        ),
-                        // a group
-                        2 => array(
-                                1 => 1,
-                                2 => 2,
-                                3 => 3,
-                                4 => 4,
-                        ),
-                        // a person
-                        3 => array(
-                                        1 => 2,
-                                        2 => 3,
-                                        3 => 3,
-                                        4 => 4,
-                        ),
-                );
-                $iPriority = null;
-                $oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
-				if (!$oAttDef->IsNullAllowed()) {
-					$iPriority = $oAttDef->GetDefaultValue();
-				}
+					<code><![CDATA[public function ComputePriority()
+	{
+		// priority[impact][urgency]
+		$aPriorities = array(
+			// a department
+			1 => array(
+				1 => 1,
+				2 => 1,
+				3 => 2,
+				4 => 4,
+			),
+			// a group
+			2 => array(
+				1 => 1,
+				2 => 2,
+				3 => 3,
+				4 => 4,
+			),
+			// a person
+			3 => array(
+				1 => 2,
+				2 => 3,
+				3 => 3,
+				4 => 4,
+			),
+		);
+		$oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
+		$iPriority = $oAttDef->IsNullAllowed() ? null : $oAttDef->GetDefaultValue();
 
-                if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')])) {
-                        $iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];
-                }
-                return $iPriority;              
-        }]]></code>
+		if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')])) {
+			$iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];
+		}
+		return $iPriority;
+	}]]></code>
 				</method>
 				<method id="ComputeValues">
 					<static>false</static>

--- a/datamodels/2.x/itop-request-mgmt-itil/datamodel.itop-request-mgmt-itil.xml
+++ b/datamodels/2.x/itop-request-mgmt-itil/datamodel.itop-request-mgmt-itil.xml
@@ -1328,7 +1328,7 @@
                                         4 => 4,
                         ),
                 );
-                $iPriority = 1;
+                $iPriority = null;
                 if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')]))
                 {
                         $iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];

--- a/datamodels/2.x/itop-request-mgmt-itil/datamodel.itop-request-mgmt-itil.xml
+++ b/datamodels/2.x/itop-request-mgmt-itil/datamodel.itop-request-mgmt-itil.xml
@@ -1344,7 +1344,12 @@
 	{
 
 		// Compute the priority of the ticket
-		$this->Set('priority', $this->ComputePriority());
+		$iPriority = $this->ComputePriority();
+		$oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
+		if(is_null($iPriority) && !$oAttDef->IsNullAllowed()){
+			$iPriority = $oAttDef->GetDefaultValue();
+		}
+		$this->Set('priority', $iPriority);
 
 		return parent::ComputeValues();
 	}]]></code>

--- a/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
+++ b/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
@@ -1363,8 +1363,12 @@
                         ),
                 );
                 $iPriority = null;
-                if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')]))
-                {
+                $oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
+				if (!$oAttDef->IsNullAllowed()) {
+					$iPriority = $oAttDef->GetDefaultValue();
+				}
+
+                if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')])) {
                         $iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];
                 }
                 return $iPriority;              
@@ -1377,12 +1381,7 @@
                     <code><![CDATA[	public function ComputeValues()
 	{
 		// Compute the priority of the ticket
-		$iPriority = $this->ComputePriority();
-		$oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
-		if(is_null($iPriority) && !$oAttDef->IsNullAllowed()){
-			$iPriority = $oAttDef->GetDefaultValue();
-		}
-		$this->Set('priority', $iPriority);
+		$this->Set('priority', $this->ComputePriority());
 
 		// Compute the request_type if not already defined (by the user)
 		$sType = $this->Get('request_type');

--- a/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
+++ b/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
@@ -1362,7 +1362,7 @@
                                         4 => 4,
                         ),
                 );
-                $iPriority = 1;
+                $iPriority = null;
                 if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')]))
                 {
                         $iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];

--- a/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
+++ b/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
@@ -1336,43 +1336,40 @@
                     <static>false</static>
                     <access>public</access>
                     <type>LifecycleAction</type>
-                    <code><![CDATA[        public function ComputePriority()
-        {
-                // priority[impact][urgency]
-                $aPriorities = array(
-                        // a department
-                        1 => array(
-                                        1 => 1,
-                                        2 => 1,
-                                        3 => 2,
-                                        4 => 4,
-                        ),
-                        // a group
-                        2 => array(
-                                1 => 1,
-                                2 => 2,
-                                3 => 3,
-                                4 => 4,
-                        ),
-                        // a person
-                        3 => array(
-                                        1 => 2,
-                                        2 => 3,
-                                        3 => 3,
-                                        4 => 4,
-                        ),
-                );
-                $iPriority = null;
-                $oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
-				if (!$oAttDef->IsNullAllowed()) {
-					$iPriority = $oAttDef->GetDefaultValue();
-				}
+                    <code><![CDATA[public function ComputePriority()
+	{
+		// priority[impact][urgency]
+		$aPriorities = array(
+			// a department
+			1 => array(
+				1 => 1,
+				2 => 1,
+				3 => 2,
+				4 => 4,
+			),
+			// a group
+			2 => array(
+				1 => 1,
+				2 => 2,
+				3 => 3,
+				4 => 4,
+			),
+			// a person
+			3 => array(
+				1 => 2,
+				2 => 3,
+				3 => 3,
+				4 => 4,
+			),
+		);
+		$oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
+		$iPriority = $oAttDef->IsNullAllowed() ? null : $oAttDef->GetDefaultValue();
 
-                if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')])) {
-                        $iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];
-                }
-                return $iPriority;              
-        }]]></code>
+		if (isset($aPriorities[(int)$this->Get('impact')]) && isset($aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')])) {
+			$iPriority = $aPriorities[(int)$this->Get('impact')][(int)$this->Get('urgency')];
+		}
+		return $iPriority;
+	}]]></code>
                 </method>
                 <method id="ComputeValues">
                     <static>false</static>

--- a/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
+++ b/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
@@ -1377,7 +1377,12 @@
                     <code><![CDATA[	public function ComputeValues()
 	{
 		// Compute the priority of the ticket
-		$this->Set('priority', $this->ComputePriority());
+		$iPriority = $this->ComputePriority();
+		$oAttDef = MetaModel::GetAttributeDef(get_class($this), 'priority');
+		if(is_null($iPriority) && !$oAttDef->IsNullAllowed()){
+			$iPriority = $oAttDef->GetDefaultValue();
+		}
+		$this->Set('priority', $iPriority);
 
 		// Compute the request_type if not already defined (by the user)
 		$sType = $this->Get('request_type');


### PR DESCRIPTION
By default, if no urgency or impact have been selected in a user request, the priority shown is "Critical"
![priority_01](https://user-images.githubusercontent.com/101416770/157911742-4b311f87-b720-411c-929e-948e7c80315e.png)

It is misleading when the impact is set to only one person : changing the value of urgency from "undefined" to "critical" change the priority from "Critical" to "High" !
![priority_02](https://user-images.githubusercontent.com/101416770/157910724-bb6237d3-9a55-4023-9414-b28bfde2c399.png)

I suggest changing the default priority (when no priority can be computed) to undefined ($iPriority is null)
![priority_fixed](https://user-images.githubusercontent.com/101416770/157911233-fd1e87f9-4d40-462d-a3b3-2c2f2a571136.png)

The provided implementation has been tested on the 4 cases : user request (all in one), user request (itil), incident and problem
This behavior was already present in previous versions.