### PR TITLE
N°5090 Setup : improve missing dependencies message

### DIFF
--- a/setup/modulediscovery.class.inc.php
+++ b/setup/modulediscovery.class.inc.php
@@ -36,10 +36,20 @@ class MissingDependencyException extends CoreException
 HTML;
 		foreach ($this->aModulesInfo as $sModuleId => $aModuleErrors) {
 			$sModuleLabel = $aModuleErrors['module']['label'];
-			$sModuleMissingDependencies = implode(' + ', $aModuleErrors['dependencies']);
+			$aModuleMissingDependencies = $aModuleErrors['dependencies'];
 			$sErrorMessage .= <<<HTML
-	<li>{$sModuleLabel} ({$sModuleId}): {$sModuleMissingDependencies}</li>
+	<li><strong>{$sModuleLabel} ({$sModuleId})</strong>:
+		<ul>
 HTML;
+
+			foreach ($aModuleMissingDependencies as $sMissingModule) {
+				$sErrorMessage .= "<li>{$sMissingModule}</li>";
+			}
+			$sErrorMessage .= <<<HTML
+		</ul>
+	</li>
+HTML;
+
 		}
 		$sErrorMessage .= '</ul>';
 

--- a/setup/modulediscovery.class.inc.php
+++ b/setup/modulediscovery.class.inc.php
@@ -22,7 +22,7 @@
 class MissingDependencyException extends CoreException
 {
 	/**
-	 * @see init in OrderModulesByDependencies
+	 * @see \ModuleDiscovery::OrderModulesByDependencies property init
 	 * @var array module id as key
 	 *            another array as value, containing : 'module' with module info, 'dependencies' with missing dependencies
 	 */

--- a/setup/modulediscovery.class.inc.php
+++ b/setup/modulediscovery.class.inc.php
@@ -28,6 +28,10 @@ class MissingDependencyException extends CoreException
 	 */
 	public $aModulesInfo;
 
+	/**
+	 * @return string HTML to print to the user the modules impacted
+	 * @since 2.7.7 3.0.2 3.1.0 PR #280
+	 */
 	public function GetMessageForHtml()
 	{
 		$sErrorMessage = <<<HTML

--- a/setup/modulediscovery.class.inc.php
+++ b/setup/modulediscovery.class.inc.php
@@ -32,7 +32,7 @@ class MissingDependencyException extends CoreException
 	 * @return string HTML to print to the user the modules impacted
 	 * @since 2.7.7 3.0.2 3.1.0 PR #280
 	 */
-	public function GetMessageForHtml()
+	public function getHtmlDesc($sHighlightHtmlBegin = null, $sHighlightHtmlEnd = null)
 	{
 		$sErrorMessage = <<<HTML
 <p>The following modules have unmet dependencies:</p>

--- a/setup/modulediscovery.class.inc.php
+++ b/setup/modulediscovery.class.inc.php
@@ -38,7 +38,7 @@ HTML;
 			$sModuleLabel = $aModuleErrors['module']['label'];
 			$aModuleMissingDependencies = $aModuleErrors['dependencies'];
 			$sErrorMessage .= <<<HTML
-	<li><strong>{$sModuleLabel} ({$sModuleId})</strong>:
+	<li><strong>{$sModuleLabel}</strong> ({$sModuleId}):
 		<ul>
 HTML;
 

--- a/setup/modulediscovery.class.inc.php
+++ b/setup/modulediscovery.class.inc.php
@@ -19,9 +19,32 @@
  *
  */
 
-class MissingDependencyException extends Exception
+class MissingDependencyException extends CoreException
 {
+	/**
+	 * @see init in OrderModulesByDependencies
+	 * @var array module id as key
+	 *            another array as value, containing : 'module' with module info, 'dependencies' with missing dependencies
+	 */
 	public $aModulesInfo;
+
+	public function GetMessageForHtml()
+	{
+		$sErrorMessage = <<<HTML
+<p>The following modules have unmet dependencies:</p>
+<ul>
+HTML;
+		foreach ($this->aModulesInfo as $sModuleId => $aModuleErrors) {
+			$sModuleLabel = $aModuleErrors['module']['label'];
+			$sModuleMissingDependencies = implode(' + ', $aModuleErrors['dependencies']);
+			$sErrorMessage .= <<<HTML
+	<li>{$sModuleLabel} ({$sModuleId}): {$sModuleMissingDependencies}</li>
+HTML;
+		}
+		$sErrorMessage .= '</ul>';
+
+		return $sErrorMessage;
+	}
 }
 
 class ModuleDiscovery

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -1351,7 +1351,7 @@ class WizStepModulesChoice extends WizardStep
 		}
 		catch(MissingDependencyException $e)
 		{
-			$oPage->warning($e->GetMessageForHtml());
+			$oPage->warning($e->getHtmlDesc());
 		}
 
 		$this->bUpgrade = ($this->oWizard->GetParameter('install_mode') != 'install');
@@ -2092,7 +2092,7 @@ class WizStepSummary extends WizardStep
 			catch(MissingDependencyException $e)
 			{
 				$this->bDependencyCheck = false;
-				$this->sDependencyIssue = $e->GetMessageForHtml();
+				$this->sDependencyIssue = $e->getHtmlDesc();
 			}
 		}
 		return $this->bDependencyCheck;

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -1351,7 +1351,7 @@ class WizStepModulesChoice extends WizardStep
 		}
 		catch(MissingDependencyException $e)
 		{
-			$oPage->warning($e->getMessage());
+			$oPage->warning($e->GetMessageForHtml());
 		}
 
 		$this->bUpgrade = ($this->oWizard->GetParameter('install_mode') != 'install');
@@ -2092,7 +2092,7 @@ class WizStepSummary extends WizardStep
 			catch(MissingDependencyException $e)
 			{
 				$this->bDependencyCheck = false;
-				$this->sDependencyIssue = $e->getMessage();
+				$this->sDependencyIssue = $e->GetMessageForHtml();
 			}
 		}
 		return $this->bDependencyCheck;


### PR DESCRIPTION
To reproduce, simply add a single module that is part of a multi module extension. 
For example itop-approval-portal or itop-standard-email-synchro

Before PR you'll get : 

![image](https://user-images.githubusercontent.com/8947448/159303923-3e5699d0-f4b6-4d9a-8514-5d9ec42e5f06.png)

After PR : 

![image](https://user-images.githubusercontent.com/8947448/159687942-22d70ff6-f17c-44d8-a5d8-65c5c6bebe94.png)

I also changed the MissingDependencyException parent (from Exception to CoreException), as this is an iTop exception !
