### PR TITLE
N°4998 Fix CSS for AttributeDuration in transition form

### DIFF
--- a/css/light-grey.scss
+++ b/css/light-grey.scss
@@ -2424,26 +2424,33 @@ fieldset .details>.field_container {
 
 								.selectize-dropdown,
 								.selectize-input,
-								.selectize-input input{
-									font-size: 12px;
-								}
-								.selectize-input{
-									padding: 2px 2px 0px 2px; /* padding-bottom = padding-top - item margin-bottom */
-									border: 1px solid #ABABAB;
-									border-radius: 0;
+                .selectize-input input {
+                  font-size: 12px;
+                }
 
-									.attribute-set-item.partial-code{
-										color: transparentize($gray-darker, 0.4);
-										background-color: lighten($gray-lighter, 5%);
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+                .selectize-input {
+                  padding: 2px 2px 0px 2px; /* padding-bottom = padding-top - item margin-bottom */
+                  border: 1px solid #ABABAB;
+                  border-radius: 0;
+
+                  .attribute-set-item.partial-code {
+                    color: transparentize($gray-darker, 0.4);
+                    background-color: lighten($gray-lighter, 5%);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  &[data-attribute-type="AttributeDuration"] {
+    div.field_value_container {
+      white-space: nowrap;
+    }
+  }
 }
 .one-col-details .details .field_container.field_small {
 	div.field_label {

--- a/css/light-grey.scss
+++ b/css/light-grey.scss
@@ -2447,7 +2447,7 @@ fieldset .details>.field_container {
   }
 
   &[data-attribute-type="AttributeDuration"] {
-    div.field_value_container {
+    .field_value_container {
       white-space: nowrap;
     }
   }


### PR DESCRIPTION
Those fields are badly displayed in such context (notice the "s" that is wrapped on next line)

![image](https://user-images.githubusercontent.com/8947448/159955695-3dced68d-94ed-4c0f-b5a5-11a00626fb9a.png)

XML to reproduce : 

```xml
<?xml version="1.0" encoding="UTF-8"?>
<itop_design xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.7">
  <classes>
    <class id="UserRequest" _created_in="itop-request-mgmt" _delta="must_exist">
      <fields>
        <field id="timespentphase" xsi:type="AttributeDuration" _delta="define">
          <sql>timespentphase</sql>
          <default_value/>
          <is_null_allowed>true</is_null_allowed>
          <tracking_level>all</tracking_level>
        </field>
      </fields>
      <lifecycle>
        <states>
          <state id="new" _delta="must_exist">
            <transitions>
              <transition id="ev_assign" _delta="must_exist">
                <flags _delta="define">
                  <attribute id="timespentphase">
                    <must_prompt/>
                  </attribute>
                </flags>
              </transition>
            </transitions>
          </state>
        </states>
      </lifecycle>
      <presentation>
        <details>
          <items>
            <item id="timespentphase" _delta="define">
              <rank>90</rank>
            </item>
          </items>
        </details>
      </presentation>
    </class>
  </classes>
  <dictionaries>
  </dictionaries>
  <menus>
  </menus>
  <user_rights _created_in="core">
  </user_rights>
  <module_designs>
  </module_designs>
</itop_design>
```