### PR TITLE
N°5414 Debug log for invalid placeholders

### DIFF
--- a/core/metamodel.class.php
+++ b/core/metamodel.class.php
@@ -7370,7 +7370,18 @@ abstract class MetaModel
 									}
 								}
 								catch (Exception $e) {
-									// No replacement will occur
+									$aContext = [
+										'placeholder'   => $sPlaceholderAttCode,
+										'replace class' => get_class($replace),
+									];
+									if ($replace instanceof DBObject) {
+										$aContext['replace id'] = $replace->GetKey();
+									}
+									IssueLog::Debug(
+										'Invalid placeholder in notification, no replacement will occur !',
+										LogChannels::NOTIFICATION,
+										$aContext
+									);
 								}
 							}
 						}
@@ -7391,7 +7402,14 @@ abstract class MetaModel
 								$aSearches[] = $aMatches[1][$idx].$sSearch.$aMatches[1][$idx];
 							}
 							catch (Exception $e) {
-								// No replacement will occur
+								IssueLog::Debug(
+									'Invalid placeholder in notification, no replacement will occur !',
+									LogChannels::NOTIFICATION,
+									[
+										'placeholder' => $sPlaceholderAttCode,
+										'replace'     => $replace,
+									]
+								);
 							}
 						}
 					}

--- a/core/metamodel.class.php
+++ b/core/metamodel.class.php
@@ -7344,14 +7344,11 @@ abstract class MetaModel
 
 		$aSearches = array();
 		$aReplacements = array();
-		foreach ($aParams as $sSearch => $replace)
-		{
+		foreach ($aParams as $sSearch => $replace) {
 			// Some environment parameters are objects, we just need scalars
-			if (is_object($replace))
-			{
+			if (is_object($replace)) {
 				$iPos = strpos($sSearch, '->object()');
-				if ($iPos !== false)
-				{
+				if ($iPos !== false) {
 					// Expand the parameters for the object
 					$sName = substr($sSearch, 0, $iPos);
 					// Note: Capturing
@@ -7359,56 +7356,41 @@ abstract class MetaModel
 					// 2 - The arrow
 					// 3 - The attribute code
 					$aRegExps = array(
-                        '/(\\$)'.$sName.'-(>|&gt;)([^\\$]+)\\$/', // Support both syntaxes: $this->xxx$ or $this-&gt;xxx$ for HTML compatibility
-                        '/(%24)'.$sName.'-(>|&gt;)([^%24]+)%24/', // Support for urlencoded in HTML attributes (%20this-&gt;xxx%20)
-                    );
-					foreach($aRegExps as $sRegExp)
-                    {
-                        if(preg_match_all($sRegExp, $sInput, $aMatches))
-                        {
-                            foreach($aMatches[3] as $idx => $sPlaceholderAttCode)
-                            {
-                                try
-                                {
-                                    $sReplacement = $replace->GetForTemplate($sPlaceholderAttCode);
-                                    if($sReplacement !== null)
-                                    {
-                                        $aReplacements[] = $sReplacement;
-                                        $aSearches[] = $aMatches[1][$idx] . $sName . '-' . $aMatches[2][$idx] . $sPlaceholderAttCode . $aMatches[1][$idx];
-                                    }
-                                }
-                                catch(Exception $e)
-                                {
-                                    // No replacement will occur
-                                }
-                            }
-                        }
-                    }
-				}
-				else
-				{
+						'/(\\$)'.$sName.'-(>|&gt;)([^\\$]+)\\$/', // Support both syntaxes: $this->xxx$ or $this-&gt;xxx$ for HTML compatibility
+						'/(%24)'.$sName.'-(>|&gt;)([^%24]+)%24/', // Support for urlencoded in HTML attributes (%20this-&gt;xxx%20)
+					);
+					foreach ($aRegExps as $sRegExp) {
+						if (preg_match_all($sRegExp, $sInput, $aMatches)) {
+							foreach ($aMatches[3] as $idx => $sPlaceholderAttCode) {
+								try {
+									$sReplacement = $replace->GetForTemplate($sPlaceholderAttCode);
+									if ($sReplacement !== null) {
+										$aReplacements[] = $sReplacement;
+										$aSearches[] = $aMatches[1][$idx].$sName.'-'.$aMatches[2][$idx].$sPlaceholderAttCode.$aMatches[1][$idx];
+									}
+								}
+								catch (Exception $e) {
+									// No replacement will occur
+								}
+							}
+						}
+					}
+				} else {
 					continue; // Ignore this non-scalar value
 				}
-			}
-			else
-			{
+			} else {
 				$aRegExps = array(
 					'/(\$)'.$sSearch.'\$/',   // Support for regular placeholders (eg. $APP_URL$)
 					'/(%24)'.$sSearch.'%24/', // Support for urlencoded in HTML attributes (eg. %24APP_URL%24)
 				);
-				foreach($aRegExps as $sRegExp)
-				{
-					if(preg_match_all($sRegExp, $sInput, $aMatches))
-					{
-						foreach($aMatches[1] as $idx => $sDelimiter)
-						{
-							try
-							{
-								$aReplacements[] = (string) $replace;
-								$aSearches[] = $aMatches[1][$idx] . $sSearch . $aMatches[1][$idx];
+				foreach ($aRegExps as $sRegExp) {
+					if (preg_match_all($sRegExp, $sInput, $aMatches)) {
+						foreach ($aMatches[1] as $idx => $sDelimiter) {
+							try {
+								$aReplacements[] = (string)$replace;
+								$aSearches[] = $aMatches[1][$idx].$sSearch.$aMatches[1][$idx];
 							}
-							catch(Exception $e)
-							{
+							catch (Exception $e) {
 								// No replacement will occur
 							}
 						}
@@ -7416,6 +7398,7 @@ abstract class MetaModel
 				}
 			}
 		}
+
 		return str_replace($aSearches, $aReplacements, $sInput);
 	}
 

--- a/core/metamodel.class.php
+++ b/core/metamodel.class.php
@@ -7378,7 +7378,7 @@ abstract class MetaModel
 										$aContext['replace id'] = $replace->GetKey();
 									}
 									IssueLog::Debug(
-										'Invalid placeholder in notification, no replacement will occur !',
+										'Invalid placeholder in notification, no replacement will occur!',
 										LogChannels::NOTIFICATION,
 										$aContext
 									);


### PR DESCRIPTION
This adds a debug log when a placeholder cannot be replaced.

This can happen for example in notifications, for a hyperlink() function for which we are specifying an invalid portal id : `$this->hyperlink('non_existing_portal')$`

Before the placeholder was just not replaced.
Now we can enable a debug log on the LogChannels::NOTIFICATION channel.

Unfortunately the catch is done where we don't have the trigger / action context... But at least we will have more info than before !