### PR TITLE
:sparkles: Add support for AttributeClass from XML

### DIFF
--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -1725,6 +1725,16 @@ EOF
 						$aParameters['definition_file'] = "'".str_replace("'", "\\'", $sFileName)."'";
 					}
 				}
+				elseif ($sAttType == 'AttributeClass')
+				{
+                    $aParameters['class_category'] = $this->GetPropString($oField, 'class_category', '');
+                    $aParameters['more_values'] = $this->GetPropString($oField, 'more_values', '');
+                    $aParameters['allowed_values'] = 'null'; // or "new ValueSetEnum('SELECT xxxx')"
+                    $aParameters['sql'] = $this->GetMandatoryPropString($oField, 'sql');
+                    $aParameters['default_value'] = $this->GetPropString($oField, 'default_value', '');
+                    $aParameters['is_null_allowed'] = $this->GetPropBoolean($oField, 'is_null_allowed', false);
+                    $aParameters['depends_on'] = $sDependencies;
+				}
 				else
 				{
                     $aParameters['allowed_values'] = 'null'; // or "new ValueSetEnum('SELECT xxxx')"


### PR DESCRIPTION
Hello,

When creating an attribute of type "AttributeClass" from PHP, it's working.

When creating an attribute of type "AttributeClass" from XML, there are two parameters that are not taken from the XML :
- class_category 
- more_values 

Thus, it generates an error on compilation (setup):
![2022-02-26 08_55_39-Window_itop_error](https://user-images.githubusercontent.com/3492475/161208454-124c2401-5d8e-41de-9f3c-6fff28bbac26.png)
Notice: Undefined index: class_category in /var/www/html/web/core/attributedef.class.inc.php
Notice: Undefined index: more_values in /var/www/html/web/core/attributedef.class.inc.php

I didn't found a testCase for testing the Compiler creating attributes. If you point me to it, I would gladly add the adequate test.

Have a good snowy day (April joke here :) )
