### PR TITLE
🎨 AttributeCaseLog index is not binary data, but serialised data

### DIFF
--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -4667,7 +4667,7 @@ class AttributeCaseLog extends AttributeLongText
 		$aColumns = array();
 		$aColumns[$this->GetCode()] = 'LONGTEXT' // 2^32 (4 Gb)
 			.CMDBSource::GetSqlStringColumnDefinition();
-		$aColumns[$this->GetCode().'_index'] = 'BLOB';
+		$aColumns[$this->GetCode().'_index'] = 'TEXT';
 
 		return $aColumns;
 	}


### PR DESCRIPTION
This improves compatibility and portability of raw database data.

Both data types have same length, so it should have no problems when migrating.