### PR TITLE
N°5867 - Display binary data size in SynchroReplica details

### DIFF
--- a/synchro/synchrodatasource.class.inc.php
+++ b/synchro/synchrodatasource.class.inc.php
@@ -2823,7 +2823,11 @@ class SynchroReplica extends DBObject implements iDisplay
 			);
 			$aRows = array();
 			foreach ($aData as $sKey => $value) {
-				$aRows[] = array('attcode' => $sKey, 'data' => $value);
+				if ((strpos(CMDBSource::GetFieldType($sSQLTable, $sKey), 'blob') !== false))
+				{
+					$aRows[] = array('attcode' => $sKey, 'data' => chunk_split(base64_encode($value)));
+				}
+				else $aRows[] = array('attcode' => $sKey, 'data' => $value);
 			}
 			$oPage->Table($aHeaders, $aRows);
 			$oPage->add('</fieldset>');

--- a/synchro/synchrodatasource.class.inc.php
+++ b/synchro/synchrodatasource.class.inc.php
@@ -2818,8 +2818,8 @@ class SynchroReplica extends DBObject implements iDisplay
 			$aData = $this->LoadExtendedDataFromTable($sSQLTable);
 
 			$aHeaders = array(
-				'attcode' => array('label' => 'Attribute Code', 'description' => ''),
-				'data'    => array('label' => 'Value', 'description' => ''),
+				'attcode' => array('label' => Dict::S('UI:Form:Property'), 'description' => ''),
+				'data'    => array('label' => Dict::S('UI:Form:Value'), 'description' => ''),
 			);
 			$aRows = array();
 			foreach ($aData as $sKey => $value) {

--- a/synchro/synchrodatasource.class.inc.php
+++ b/synchro/synchrodatasource.class.inc.php
@@ -2825,7 +2825,7 @@ class SynchroReplica extends DBObject implements iDisplay
 			foreach ($aData as $sKey => $value) {
 				if ((strpos(CMDBSource::GetFieldType($sSQLTable, $sKey), 'blob') !== false))
 				{
-					$aRows[] = array('attcode' => $sKey, 'data' => chunk_split(base64_encode($value)));
+					$aRows[] = array('attcode' => $sKey, 'data' => sprintf('<i>%s (%s)</i>', Dict::S('Core:AttributeBlob'), utils::BytesToFriendlyFormat(strlen($value))));
 				}
 				else $aRows[] = array('attcode' => $sKey, 'data' => utils::EscapeHtml($value));
 			}

--- a/synchro/synchrodatasource.class.inc.php
+++ b/synchro/synchrodatasource.class.inc.php
@@ -2823,11 +2823,11 @@ class SynchroReplica extends DBObject implements iDisplay
 			);
 			$aRows = array();
 			foreach ($aData as $sKey => $value) {
-				if ((strpos(CMDBSource::GetFieldType($sSQLTable, $sKey), 'blob') !== false))
-				{
+				if (strpos(CMDBSource::GetFieldType($sSQLTable, $sKey), 'blob') !== false) {
 					$aRows[] = array('attcode' => $sKey, 'data' => sprintf('<i>%s (%s)</i>', Dict::S('Core:AttributeBlob'), utils::BytesToFriendlyFormat(strlen($value))));
+				} else {
+					$aRows[] = array('attcode' => $sKey, 'data' => utils::EscapeHtml($value));
 				}
-				else $aRows[] = array('attcode' => $sKey, 'data' => utils::EscapeHtml($value));
 			}
 			$oPage->Table($aHeaders, $aRows);
 			$oPage->add('</fieldset>');

--- a/synchro/synchrodatasource.class.inc.php
+++ b/synchro/synchrodatasource.class.inc.php
@@ -2827,7 +2827,7 @@ class SynchroReplica extends DBObject implements iDisplay
 				{
 					$aRows[] = array('attcode' => $sKey, 'data' => chunk_split(base64_encode($value)));
 				}
-				else $aRows[] = array('attcode' => $sKey, 'data' => $value);
+				else $aRows[] = array('attcode' => $sKey, 'data' => utils::EscapeHtml($value));
 			}
 			$oPage->Table($aHeaders, $aRows);
 			$oPage->add('</fieldset>');


### PR DESCRIPTION
Currently the SynchroReplica details page shows all data from the `synchro_data` table as unformatted/raw. With this change it doesn't try to display binary data directly anymore, but it now shows the size of the data.

Before:
<img width="721" alt="image" src="https://user-images.githubusercontent.com/228588/162205457-0efce859-34a1-4971-a611-6308186690ce.png">

After:
<img width="333" alt="image" src="https://user-images.githubusercontent.com/228588/182122174-61683cc1-4002-4734-b556-d1284a7ad4d8.png">

Disclaimer: The sample data is not an actual image, but just 128 sample bytes.