### PR TITLE
N°689 Prototype of a Solution for the 61-Max-Joins-Limitation of MySQL

### DIFF
--- a/core/querygenerator.php
+++ b/core/querygenerator.php
@@ -1,0 +1,121 @@
+<?php
+require_once('../approot.inc.php');
+require_once(APPROOT.'/application/startup.inc.php');
+
+function GetDirectChildClasses($sRootClass)
+{
+  $aDirectChildClasses = array();
+  $aAllChildClasses = MetaModel::EnumChildClasses($sRootClass);
+  foreach ($aAllChildClasses as $sChildClass)
+  {
+    if (get_parent_class($sChildClass) == $sRootClass)
+    {
+      $aDirectChildClasses[] = $sChildClass;
+    }
+  }
+  return $aDirectChildClasses;
+}
+
+// START
+
+$fStart = microtime(true);
+
+// this script produces a working query with a class linking fci to fci on the said customers datamodel.
+// even when giving $aGivenClasses = array("CiManagedByCi", "CiManagedByCi");, so: simulating two times
+// querying the problematic class, it produces a query, which works.
+
+// additional optimization: merge the combodo-optimization from DbObjectSet::Load() in the workround for N.689
+// to only request the finalclass of the to-be-retrieved-objects
+
+
+// like from this line: foreach($this->m_oFilter->GetSelectedClasses() as $sClassAlias => $sClass)
+// this the line in DbObjectSet::Load() within the workaround for N.689
+// -> we might have more than one given class, so we start the prototype from the
+// exact same point.
+$aGivenClasses = array("CiManagedByCi");
+// This works aswell:
+// $aGivenClasses = array("CiManagedByCi", "CiManagedByCi");
+
+// now we are going to create a new array with this structure:
+// array(
+//   "givenclass1" => array(
+//     "extkeyattr1" => array(all, direct, subclasses, of, the, targetclass, of, extkeyattr1),
+//     "extkeyattr2" => array(all, direct, subclasses, of, the, targetclass, of, extkeyattr2),
+//   ),
+//   "givenclass2" => array(...),
+//   ...
+// )
+
+$aJoinClasses = array();
+foreach ($aGivenClasses as $sClass)
+{
+	$aAttrs = MetaModel::GetAttributesList($sClass);
+	foreach ($aAttrs as $sAttr)
+	{
+    $oAttrDef = MetaModel::GetAttributeDef($sClass, $sAttr);
+    $sAttrCode = $oAttrDef->GetCode();
+		if ($oAttrDef->IsExternalKey(EXTKEY_RELATIVE) ||
+        $oAttrDef->IsExternalKey(EXTKEY_ABSOLUTE) ||
+        $oAttrDef->IsHierarchicalKey() // ||
+        // $oAttrDef->IsExternalField() // we dont need them here, we only need
+        // the directly linked classes
+    )
+		{
+			$sTargetClass =  $oAttrDef->GetTargetClass();
+			$aChildClasses = GetDirectChildClasses($sTargetClass);
+      foreach ($aChildClasses as $sChildClass)
+      {
+          $aJoinClasses[$sClass][$sAttrCode][] = $sChildClass;
+      }
+    }
+  }
+}
+
+// echo "<pre>";
+// var_dump($aJoinClasses);
+// echo "</pre>";
+// die();
+
+$aSingleQueries = array();
+$iOuterCount = 1;
+$iInnerCount = 1;
+
+foreach ($aJoinClasses as $sGivenClass => $aAttrCodes)
+{
+  foreach ($aAttrCodes as $sAttrCode => $aSubClasses)
+  {
+    // TODO: Check, if there exists a where-clause containing a question to an external field at the rootclass.
+    // if so, check if the given subclass actually _has_ the field referenced in the external key. if so: add the where-clause.
+    // if not, we can just skip this class, since the where-clause with this subclass makes no sense.
+    // note: a where-clause possibly even reduces the amount of produced queries, but never adds to it.
+    foreach ($aSubClasses as $sSubClass)
+    {
+      // TODO: Re-Insert the possible WHERE-parts before the UNION.
+      // This means the possibly set Filter for the ext-key aswell!
+      // If both given, it should be possible to simply concat them, should it?
+      $aSingleQueries[] = "SELECT {$sGivenClass} AS o{$iOuterCount} JOIN {$sSubClass} AS j{$iInnerCount} ON o{$iOuterCount}.{$sAttrCode} = j{$iInnerCount}.id UNION ";
+      // TODO: Implement recursion, to further subdivide a class, which still returns the 1116-MySQL-Error
+      $iInnerCount++;
+    }
+  }
+  $iOuterCount++;
+}
+
+$sAllUnions = implode("", $aSingleQueries);
+$sAllUnionsClean = substr($sAllUnions, 0, -7); // removes the last " UNION" at the end.
+
+
+$oObjSet = new DBObjectSet(DBSearch::FromOQL($sAllUnionsClean));
+$iCount = $oObjSet->Count();
+$oObjSet->Load();
+$fTimeElapsedSecs = microtime(true) - $fStart;
+echo "<ul>";
+echo "<li>Reworked query ran successful and reports a count of " . $oObjSet->Count() . " elements.</li>";
+echo "<li>Execution (including generating the new query, counting the set _and_ loading all data) took " . number_format($fTimeElapsedSecs, 3) . " seconds.</li>";
+echo "</ul>";
+
+
+echo "<pre>";
+print_r($sAllUnionsClean);
+echo "</pre>";
+die();


### PR DESCRIPTION
Hi Combodo,

## What is this?
This is not a PR in the sense, that it tries to deliver productionready code. Rather it is an approach to provide a (simple, ~50 SLOC) prototype of a solution to a well known problem, existing for a long time, which limits iTops fundamental flexibility with regards to the datamodel. It is totally possible, I missed something obvious. In this case: Please excuse the wall of text and please excuse me wasting your time.

## What is this about?
There exists the 61-Max-Joins-Limitation in MySQL. Currently, we have a customer with a lot of additional classes below FunctionalCI and he raised a request, which requires linking two arbitrary FunctionalCIs together in a new class; but the problem pops up here and there on other occassions aswell. Until last week, when your support provided me with a detailed explanation on the problem, I wasn't even fully aware of the fundamental limitation this problem imposes on the extensibility and the flexibility of the datamodel. They even engineered a possible solution to the problem, which has the drawback of requiring massive changes to the Datamodel and, additionally, flexibility of the datamodel must be sacrificed. I was provided with a helper script of yours to check the "worst offender"-classes with regards to implicit joins and noticed, the customer already has other classes, which are likely to blow up, if the customer decides to add only a few more classes at the "wrong location".

![image](https://user-images.githubusercontent.com/21227916/162722817-4594cae6-e22e-4e2f-a29a-55cc6518185d.png)

I got to know, this problem is known since ~4 years and no solution has been found. Something inside me bugs me, knowing there is this fundamental limitation to iTop. If the following approach seems to work for you aswell, it might be even a contender for calling the problem "practically solved" (instead of being only an addition/refinement to an already existing workaround, which partially tackles the problem). 

I'll now try to walk you through my thoughtprocess, such that false assumptions on my side can be easily spotted by you and aren't implicit. 

## The Initial Problem
To recall, the problem is given by the nature of the implementation of the "generic" inheritance for various autocalculated attributes, which makes it possible, to define e. g. different friendlynames, obsolescence conditions and more for each class on its own in the inheritance tree. This possibility is very valuable and is wished to be kept (even our customer, which was provided with the solution engineered by your support, said so). However, the more abstract a class is, the more instanciable subclasses have to be joined subsequently, to check for the obsolescence flag, provide the right friendlyname and so on. The OQL-Parser for that reason, while developing a given querystring, joins all subclasses of a queried abstract class. Depending on the number of subclasses-to-be-involved, it is possible (and likely, the more classes one has in use), the rendered SQL-Query fails with `MySQL-Error 1116 (Too many tables)`. This problem becomes even more severe, if one tries to create a class, where two abstract classes are linked together, because the subclasses to join by the rendered SQL-Query are "doubling" (if it's the same abstract class on both external keys, of course). The most "problematic" class, one can build, given the standard-datamodel, is a class, where two (or more) FunctionalCIs are linked. - With the rapid growth of users of the Designer, making it easier to create new classes, the likelihood of becoming subject to the explained problem, rises continously.

A developed OQL-Query triggering the error has the following anatomy (CiManagedByCi in this example is a class linking together two FunctionalCIs):

```
SELECT `CiManagedByCi` FROM `CiManagedByCi` AS `CiManagedByCi`
    INNER JOIN `FunctionalCI` AS `FunctionalCI_managedci_id`
      ON `CiManagedByCi`.`managedci_id` = `FunctionalCI_managedci_id`.`id` 
        LEFT JOIN `Aggregate` AS `FunctionalCI_managedci_id_poly_Aggregate`
          ON `FunctionalCI_managedci_id`.`id` = `FunctionalCI_managedci_id_poly_Aggregate`.`id` 
            INNER JOIN `FunctionalCI` AS `MemorySystem_memorysystem_id_FunctionalCI`
              ON `FunctionalCI_managedci_id_poly_Aggregate`.`memorysystem_id` = `MemorySystem_memorysystem_id_FunctionalCI`.`id` 

	(...more left joins on each subclass and each containing possibly more inner joins...)

	(now comes the second external key)

    INNER JOIN `FunctionalCI` AS `FunctionalCI_managingci_id`
      ON `CiManagedByCi`.`managingci_id` = `FunctionalCI_managingci_id`.`id` 
        LEFT JOIN `Aggregate` AS `FunctionalCI_managingci_id_poly_Aggregate`
          ON `FunctionalCI_managingci_id`.`id` = `FunctionalCI_managingci_id_poly_Aggregate`.`id` 
            INNER JOIN `FunctionalCI` AS `MemorySystem_memorysystem_id1_FunctionalCI`
              ON `FunctionalCI_managingci_id_poly_Aggregate`.`memorysystem_id` = `MemorySystem_memorysystem_id1_FunctionalCI`.`id` 
```
        
## Requirements of a Solution to the Problem
- Correct
- No changes to the datamodel (high risks involved)
- Don't sacrifice the flexibility of the datamodel
- Possible to fail gracefully
- As fast as possible
- Rely on well tested Classes/Functions of iTop, to make the implementation somewhat reliable with regards to the underlying details
    
## Work Already being Done
There already a exists a workaround in `DBObjectSet::Load()`, which tries to minimize the amount of attributes to be loaded by only loading the finalclass-attribute of the objet, to at least being able to construct it in PHP.

## Priority
I think, the urgency is low, but the impact might be high(-ish). This problem poses a fundamental limit on how many classes can be used without "hickups" in iTop.

## A Case Example
To ease my explanation, let's suppose there exists the small given below part of the iTop Datamodel and the `Max-61-Joins-Problem` actually is a `Max-3-Joins-Problem`, such that even when creating a linkclass `Z` with two external keys, both pointing to the abstract class `A`, a simple `SELECT Z` triggers the error.

![image](https://user-images.githubusercontent.com/21227916/162723037-ed117072-08e5-41c8-b0c8-44ad7af25854.png)

## Assumptions

- As of today, if the error is triggered and the workaround is not able to retrieve the data aswell, iTop fails silently and reports an empty ObjectSet.
- The problem arises from the "implicit" joins in the rendered OQL-Query and then-rendered SQL-Query. Already receiving a Query from the Enduser, which already contains a JOIN to "lower" class than FunctionalCI will reduce the likelihood of triggering the error, because the searchspace get's very limited then.
- Querying an abstract class in the where-clause only can contain attributes defined on the abstract class (or classes above).
- The limit is imposed via the total count of joins WITHIN _one_ SELECT-Statement given to MySQL; UNIONS asking for all the possible subclasses in the abstractiontree dont have this restriction. (A good detailed explanation with references to the MySQL-Codebase can be looked up here: https://www.quora.com/For-what-reason-is-the-maximum-number-of-tables-that-can-be-referenced-in-a-single-MySQL-join-61/answer/Bill-Karwin). Which means: in a query like `SELECT ... UNION SELECT ...`, the number of joins won't be summed up by MySQL in the 64bit `table_map`-struct.
- The general maximum length of an SQL-Query seems to be only limited by the mysql-var `max_allowed_packet`, which is likely to have been adjusted by customers anyway, because of attachments (in the range of several MB).
- Being slow one time is acceptable, as long as the general performance is (mostly) not impacted. If a query executed by an enduser is developed once (given the query-cache is enabled), will be as fast as any other query the next time.
- If a field is defined in `A`, it can only be removed in `A` later on via customization, but not in `AA`, `AAA`, or `AB`, but at the same time still exist in `A`. Means: If given a query asking for the attribute `A.h`, we can be sure, it will exist on all subclasses (`AA`, `AAA`, `AAB` and so on).

## Keyobservation Regarding the Fundamental Problem

The Query ...

`"SELECT Z" ...`

... resulting in a developed query like ...

```
SELECT Z FROM Z 
    INNER JOIN A ON [External Key 1 of class Z]
         LEFT JOIN AAA
             INNER JOIN ...
         LEFT JOIN [each other sublclass, like AAB, AB]
             INNER JOIN ...
    INNER JOIN A ON [External Key 2 of class Z]
         LEFT JOIN AAA
             INNER JOIN ...
         LEFT JOIN [each other sublclass, like AAB, AB]
             INNER JOIN ...
```    
... can be rewritten -- without changing the semantics, I hope -- of the developed query above as...
```
SELECT Z FROM Z JOIN AAA ON [External Key 1 of class Z]
UNION
SELECT Z FROM Z JOIN AAB ON [External Key 1 of class Z]
UNION
...
UNION
SELECT Z FROM Z JOIN AAA ON [External Key 2 of class Z]
...
```
The key difference is: Since I am using "explicit" joins down to each _one_ of the instanciable subclasses within every _one_ SELECT-Query, the number of resulting JOINS in the developed OQL and the rendered SQL can be reduced to the minimum, since the finalclass is already "given". Phrased differently: I am just "manually" telling iTop, _how_ to reduce the searchspace of joins in _one_ SELECT statement _explicitely_, but the overall result will be the same.

I don't know if that's really an isomorphism (if that's the right word in this context), but I think, this is the bar we have to set here.

## Primitive, But Working Approach of an Implementation
My first approach went like this:
- Get the targeted classes of a given OQL-Statement with `$aSelectedClasses $this->m_oFilter->GetSelectedClasses() as $sClassAlias => $sClass)`, like you are already doing in the workaround in `DBObjectSet::Load()`. In my example, given the query `SELECT A`, the content will be `array("A")`.
- Foreach of those classes, get the attributes, constituating any exeternal key or hierarchical key.
- Foreach of those attributes, get the targetclass.
- Foreach of those targetclasses under the given Attribute, get the instanciable subclasses
- Foreach of those subclasses under one attribute, create a SELECT-Statement containing the "explicit" JOIN from the givenclass down to the subclass like shown above.
- Concat all of those SELECT statements with UNIONs into one big single statement.

Run this resulting (long) OQL-Query through iTop and you will get a valid result. Heureka! This approach was successful. It will even work with arbitrary WHERE-statements, since only attributes available on `A` can be mentioned in the query, which will exist at all childclasses. Nice!

## The Problem with the Primitive Approach
I presented Lars with the primitive approach, who, while not being completely convinced, this really is equivalent (I am not completely, either, but we count on you!), mentioned another problem: It probably will even be possible to just keep the initial `SELECT [class], [class] ...` in the computed single queries (like: `SELECT blub, bla FROM ...`) _and_ it probably will be fine to append the WHERE-Statement on each single SELECT-Query (where it makes sense), _but_ we aswell have to account for possible external _fields_ of class `Z` referencing a field on class `A`. E.g. there not only exist two external keys to `A` on `Z`, but two or more external fields to `A` aswell (e.g `Z.name` which points to `A.name`). 

Now: Since it is possible, ....
- the two classes linked together in `Z` aren't of the same kind (e. g. `PhysicalDevice` and `FunctionalCI`) and thus there might be attributes referenced on `PhysicalDevice`, which aren't available on `FunctionalCI` and
- there might be more than two external keys referenced,

... the number of computed single SELECT-Queries will blow up very rapidly (`for every givenclass -> for every attributeexternal -> for every possible subclass` (which are a lot)). We cannot simply "squash" them together and run them once, no matter the count of attributes. Rather we have to enumerate all _possible_ queries for each attribute, where it makes sense. 

I tried that and indeed ran into a stackoverflow (in PHP or SQL, dunno) at some point when trying to give the linkclass two times as the initial selected classes (it was like 800(?) SELECT-Statements, so very high, but nevertheless, it imposes a limitation). 

So the new optimizationproblem is: How do we keep the number of computed queries as low as possible?

## The Solution for the Optimizationproblem
The keyobservation to the solution of the optimizationproblem is: My assumption, I have to join each possible _instanciable_ subclass (meaning: a leafclass) _directly_ is wrong (like I did with the primitive approach). The 1116-Error is likely to already _not_ happen anymore, if we just have _any_ direct join to the direct subclasses of the linked class (so, from `Z` to `AA` for example), because joining `AA` and `AB` from `Z` already probably "halfes" the searchspace, resulting in half of the implicit joins in the developed OQL-Query ("halfing" here is not meant to be understood in a strict sense, rather as in "dividing them"). 

Which gives: Most of the time, it will already be enough to simply join all directly inheriting classes, such as `AA` and `AB`, to reduce the searchspace for possible subqueries enough, that the 1116-Error does not appear. 

And now for the elegant part: Even _if_ it happens, there is the case (very rare, given the standard model and assuming more than like 60 classes are added), where directly joining `AA` from `Z` results in another 1116-Error (but not on `AB`), we can happily further split the problematic SELECT-Statement-Part regarding `AA` to directly JOIN the childs of `AA` (`AAA` and `AAB`), which further reduces the searchspace of implicit joins, while we don't have to do so for `AB`, if there is no 1116-Error happening there. This results in a few more SELECT-Statements, but only where absolutely necessary. It will result in the _lowest_ sum of SELECTs, without giving the error. So, the resulting query at the end will explicitely join `AAA`, `AAB`, `AB`; _but_ not `ABA`, `ABB` explicitely aswell, only `AB`.

This is a recursive divide-and-conquer-approach, where there are two "easily" managable exit-conditions: 
(1) There is no error occuring anymore. We are getting back a valid resultset for each directly joined subclass. Nice. 
(2) The error is appearing at the stage where we already have approached at least one leaf-class via divide-an-conquer down to the lowest level. In this case, the same behaviour as programmed now (silently fail), could happen. But I think, this concern is a 1% case and more or less of theoretical nature.

## How to Reproduce the Problem
### Option 1:
- Take a standard datamodel
- Add one new class of type `bizmodel, searchable` below `cmdbAbstractObject`, linking together two FunctionalCIs via two External Keys (it it possible, on 2.7 you have to first inherit from a class, which doesn't attempt to create a view, because that will fail aswell, but since views are gone in 3.0, the problem should not exist there(?))
- Add like 20 or 30 classes somewhere below FunctionalCI
- Run a simple SELECT-Query on the new linkclass. The query won't deliver results and the error.log contains the blown up MySQL-Query.

### Option 2:
- Take the datamodel of the customer mentioned in Ticket R-032494 (be aware of: a) don't install with demodata; will fail, b) apply the workaround to for the problem mentioned in the Ticket, which is the cause of a Designer bug to deploy the datamodel without error)
- It is possible, on their 2.7 you have to temporarely inherit from a class, which doesn't attempt to create a view at installation runtime, because that will fail aswell, but since views are gone in 3.0, the problem should not exist there.
- Create one new class, linking together two FunctionalCIs.
- Add a few FCIs (I think, the amount of Objects doesn't matter for this problem; only the amount of classes).
- Run a simple SELECT-Query on the new linkclass. -> SQL should blow up.

## Proof by Code
Place this prototype in the core/-Folder of your test-instance. Call the new (example-)code of this PR from the browser. Paste the resulting SELECT-Query into the Run-Query-Window. 

It will produce the optimized `SELECT [...] UNION SELECT [...] ...`-Query. On the customers datamodel, since there is no recursive descent into further subclasses than direct descendants of FunctionalCI necessary, the query contains 40 SELECT-Statements, concatenated by UNIONs. This is the result of `20 direct childclasses of FunctionalCI` multiplied by `2 external keys, both pointing to FunctionalCI`. 

Please note: The script does not contain the recursive approach. It is only a prototype constructing a correct long OQL for the standard datamodel and the datamodel of the customer facing the problem with the mentioned linkclass. The prototype aswell does not contain the handling of WHERE-clauses in the user-or-class-supplied-oql-query.

I am not pasting the resulting query here, since some of the classnames in the query contain the customers companys shortname. But the resulting structure goes like this:

```
SELECT Z AS o1 JOIN PhysicalDevice AS j1 ON o1.attr1_ext_key_id = j1.id 
UNION 
SELECT Z AS o1 JOIN ApplicationSolution AS j2 ON o1.attr1_ext_key_id = j2.id
UNION
...
UNION
SELECT Z AS o1 JOIN PDB AS j34 ON o1.attr2_ext_key_id = j34.id 
UNION 
SELECT Z AS o1 JOIN AVProtectionScanExcludes ON o1.attr2_ext_key_id = j35.id
...
```
![image](https://user-images.githubusercontent.com/21227916/162727466-afdc4052-1b74-4312-be0d-691259fd4b28.png)

(If there exist more classes in the initial TargetedClasses-Array than in my example, there will be a point in the queries, where `UNION SELECT K AS o2 JOIN ....`-Queries are starting, given the other queries class is of class `K`.)

![image](https://user-images.githubusercontent.com/21227916/162779886-cbf046d9-e8f3-4db0-9c4f-ba46d7c6da42.png)

## Performance
I have a testdatabase with ~2000 Linkobjects and ~3500 FunctionalCIs, but I think, the amount of data to be retrieved isn't really of interest here, because the bottleneck of this appoarch isn't the calculation of the long SELECT-Statement in my code, nor is it "actually running the long resulting SQL-Query with a lot of UNIONS against the database". 

I think, the actual bottleneck is the OQL-Parser, reworking the resulting long query. Running the query for the  first time on my PC took about 2 seconds (which is not acceptable as the general performance, I know). _But_ the interesting thing is: After having developed the long OQL for the first time, the developed query is cached and the result is available blazingly fast on subsequent requests (~0,05 - ~0,1s). Even if I manually add a new datarow for the linkclass `Z` in the database, running the query again is blazingly fast (and returns the right result (`old-count + 1`)). This led me to the conclusion, MySQL is fast and fine with the long UNION-Query; it's the OQL-Parser/-Lexer, which takes a lot of time on the first development of the query. (Of course, because that's a lot of work, the OQL-Transpiler has to do!).

## Assessment and Upsides of the Proposed Solution
- Yes, the approach is comparably slow (on the first run). Yes, it is ugly. Yes, it is "taking a sledgehammer to crack a nut". - But it might be fast enough. 
- It seems to be reasonably simple, to be a solution worth thinking about (it doesn't need to rework the OQL-Parser or -Lexer, for instance). 
- It does not require changes to the datamodel! The flexibility is kept. 
- The level of abstraction, which the approach uses, is OQL. So the implementation is completely under your control. It isn't an approach, which tries to rework SQL-Queries or something hacky alike.

If you happen to reach the conclusion, it might theoretically work, aswell: It might be too slow. But than it might be at least a valueable addition to the mentioned workaround, or it is fast enough to call it a "practical" solution to the problem. I think, the requirements for the solution above (which I made up on my own) might be satisfied.

## Downsides
- The approach doesn't completely (theoretically) solve the problem this way; -- it does not solve the problem on a fundamental level, because there still can occur the 61-max-joins-error on joining from one abstract class down to one leafchildclass within one of the union queries, but until this will happen, this problem will have to be sorted out completely by you anyway.
- I think, this won't solve the problem, that, at installationruntime, creating a view for the linking class fails aswell, but since views are gone in 3.0, I hope, this problem doesn't exist with 3.0 anymore. So, probably this approach isn't suitable to be backported to 2.7.
- Developing the long OQL with the OQL-Parser/-Lexer for the first time is slow (in the context of a request-response-cycle, takes ~2s). - But it's fast (enough?) afterwards.
- I don't know how to prove, this works with all styles of writing OQL-Queries (`joins-in-the-initial-phrase` are giving me the most headaches, because I can't wrap my head around it. However, I don't see any problem with `initial-union-statements`, with `initial-multiselectclass-statements`, with `intiial-arbitrary-where-clauses`, though).
- There a few n^2 and n^3 loops inside the code of the prototype, but since a) the number of classes we talk about and b) the number of possible ext.-key-attrs. per class are limited to two-digit-numbers (by reality), its a fair game, I think.
- Querying left and right (and possibly more directions, given there are more than two external keys on the linkclass) for all possible subclasses, we will of course basically ask MySQL to return the same data twice, thrice or even more. But since iTop is intelligent enough to prefix every SQL-Statement with `DISTINCT`, we don't have to bother with this problem. We just let the DBMS figure this own on its own.

## Todos
- Thinking through it and check for false assumptions on my side.
- Thinking about what could go wrong.
- Thinking about limitations, which can't be satisfied by this approach (different styles of writing OQL come to mind)
- Find the right place for an implementation. My two cents: If it might be called "a pratical solution", it is worth a try already rewriting the OQL before the first query is even sent to the database. E. g. you could statically count the calls to "AddJoin()" during the development of an OQL and decide, whether it's time to rework the query accordingly. If it is only good enough for being part of the workaround, then the workaround already in place is probably a good place to start with.


I really hope, this is not utter nonsense, I didn't miss something obvious and I did not waste your time.

Thank you for your consideration.


Martin
