### PR TITLE
🌐 Add dictionary items for integrity checks

### DIFF
--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -3957,7 +3957,7 @@ HTML;
 				}
 				elseif ($iFlags & OPT_ATT_SLAVE)
 				{
-					$aErrors[$sAttCode] = Dict::Format('UI:AttemptingToSetASlaveAttribute_Name', $oAttDef->GetLabel());
+					$aErrors[$sAttCode] = Dict::Format('UI:AttemptingToSetASlaveAttribute_Name', $oAttDef->GetLabel(), $sAttCode);
 				}
 				else
 				{

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -2265,7 +2265,7 @@ abstract class DBObject implements iDisplay
 		if ($res !== true)
 		{
 			// $res contains the error description
-			$this->m_aCheckIssues[] = "Consistency rules not followed: $res";
+			$this->m_aCheckIssues[] = Dict::Format('Core:CheckConsistencyError', $res);
 		}
 
 		// Synchronization: are we attempting to modify an attribute for which an external source is master?

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -2279,12 +2279,10 @@ abstract class DBObject implements iDisplay
 				if ($iFlags & OPT_ATT_SLAVE)
 				{
 					// Note: $aReasonInfo['name'] could be reported (the task owning the attribute)
-					$oAttDef = MetaModel::GetAttributeDef(get_class($this), $sAttCode);
-					$sAttLabel = $oAttDef->GetLabel();
 					if (!empty($aReasons))
 					{
-						// Todo: associate the attribute code with the error
-						$this->m_aCheckIssues[] = Dict::Format('UI:AttemptingToSetASlaveAttribute_Name', $sAttLabel);
+						$sAttLabel = $this->GetLabel($sAttCode);
+						$this->m_aCheckIssues[] = Dict::Format('UI:AttemptingToSetASlaveAttribute_Name', $sAttLabel, $sAttCode);
 					}
 				}
 			}

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -2249,8 +2249,9 @@ abstract class DBObject implements iDisplay
 		foreach($aChanges as $sAttCode => $value) {
 			$res = $this->CheckValue($sAttCode);
 			if ($res !== true) {
+				$sAttLabel = $this->GetLabel($sAttCode);
 				// $res contains the error description
-				$this->m_aCheckIssues[] = "Unexpected value for attribute '$sAttCode': $res";
+				$this->m_aCheckIssues[] = Dict::Format('Core:CheckValueError', $sAttLabel, $sAttCode, $res);
 			}
 
 			$this->DoCheckLinkedSetDuplicates($sAttCode, $value);

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -2028,7 +2028,7 @@ abstract class DBObject implements iDisplay
 	 *
      * @overwritable-hook You can extend this method in order to provide your own logic.
      * 
-	 * @return bool 
+	 * @return true|string true if successful, the error description otherwise
 	 */
 	public function CheckConsistency()
 	{

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * @copyright   Copyright (C) 2010-2021 Combodo SARL
+ * @copyright   Copyright (C) 2010-2022 Combodo SARL
  * @license     http://opensource.org/licenses/AGPL-3.0
  */
 

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -2028,7 +2028,7 @@ abstract class DBObject implements iDisplay
 	 *
      * @overwritable-hook You can extend this method in order to provide your own logic.
      * 
-	 * @return true|string true if successful, the error description otherwise
+	 * @return bool 
 	 */
 	public function CheckConsistency()
 	{

--- a/dictionaries/en.dictionary.itop.core.php
+++ b/dictionaries/en.dictionary.itop.core.php
@@ -30,7 +30,7 @@ Dict::Add('EN US', 'English', 'English', array(
 
 	'Core:UniquenessDefaultError' => 'Uniqueness rule \'%1$s\' in error',
 	'Core:CheckConsistencyError' => 'Consistency rules not followed: %1$s',
-	'Core:CheckValueError' => 'Unexpected value for attribute \'%1$s\': %3$s',
+	'Core:CheckValueError' => 'Unexpected value for attribute \'%1$s\' (%2$s) : %3$s',
 
 	'Core:AttributeLinkedSet' => 'Array of objects',
 	'Core:AttributeLinkedSet+' => 'Any kind of objects of the same class or subclass',

--- a/dictionaries/en.dictionary.itop.core.php
+++ b/dictionaries/en.dictionary.itop.core.php
@@ -29,6 +29,7 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Core:UnknownObjectTip' => 'The object could not be found. It may have been deleted some time ago and the log has been purged since.',
 
 	'Core:UniquenessDefaultError' => 'Uniqueness rule \'%1$s\' in error',
+	'Core:CheckConsistencyError' => 'Consistency rules not followed: %1$s',
 
 	'Core:AttributeLinkedSet' => 'Array of objects',
 	'Core:AttributeLinkedSet+' => 'Any kind of objects of the same class or subclass',

--- a/dictionaries/en.dictionary.itop.core.php
+++ b/dictionaries/en.dictionary.itop.core.php
@@ -30,6 +30,7 @@ Dict::Add('EN US', 'English', 'English', array(
 
 	'Core:UniquenessDefaultError' => 'Uniqueness rule \'%1$s\' in error',
 	'Core:CheckConsistencyError' => 'Consistency rules not followed: %1$s',
+	'Core:CheckValueError' => 'Unexpected value for attribute \'%1$s\': %3$s',
 
 	'Core:AttributeLinkedSet' => 'Array of objects',
 	'Core:AttributeLinkedSet+' => 'Any kind of objects of the same class or subclass',

--- a/dictionaries/en.dictionary.itop.core.php
+++ b/dictionaries/en.dictionary.itop.core.php
@@ -2,7 +2,7 @@
 /**
  * Localized data
  *
- * @copyright Copyright (C) 2010-2021 Combodo SARL
+ * @copyright Copyright (C) 2010-2022 Combodo SARL
  * @license    http://opensource.org/licenses/AGPL-3.0
  *
  * This file is part of iTop.

--- a/dictionaries/en.dictionary.itop.ui.php
+++ b/dictionaries/en.dictionary.itop.ui.php
@@ -1162,7 +1162,7 @@ When associated with a trigger, each action is given an "order" number, specifyi
 	'UI:CaseLogTypeYourTextHere' => 'Type your text here...',
 	'UI:CaseLog:Header_Date_UserName' => '%1$s - %2$s:',
 	'UI:CaseLog:InitialValue' => 'Initial value:',
-	'UI:AttemptingToSetASlaveAttribute_Name' => 'The field %1$s is not writable because it is mastered by the data synchronization. Value not set.',
+	'UI:AttemptingToSetASlaveAttribute_Name' => 'The field %1$s (%2$s) is not writable because it is mastered by the data synchronization. Value not set.',
 	'UI:ActionNotAllowed' => 'You are not allowed to perform this action on these objects.',
 	'UI:BulkAction:NoObjectSelected' => 'Please select at least one object to perform this operation',
 	'UI:AttemptingToChangeASlaveAttribute_Name' => 'The field %1$s is not writable because it is mastered by the data synchronization. Value remains unchanged.',

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -1455,7 +1455,7 @@ EOF
 								if ( ($iFlags & OPT_ATT_SLAVE) && ($paramValue != $oObj->Get($sAttCode)) )
 								{
 									$oAttDef = MetaModel::GetAttributeDef($sClass, $sAttCode);
-									$aErrors[] = Dict::Format('UI:AttemptingToSetASlaveAttribute_Name', $oAttDef->GetLabel());
+									$aErrors[] = Dict::Format('UI:AttemptingToSetASlaveAttribute_Name', $oAttDef->GetLabel(), $sAttCode);
 									unset($aExpectedAttributes[$sAttCode]);
 								}
 							}


### PR DESCRIPTION
Added dictionary items for:

- Leading message for `DBObject::CheckValue` result
- Leading message for `DBObject::CheckConsistency` result

Also cleaned up code for synchro replica slave attribute checks.