### PR TITLE
N°5160 - Hiding a DashboardAttribute on the fly does not work

### DIFF
--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -1732,6 +1732,7 @@ abstract class DBObject implements iDisplay
 		$iFlags = 0; // By default (if no life cycle) no flag at all
 		$sClass = get_class($this);
 
+		// The code below prevents to hide a DashboardAttribute for eg.
 		$aReadOnlyAtts = $this->GetReadOnlyAttributes();
 		if (($aReadOnlyAtts != null) && (in_array($sAttCode, $aReadOnlyAtts)))
 		{


### PR DESCRIPTION
Allowing a DashboardAttribute to be hidden by an iTop object method such as GetAttributeFlags