### PR TITLE
N°4280 Handle modules with non existing model.*.php files imported

### DIFF
--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -617,7 +617,20 @@ EOF;
 			// files to include (PHP datamodels)
 			foreach($oModule->GetFilesToInclude('business') as $sRelFileName)
 			{
-				$aDataModelFiles[] = "MetaModel::IncludeModule(MODULESROOT.'/$sRelativeDir/$sRelFileName');";
+				if (file_exists("{$sTempTargetDir}/{$sRelativeDir}/{$sRelFileName}")) {
+					$aDataModelFiles[] = "MetaModel::IncludeModule(MODULESROOT.'/$sRelativeDir/$sRelFileName');";
+				} else {
+					$sMissingBusinessFileMessage = 'A module business file is non existing on disk after compilation !';
+					$aContext = [
+						'moduleId'       => $oModule->GetId(),
+						'moduleLocation' => $oModule->GetRootDir(),
+						'includedFile'   => $sRelFileName,
+					];
+					if (utils::IsDevelopmentEnvironment()) {
+						throw new CoreException($sMissingBusinessFileMessage, $aContext);
+					}
+					SetupLog::Warning($sMissingBusinessFileMessage, null, $aContext);
+				}
 			}
 			// files to include (PHP webservices providers)
 			foreach($oModule->GetFilesToInclude('webservices') as $sRelFileName)

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -620,16 +620,17 @@ EOF;
 				if (file_exists("{$sTempTargetDir}/{$sRelativeDir}/{$sRelFileName}")) {
 					$aDataModelFiles[] = "MetaModel::IncludeModule(MODULESROOT.'/$sRelativeDir/$sRelFileName');";
 				} else {
-					$sMissingBusinessFileMessage = 'A module business file is non existing on disk after compilation !';
-					$aContext = [
-						'moduleId'       => $oModule->GetId(),
-						'moduleLocation' => $oModule->GetRootDir(),
-						'includedFile'   => $sRelFileName,
-					];
+					/** @noinspection NestedPositiveIfStatementsInspection */
 					if (utils::IsDevelopmentEnvironment()) {
+						$sMissingBusinessFileMessage = 'A module embeds a non existing file : check the module.php "datamodel" key !';
+						$aContext = [
+							'moduleId'       => $oModule->GetId(),
+							'moduleLocation' => $oModule->GetRootDir(),
+							'includedFile'   => $sRelFileName,
+						];
+						SetupLog::Error($sMissingBusinessFileMessage, null, $aContext);
 						throw new CoreException($sMissingBusinessFileMessage, $aContext);
 					}
-					SetupLog::Warning($sMissingBusinessFileMessage, null, $aContext);
 				}
 			}
 			// files to include (PHP webservices providers)

--- a/setup/modelfactory.class.inc.php
+++ b/setup/modelfactory.class.inc.php
@@ -139,7 +139,15 @@ class MFModule
 	 */
 	protected $sAutoSelect;
 	/**
-	 * @var array
+	 * @see ModelFactory::FindModules init of this structure from the module.*.php files
+	 * @var array{
+	 *          business: string[],
+	 *          webservices: string[],
+	 *          addons: string[],
+	 *     }
+	 * Warning, there are naming mismatches between this structure and the module.*.php :
+	 * - `business` here correspond to `datamodel` in module.*.php
+	 * - `webservices` here correspond to `webservice` in module.*.php
 	 */
 	protected $aFilesToInclude;
 


### PR DESCRIPTION
A module containing XML must add its corresponding model.php file in its "datamodel" section.

So for example, this module containing those files : 
datamodel.4280-datamodel-define.xml
module.4280-datamodel-define.php

In the module.4280-datamodel-define.php file you must have : 

```
		'datamodel'            => array(
			'model.4280-datamodel-define.php',
		),
```

Otherwise the XML compilation made by iTop won't be present in iTop.

But sometimes the module XML won't generate a model file, or another module will remove the XML nodes defined... 
This was crashing iTop.

Now the compiler, after compilation and before generating the env-*/autoload.php will check if the file really exists on disk.
If not : 

* if isDevEnv then an exception is throwned
* else a \SetupLog::Warning call will be made

In both cases, the context is filled with moduleId, moduleLocation, includedFile
