### PR TITLE
N°4875 : compiler now automatically adds the model.php file

### DIFF
--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -592,15 +592,18 @@ EOF;
 				{
 					// Write the code into the given module as model.<module>.php
 					//
-					$sResultFile = $sTempTargetDir.'/'.$sRelativeDir.'/model.'.$sModuleName.'.php';
+					$sModelFileName = 'model.'.$sModuleName.'.php';
+					$sResultFile = $sTempTargetDir.'/'.$sRelativeDir.'/'.$sModelFileName;
 					$this->WritePHPFile($sResultFile, $sModuleName, $sModuleVersion, $sCompiledCode);
+					// In case the model file wasn't present in the module file, we're adding it ! (N°4875)
+					$oModule->AddFileToInclude('business', $sModelFileName);
 				}
 				else
 				{
 					// Write the code into core/main.php
 					//
 					$this->sMainPHPCode .=
-					<<<EOF
+						<<<EOF
 /**
  * Data model from the delta file
  */
@@ -608,10 +611,8 @@ EOF;
 EOF;
 					$this->sMainPHPCode .= $sCompiledCode;
 				}
-			}
-			else
-			{
-					$this->Log("Compilation of module $sModuleName in version $sModuleVersion produced not code at all. No file written.");
+			} else {
+				$this->Log("Compilation of module $sModuleName in version $sModuleVersion produced not code at all. No file written.");
 			}
 
 			// files to include (PHP datamodels)
@@ -634,8 +635,7 @@ EOF;
 				}
 			}
 			// files to include (PHP webservices providers)
-			foreach($oModule->GetFilesToInclude('webservices') as $sRelFileName)
-			{
+			foreach ($oModule->GetFilesToInclude('webservices') as $sRelFileName) {
 				$aWebservicesFiles[] = "MetaModel::IncludeModule(MODULESROOT.'/$sRelativeDir/$sRelFileName');";
 			}
 		} // foreach module

--- a/setup/modelfactory.class.inc.php
+++ b/setup/modelfactory.class.inc.php
@@ -328,6 +328,14 @@ class MFModule
 		return $this->aFilesToInclude[$sCategory];
 	}
 
+	public function AddFileToInclude($sCategory, $sFile)
+	{
+		if (in_array($sFile, $this->aFilesToInclude[$sCategory], true)) {
+			return;
+		}
+		$this->aFilesToInclude[$sCategory][] = $sFile;
+	}
+
 }
 
 /**

--- a/test/setup/SetupUtilsTest.php
+++ b/test/setup/SetupUtilsTest.php
@@ -71,7 +71,7 @@ class SetupUtilsTest extends ItopTestCase
 				"/bin/ls",
 				self::WARNING,
 				"dot could not be executed (retcode=2): Please make sure it is installed and in the path",
-			]
+			],
 		];
 	}
 


### PR DESCRIPTION
Before this fix, when creating a module for iTop that was creating PHP code (an iTop class for example, a snippet, ...) it was mandatory to add the model.php file in your module.php file ("datamodel" key). If you forgot this, then the compilation was completed OK but the result code wasn't included in iTop.

Now the compiler automatically adds the model.php file to the included files.