### PR TITLE
N°5216 Invalid message-id when sending notification using cron on system with a specific locale set

### DIFF
--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -328,8 +328,12 @@ class ActionEmail extends ActionNotification
 			$sBody = MetaModel::ApplyParams($this->Get('body'), $aContextArgs);
 
 			$oObj = $aContextArgs['this->object()'];
-			$sMessageId = sprintf('iTop_%s_%d_%f@%s.openitop.org', get_class($oObj), $oObj->GetKey(), microtime(true /* get as float*/),
-				MetaModel::GetEnvironmentId());
+			$sMessageId = sprintf('iTop_%s_%d_%F@%s.openitop.org',
+				get_class($oObj),
+				$oObj->GetKey(),
+				microtime(true /* get as float*/),
+				MetaModel::GetEnvironmentId()
+			);
 			$sReference = '<'.$sMessageId.'>';
 		}
 		catch (Exception $e) {


### PR DESCRIPTION
When sending notification using cron, we had one french configured VM throwing this error : 
`Error: Invalid ID given <iTop_UserRequest_41_1654590867,049049@4802a49edd657824f11970fb7330fbb0-production.openitop.org>`

The timestamp used was indeed locale dependent.
This PR fixes this behavior by removing the locale dependency using a better printf format (see https://www.php.net/manual/fr/function.sprintf.php)