### PR TITLE
🐛 N°6174 Attachments to host objects without org_id can not be downloaded from the portal

### DIFF
--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
@@ -1105,6 +1105,12 @@ class ObjectController extends BrickController
 			$oAttachment = MetaModel::GetObject($sObjectClass, $sObjectId, true, true);
 			$sHostClass = $oAttachment->Get('item_class');
 			$sHostId = $oAttachment->Get('item_id');
+			
+			// Attachments could be linked to host objects without an org_id. Retrieving the attachment would fail if enforced silos are based on org_id
+			if($oAttachment->Get('item_org_id') === 0) {
+				$bCheckSecurity = false;
+			}
+			
 		}
 		else
 		{

--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
@@ -1107,7 +1107,7 @@ class ObjectController extends BrickController
 			$sHostId = $oAttachment->Get('item_id');
 			
 			// Attachments could be linked to host objects without an org_id. Retrieving the attachment would fail if enforced silos are based on org_id
-			if($oAttachment->Get('item_org_id') === 0) {
+			if($oAttachment->Get('item_org_id') === 0 && ($sHostId > 0) && $oSecurityHelper->IsActionAllowed(UR_ACTION_READ, $sHostClass, $sHostId)) {
 				$bCheckSecurity = false;
 			}
 			


### PR DESCRIPTION
Use case: there's a (custom) class that's not tied to an organization (so no org_id). In the iTop configuration file, it's made possible to add attachments (itop-attachments).

Now, when this info (e.g. a class "Release" containing a description of release notes + one or more attachments) is published in the web portal, the error does not have sufficient rights.

This happens because it tries to query attachments which are published in the organizations the user has access to.

However, since in this case the attachment's "item_org_id" is 0, the user doesn't have access.

To address this, the PR adds a simple condition which will bypass the security check (allowing all data) when the attachment's item_org_id is 0.
