### PR TITLE
N°4692 - Enable parallelization of multiple CRON jobs

### DIFF
--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -583,14 +583,6 @@ class Config
 			'source_of_value'     => '',
 			'show_in_conf_sample' => true,
 		],
-		'cron_task_max_execution_time' => [
-			'type' => 'integer',
-			'description' => 'Background tasks will use this value (integer) multiplicated by its periodicity (in seconds) as max duration per cron execution. 0 is unlimited time',
-			'default' => 0,
-			'value' => 0,
-			'source_of_value' => '',
-			'show_in_conf_sample' => false,
-		],
 		'cron_sleep' => [
 			'type' => 'integer',
 			'description' => 'Duration (seconds) before cron.php checks again if something must be done',
@@ -598,6 +590,14 @@ class Config
 			'value' => 2,
 			'source_of_value' => '',
 			'show_in_conf_sample' => false,
+		],
+		'cron.max_processes' => [
+			'type' => 'integer',
+			'description' => 'Maximum number of cron processes to run',
+			'default' => 10,
+			'value' => 10,
+			'source_of_value' => '',
+			'show_in_conf_sample' => true,
 		],
 		'async_task_retries' => [
 			'type' => 'array',

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -593,9 +593,9 @@ class Config
 			'source_of_value' => '',
 			'show_in_conf_sample' => false,
 		],
-		'cron.max_process' => [
+		'cron.max_processes' => [
 			'type' => 'integer',
-			'description' => 'Maximum number of cron process to run',
+			'description' => 'Maximum number of cron processes to run',
 			'default' => 10,
 			'value' => 10,
 			'source_of_value' => '',

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -585,14 +585,6 @@ class Config
 			'source_of_value'     => '',
 			'show_in_conf_sample' => true,
 		],
-		'cron_task_max_execution_time' => [
-			'type' => 'integer',
-			'description' => 'Background tasks will use this value (integer) multiplicated by its periodicity (in seconds) as max duration per cron execution. 0 is unlimited time',
-			'default' => 0,
-			'value' => 0,
-			'source_of_value' => '',
-			'show_in_conf_sample' => false,
-		],
 		'cron_sleep' => [
 			'type' => 'integer',
 			'description' => 'Duration (seconds) before cron.php checks again if something must be done',
@@ -600,6 +592,14 @@ class Config
 			'value' => 2,
 			'source_of_value' => '',
 			'show_in_conf_sample' => false,
+		],
+		'cron.max_process' => [
+			'type' => 'integer',
+			'description' => 'Maximum number of cron process to run',
+			'default' => 10,
+			'value' => 10,
+			'source_of_value' => '',
+			'show_in_conf_sample' => true,
 		],
 		'async_task_retries' => [
 			'type' => 'array',

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -316,9 +316,14 @@ class MFCompiler
 		}
 
 		try {
+			SetupLog::Info("Compiling $sTempTargetDir...");
 			$this->DoCompile($sTempTargetDir, $sFinalTargetDir, $oP = null, $bUseSymbolicLinks);
-		} catch (Exception $e) {
-			if ($sTempTargetDir != $sFinalTargetDir) {
+		}
+		catch (Exception $e)
+		{
+			SetupLog::Info("Compiling error: ".$e->getMessage());
+			if ($sTempTargetDir != $sFinalTargetDir)
+			{
 				// Cleanup the temporary directory
 				SetupUtils::rrmdir($sTempTargetDir);
 			}

--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -2056,25 +2056,45 @@ JS
 	 */
 	private static function WaitCronTermination($oConfig, $sMode)
 	{
+		$iMaxDuration = $oConfig->Get('cron_max_execution_time');
+		// Avoid PHP stopping while waiting the cron
+		set_time_limit($iMaxDuration);
 		try {
 			// Wait for cron to stop
 			if (is_null($oConfig) || ContextTag::Check(ContextTag::TAG_CRON)) {
 				return;
 			}
-			// Use mutex to check if cron is running
-			$oMutex = self::GetCronMutex($oConfig);
+			// Limit the number of cron process to run in parallel
+			$iMaxCronProcess = $oConfig->Get('cron.max_processes');
 			$iCount = 1;
-			$iStarted = time();
-			$iMaxDuration = $oConfig->Get('cron_max_execution_time');
-			$iTimeLimit = $iStarted + $iMaxDuration;
-			while ($oMutex->IsLocked()) {
-				SetupLog::Info("Waiting for cron to stop ($iCount)");
-				$iCount++;
-				sleep(1);
-				if (time() > $iTimeLimit) {
-					throw new Exception("Cannot enter $sMode mode, consider stopping the cron temporarily");
+			$iTimeLimit = time() + $iMaxDuration;
+			do {
+				$bIsRunning = false;
+				// Use all mutexes to check if cron is running
+				for ($i = 0; $i < $iMaxCronProcess; $i++) {
+					$sName = "cron#$i";
+
+					$oMutex = new iTopMutex(
+						$sName.$oConfig->Get('db_name').$oConfig->Get('db_subname'),
+						$oConfig->Get('db_host'),
+						$oConfig->Get('db_user'),
+						$oConfig->Get('db_pwd'),
+						$oConfig->Get('db_tls.enabled'),
+						$oConfig->Get('db_tls.ca')
+					);
+					if ($oMutex->IsLocked()) {
+						$bIsRunning = true;
+						SetupLog::Info("Waiting for cron to stop ($iCount)");
+						$iCount++;
+						sleep(1);
+						if (time() > $iTimeLimit) {
+							SetupLog::Error("Cannot enter $sMode mode, consider stopping the cron temporarily");
+							throw new Exception("Cannot enter $sMode mode, consider stopping the cron temporarily");
+						}
+						break;
+					}
 				}
-			}
+			} while ($bIsRunning);
 		} catch (Exception $e) {
 			// Ignore errors
 		}

--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -1992,28 +1992,39 @@ JS
 			if (is_null($oConfig) || ContextTag::Check(ContextTag::TAG_CRON)) {
 				return;
 			}
-			// Use mutex to check if cron is running
+			// Limit the number of cron process to run in parallel
+			$iMaxCronProcess = $oConfig->Get('cron.max_process');
+			$iCount = 1;
+			$iMaxDuration = $oConfig->Get('cron_max_execution_time');
+			$iTimeLimit = time() + $iMaxDuration;
+			do {
+				$bIsRunning = false;
+				// Use all mutexes to check if cron is running
+				for ($i = 0; $i < $iMaxCronProcess; $i++) {
+					$sName = "cron#$i";
+
 			$oMutex = new iTopMutex(
-				'cron'.$oConfig->Get('db_name').$oConfig->Get('db_subname'),
+						$sName.$oConfig->Get('db_name').$oConfig->Get('db_subname'),
 				$oConfig->Get('db_host'),
 				$oConfig->Get('db_user'),
 				$oConfig->Get('db_pwd'),
 				$oConfig->Get('db_tls.enabled'),
 				$oConfig->Get('db_tls.ca')
 			);
-			$iCount = 1;
-			$iStarted = time();
-			$iMaxDuration = $oConfig->Get('cron_max_execution_time');
-			$iTimeLimit = $iStarted + $iMaxDuration;
-			while ($oMutex->IsLocked()) {
+					if ($oMutex->IsLocked()) {
+						$bIsRunning = true;
 				SetupLog::Info("Waiting for cron to stop ($iCount)");
 				$iCount++;
 				sleep(1);
 				if (time() > $iTimeLimit) {
 					throw new Exception("Cannot enter $sMode mode, consider stopping the cron temporarily");
 				}
+						break;
+					}
 			}
-		} catch (Exception $e) {
+			} while ($bIsRunning);
+		}
+		catch (Exception $e) {
 			// Ignore errors
 		}
 	}

--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -1987,6 +1987,9 @@ JS
 	 */
 	private static function WaitCronTermination($oConfig, $sMode)
 	{
+		$iMaxDuration = $oConfig->Get('cron_max_execution_time');
+		// Avoid PHP stopping while waiting the cron
+		set_time_limit($iMaxDuration);
 		try {
 			// Wait for cron to stop
 			if (is_null($oConfig) || ContextTag::Check(ContextTag::TAG_CRON)) {
@@ -1995,7 +1998,6 @@ JS
 			// Limit the number of cron process to run in parallel
 			$iMaxCronProcess = $oConfig->Get('cron.max_processes');
 			$iCount = 1;
-			$iMaxDuration = $oConfig->Get('cron_max_execution_time');
 			$iTimeLimit = time() + $iMaxDuration;
 			do {
 				$bIsRunning = false;
@@ -2003,25 +2005,26 @@ JS
 				for ($i = 0; $i < $iMaxCronProcess; $i++) {
 					$sName = "cron#$i";
 
-			$oMutex = new iTopMutex(
+					$oMutex = new iTopMutex(
 						$sName.$oConfig->Get('db_name').$oConfig->Get('db_subname'),
-				$oConfig->Get('db_host'),
-				$oConfig->Get('db_user'),
-				$oConfig->Get('db_pwd'),
-				$oConfig->Get('db_tls.enabled'),
-				$oConfig->Get('db_tls.ca')
-			);
+						$oConfig->Get('db_host'),
+						$oConfig->Get('db_user'),
+						$oConfig->Get('db_pwd'),
+						$oConfig->Get('db_tls.enabled'),
+						$oConfig->Get('db_tls.ca')
+					);
 					if ($oMutex->IsLocked()) {
 						$bIsRunning = true;
-				SetupLog::Info("Waiting for cron to stop ($iCount)");
-				$iCount++;
-				sleep(1);
-				if (time() > $iTimeLimit) {
-					throw new Exception("Cannot enter $sMode mode, consider stopping the cron temporarily");
-				}
+						SetupLog::Info("Waiting for cron to stop ($iCount)");
+						$iCount++;
+						sleep(1);
+						if (time() > $iTimeLimit) {
+							SetupLog::Error("Cannot enter $sMode mode, consider stopping the cron temporarily");
+							throw new Exception("Cannot enter $sMode mode, consider stopping the cron temporarily");
+						}
 						break;
 					}
-			}
+				}
 			} while ($bIsRunning);
 		}
 		catch (Exception $e) {

--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -1993,7 +1993,7 @@ JS
 				return;
 			}
 			// Limit the number of cron process to run in parallel
-			$iMaxCronProcess = $oConfig->Get('cron.max_process');
+			$iMaxCronProcess = $oConfig->Get('cron.max_processes');
 			$iCount = 1;
 			$iMaxDuration = $oConfig->Get('cron_max_execution_time');
 			$iTimeLimit = time() + $iMaxDuration;

--- a/sources/Service/Cron/CronLog.php
+++ b/sources/Service/Cron/CronLog.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * @copyright   Copyright (C) 2010-2022 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\Service\Cron;
+
+use LogAPI;
+
+class CronLog extends LogAPI
+{
+	public static $iProcessNumber = 0;
+
+	const CHANNEL_DEFAULT = 'Cron';
+	/**
+	 * @inheritDoc
+	 *
+	 * As this object is used during setup, without any conf file available, customizing the level can be done by changing this constant !
+	 */
+	const LEVEL_DEFAULT = self::LEVEL_INFO;
+
+	protected static $m_oFileLog = null;
+
+	public static function Log($sLevel, $sMessage, $sChannel = null, $aContext = array())
+	{
+		$sMessage = 'cron'.str_pad(static::$iProcessNumber, 3).$sMessage;
+		parent::Log($sLevel, $sMessage, $sChannel, $aContext);
+	}
+}

--- a/sources/Service/Cron/CronLog.php
+++ b/sources/Service/Cron/CronLog.php
@@ -9,6 +9,9 @@ namespace Combodo\iTop\Service\Cron;
 use LogAPI;
 use Page;
 
+/**
+ * @since 3.1.0
+ */
 class CronLog extends LogAPI
 {
 	public static $iProcessNumber = 0;

--- a/sources/Service/Cron/CronLog.php
+++ b/sources/Service/Cron/CronLog.php
@@ -7,10 +7,13 @@
 namespace Combodo\iTop\Service\Cron;
 
 use LogAPI;
+use Page;
 
 class CronLog extends LogAPI
 {
 	public static $iProcessNumber = 0;
+	private static $bDebug = false;
+	private static $oP = null;
 
 	const CHANNEL_DEFAULT = 'Cron';
 	/**
@@ -26,5 +29,19 @@ class CronLog extends LogAPI
 	{
 		$sMessage = 'cron'.str_pad(static::$iProcessNumber, 3).$sMessage;
 		parent::Log($sLevel, $sMessage, $sChannel, $aContext);
+	}
+
+	public static function Debug($sMessage, $sChannel = null, $aContext = array())
+	{
+		if (self::$bDebug && self::$oP) {
+			self::$oP->p('cron'.str_pad(static::$iProcessNumber, 3).$sMessage);
+		}
+		parent::Debug($sMessage, $sChannel, $aContext);
+	}
+
+	public static function SetDebug(Page $oP, $bDebug)
+	{
+		self::$oP = $oP;
+		self::$bDebug = $bDebug;
 	}
 }

--- a/sources/Service/Cron/CronLog.php
+++ b/sources/Service/Cron/CronLog.php
@@ -8,6 +8,7 @@ namespace Combodo\iTop\Service\Cron;
 
 use LogAPI;
 use Page;
+use utils;
 
 /**
  * @since 3.1.0
@@ -44,7 +45,7 @@ class CronLog extends LogAPI
 
 	public static function Trace($sMessage, $sChannel = null, $aContext = []): void
 	{
-		if (self::$iDebugLevel > 2 && self::$oP) {
+		if (self::$iDebugLevel > 1 && self::$oP) {
 			self::$oP->p('cron'.str_pad(static::$iProcessNumber, 3).$sMessage);
 		}
 		parent::Trace($sMessage, $sChannel, $aContext);
@@ -54,5 +55,16 @@ class CronLog extends LogAPI
 	{
 		self::$oP = $oP;
 		self::$iDebugLevel = $iDebugLevel;
+	}
+
+	public static function GetDebugClassName($sTaskClass): string
+	{
+		if (utils::StartsWith($sTaskClass, 'Combodo\\iTop\\Service\\')) {
+			return substr($sTaskClass, strlen('Combodo\\iTop\\Service\\'));
+		}
+		if (utils::StartsWith($sTaskClass, 'Combodo\\iTop\\')) {
+			return substr($sTaskClass, strlen('Combodo\\iTop\\'));
+		}
+		return $sTaskClass;
 	}
 }

--- a/sources/Service/Cron/CronLog.php
+++ b/sources/Service/Cron/CronLog.php
@@ -14,9 +14,9 @@ use Page;
  */
 class CronLog extends LogAPI
 {
-	public static $iProcessNumber = 0;
-	private static $bDebug = false;
-	private static $oP = null;
+	public static int $iProcessNumber = 0;
+	private static int $iDebugLevel = 0;
+	private static ?Page $oP = null;
 
 	const CHANNEL_DEFAULT = 'Cron';
 	/**
@@ -36,15 +36,23 @@ class CronLog extends LogAPI
 
 	public static function Debug($sMessage, $sChannel = null, $aContext = []): void
 	{
-		if (self::$bDebug && self::$oP) {
+		if (self::$iDebugLevel > 0 && self::$oP) {
 			self::$oP->p('cron'.str_pad(static::$iProcessNumber, 3).$sMessage);
 		}
 		parent::Debug($sMessage, $sChannel, $aContext);
 	}
 
-	public static function SetDebug(Page $oP, $bDebug): void
+	public static function Trace($sMessage, $sChannel = null, $aContext = []): void
+	{
+		if (self::$iDebugLevel > 2 && self::$oP) {
+			self::$oP->p('cron'.str_pad(static::$iProcessNumber, 3).$sMessage);
+		}
+		parent::Trace($sMessage, $sChannel, $aContext);
+	}
+
+	public static function SetDebug(Page $oP, int $iDebugLevel): void
 	{
 		self::$oP = $oP;
-		self::$bDebug = $bDebug;
+		self::$iDebugLevel = $iDebugLevel;
 	}
 }

--- a/sources/Service/Cron/CronLog.php
+++ b/sources/Service/Cron/CronLog.php
@@ -28,13 +28,13 @@ class CronLog extends LogAPI
 
 	protected static $m_oFileLog = null;
 
-	public static function Log($sLevel, $sMessage, $sChannel = null, $aContext = array())
+	public static function Log($sLevel, $sMessage, $sChannel = null, $aContext = []): void
 	{
 		$sMessage = 'cron'.str_pad(static::$iProcessNumber, 3).$sMessage;
 		parent::Log($sLevel, $sMessage, $sChannel, $aContext);
 	}
 
-	public static function Debug($sMessage, $sChannel = null, $aContext = array())
+	public static function Debug($sMessage, $sChannel = null, $aContext = []): void
 	{
 		if (self::$bDebug && self::$oP) {
 			self::$oP->p('cron'.str_pad(static::$iProcessNumber, 3).$sMessage);
@@ -42,7 +42,7 @@ class CronLog extends LogAPI
 		parent::Debug($sMessage, $sChannel, $aContext);
 	}
 
-	public static function SetDebug(Page $oP, $bDebug)
+	public static function SetDebug(Page $oP, $bDebug): void
 	{
 		self::$oP = $oP;
 		self::$bDebug = $bDebug;

--- a/sources/Service/Cron/CronLog.php
+++ b/sources/Service/Cron/CronLog.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * @copyright   Copyright (C) 2010-2022 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\Service\Cron;
+
+use LogAPI;
+use Page;
+use utils;
+
+/**
+ * @since 3.1.0
+ */
+class CronLog extends LogAPI
+{
+	public static int $iProcessNumber = 0;
+	private static int $iDebugLevel = 0;
+	private static ?Page $oP = null;
+
+	public const CHANNEL_DEFAULT = 'Cron';
+	/**
+	 * @inheritDoc
+	 *
+	 * As this object is used during setup, without any conf file available, customizing the level can be done by changing this constant !
+	 */
+	public const LEVEL_DEFAULT = self::LEVEL_INFO;
+
+	protected static $m_oFileLog = null;
+
+	public static function Log($sLevel, $sMessage, $sChannel = null, $aContext = []): void
+	{
+		$sMessage = 'cron'.str_pad(static::$iProcessNumber, 3).$sMessage;
+		parent::Log($sLevel, $sMessage, $sChannel, $aContext);
+	}
+
+	public static function Debug($sMessage, $sChannel = null, $aContext = []): void
+	{
+		if (self::$iDebugLevel > 0 && self::$oP) {
+			self::$oP->p('cron'.str_pad(static::$iProcessNumber, 3).$sMessage);
+		}
+		parent::Debug($sMessage, $sChannel, $aContext);
+	}
+
+	public static function Trace($sMessage, $sChannel = null, $aContext = []): void
+	{
+		if (self::$iDebugLevel > 1 && self::$oP) {
+			self::$oP->p('cron'.str_pad(static::$iProcessNumber, 3).$sMessage);
+		}
+		parent::Trace($sMessage, $sChannel, $aContext);
+	}
+
+	public static function SetDebug(Page $oP, int $iDebugLevel): void
+	{
+		self::$oP = $oP;
+		self::$iDebugLevel = $iDebugLevel;
+	}
+
+	public static function GetDebugClassName($sTaskClass): string
+	{
+		if (utils::StartsWith($sTaskClass, 'Combodo\\iTop\\Service\\')) {
+			return substr($sTaskClass, strlen('Combodo\\iTop\\Service\\'));
+		}
+		if (utils::StartsWith($sTaskClass, 'Combodo\\iTop\\')) {
+			return substr($sTaskClass, strlen('Combodo\\iTop\\'));
+		}
+		return $sTaskClass;
+	}
+}

--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -19,9 +19,13 @@
  */
 
 use Combodo\iTop\Application\WebPage\CLIPage;
-use Combodo\iTop\Application\WebPage\Page;
 use Combodo\iTop\Application\WebPage\WebPage;
+use Combodo\iTop\Service\Cron\CronLog;
 use Combodo\iTop\Service\InterfaceDiscovery\InterfaceDiscovery;
+
+if (!defined('__DIR__')) {
+	define('__DIR__', dirname(__FILE__));
+}
 
 require_once(__DIR__.'/../approot.inc.php');
 
@@ -63,7 +67,7 @@ function UsageAndExit($oP)
 
 	if ($bModeCLI) {
 		$oP->p("USAGE:\n");
-		$oP->p("php cron.php --auth_user=<login> --auth_pwd=<password> [--param_file=<file>] [--verbose=1] [--debug=1] [--status_only=1]\n");
+		$oP->p("php cron.php --auth_user=<login> --auth_pwd=<password> [--param_file=<file>] [--verbose=0] [--status_only=1]\n");
 	} else {
 		$oP->p("Optional parameters: verbose, param_file, status_only\n");
 	}
@@ -91,7 +95,6 @@ function RunTask(BackgroundTask $oTask, $iTimeLimit)
 	$oProcess = new $TaskClass();
 	$oRefClass = new ReflectionClass(get_class($oProcess));
 	$oDateStarted = new DateTime();
-	$oDatePlanned = new DateTime($oTask->Get('next_run_date'));
 	$fStart = microtime(true);
 	$oCtx = new ContextTag('CRON:Task:'.$TaskClass);
 
@@ -99,25 +102,34 @@ function RunTask(BackgroundTask $oTask, $iTimeLimit)
 	$oExceptionToThrow = null;
 	try {
 		// Record (when starting) that this task was started, just in case it crashes during the execution
+		if ($oTask->Get('total_exec_count') == 0) {
+			// First execution
+			$oTask->Set('first_run_date', $oDateStarted->format('Y-m-d H:i:s'));
+		}
 		$oTask->Set('latest_run_date', $oDateStarted->format('Y-m-d H:i:s'));
 		// Record the current user running the cron
 		$oTask->Set('system_user', utils::GetCurrentUserName());
 		$oTask->Set('running', 1);
-		$oTask->DBUpdate();
-		// Time in seconds allowed to the task
-		$iCurrTimeLimit = $iTimeLimit;
-		// Compute allowed time
-		if ($oRefClass->implementsInterface('iScheduledProcess') === false) {
-			// Periodic task, allow only X times ($iMaxTaskExecutionTime) its periodicity (GetPeriodicity())
-			$iMaxTaskExecutionTime = MetaModel::GetConfig()->Get('cron_task_max_execution_time');
-			$iTaskLimit = time() + $oProcess->GetPeriodicity() * $iMaxTaskExecutionTime;
-			// If our proposed time limit is less than cron limit, and cron_task_max_execution_time is > 0
-			if ($iTaskLimit < $iTimeLimit && $iMaxTaskExecutionTime > 0) {
-				$iCurrTimeLimit = $iTaskLimit;
+		// Compute the next run date
+		if ($oRefClass->implementsInterface('iScheduledProcess')) {
+			// Schedules process do repeat at specific moments
+			$oPlannedStart = $oProcess->GetNextOccurrence();
+		} else {
+			// Background processes do repeat periodically
+			$oDatePlanned = new DateTime($oTask->Get('next_run_date'));
+			$oPlannedStart = clone $oDatePlanned;
+			// Let's schedule from the previous planned date of execution to avoid shift
+			$oPlannedStart->modify('+'.$oProcess->GetPeriodicity().' seconds');
+			$oNow = new DateTime();
+			while ($oPlannedStart->format('U') <= $oNow->format('U')) {
+				// Next planned start is already in the past, increase it again by a period
+				$oPlannedStart = $oPlannedStart->modify('+'.$oProcess->GetPeriodicity().' seconds');
 			}
 		}
-		$sMessage = $oProcess->Process($iCurrTimeLimit);
-		$oTask->Set('running', 0);
+		$oTask->Set('next_run_date', $oPlannedStart->format('Y-m-d H:i:s'));
+		$oTask->DBUpdate();
+
+		$sMessage = $oProcess->Process($iTimeLimit);
 	} catch (MySQLHasGoneAwayException $e) {
 		throw $e;
 	} catch (ProcessFatalException $e) {
@@ -129,34 +141,12 @@ function RunTask(BackgroundTask $oTask, $iTimeLimit)
 			$sMessage = 'Processing failed with message: '.$e->getMessage();
 		}
 	}
-	$fDuration = microtime(true) - $fStart;
-	if ($oTask->Get('total_exec_count') == 0) {
-		// First execution
-		$oTask->Set('first_run_date', $oDateStarted->format('Y-m-d H:i:s'));
+	finally {
+		$oTask->Set('running', 0);
+		$fDuration = microtime(true) - $fStart;
+		$oTask->ComputeDurations($fDuration); // does increment the counter and compute statistics
+		$oTask->DBUpdate();
 	}
-	$oTask->ComputeDurations($fDuration); // does increment the counter and compute statistics
-
-	// Update the timestamp since we want to be able to re-order the tasks based on the time they finished
-	$oDateEnded = new DateTime();
-	$oTask->Set('latest_run_date', $oDateEnded->format('Y-m-d H:i:s'));
-
-	if ($oRefClass->implementsInterface('iScheduledProcess')) {
-		// Schedules process do repeat at specific moments
-		$oPlannedStart = $oProcess->GetNextOccurrence();
-	} else {
-		// Background processes do repeat periodically
-		$oPlannedStart = clone $oDatePlanned;
-		// Let's schedule from the previous planned date of execution to avoid shift
-		$oPlannedStart->modify($oProcess->GetPeriodicity().' seconds');
-		$oEnd = new DateTime();
-		while ($oPlannedStart->format('U') < $oEnd->format('U')) {
-			// Next planned start is already in the past, increase it again by a period
-			$oPlannedStart = $oPlannedStart->modify('+'.$oProcess->GetPeriodicity().' seconds');
-		}
-	}
-
-	$oTask->Set('next_run_date', $oPlannedStart->format('Y-m-d H:i:s'));
-	$oTask->DBUpdate();
 
 	if ($oExceptionToThrow) {
 		throw $oExceptionToThrow;
@@ -168,8 +158,6 @@ function RunTask(BackgroundTask $oTask, $iTimeLimit)
 }
 
 /**
- * @param CLIPage|WebPage $oP
- * @param boolean $bVerbose
  *
  * @param bool $bDebug
  *
@@ -184,22 +172,31 @@ function RunTask(BackgroundTask $oTask, $iTimeLimit)
  * @throws \OQLException
  * @throws \ReflectionException
  */
-function CronExec($oP, $bVerbose, $bDebug = false)
+function CronExec($bDebug )
 {
 	$iStarted = time();
 	$iMaxDuration = MetaModel::GetConfig()->Get('cron_max_execution_time');
 	$iTimeLimit = $iStarted + $iMaxDuration;
 	$iCronSleep = MetaModel::GetConfig()->Get('cron_sleep');
+	$iMaxCronProcess = max(MetaModel::GetConfig()->Get('cron.max_processes'), 1);
 
-	if ($bVerbose) {
-		$oP->p("Planned duration = $iMaxDuration seconds");
-		$oP->p("Loop pause = $iCronSleep seconds");
-	}
+	// Allow a time slot for every task
+	// knowing that there are $iMaxCronProcess running in parallel for the amount of tasks
+	$oSearch = new DBObjectSearch('BackgroundTask');
+	$oSearch->AddCondition('status', 'active');
+	$oTasks = new DBObjectSet($oSearch);
+	$iCount = $oTasks->Count();
+	$iTotalAvailableTime = $iMaxDuration * $iMaxCronProcess;
+	$iTimeSlot = (int)($iTotalAvailableTime / max($iCount, 1));
 
-	ReSyncProcesses($oP, $bVerbose, $bDebug);
+	CronLog::Trace("Planned duration = $iMaxDuration seconds");
+	CronLog::Trace("Planned duration per task = $iTimeSlot seconds");
+	CronLog::Trace("Loop pause = $iCronSleep seconds");
+
+	ReSyncProcesses($bDebug);
 
 	while (time() < $iTimeLimit) {
-		CheckMaintenanceMode($oP);
+		CheckMaintenanceMode();
 
 		$oNow = new DateTime();
 		$sNow = $oNow->format('Y-m-d H:i:s');
@@ -207,103 +204,108 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 		$oSearch->AddCondition('next_run_date', $sNow, '<=');
 		$oSearch->AddCondition('status', 'active');
 		$oTasks = new DBObjectSet($oSearch, ['next_run_date' => true]);
-		$bWorkDone = false;
 
+		$aTasks = [];
 		if ($oTasks->CountExceeds(0)) {
-			$bWorkDone = true;
-			$aTasks = [];
-			if ($bVerbose) {
-				$sCount = $oTasks->Count();
-				$oP->p("$sCount Tasks planned to run now ($sNow):");
-				$oP->p('+---------------------------+---------+---------------------+---------------------+');
-				$oP->p('| Task Class                | Status  | Last Run            | Next Run            |');
-				$oP->p('+---------------------------+---------+---------------------+---------------------+');
-			}
+			$aDebugMessages = [];
 			while ($oTask = $oTasks->Fetch()) {
-				$aTasks[$oTask->Get('class_name')] = $oTask;
-				if ($bVerbose) {
-					$sTaskName = $oTask->Get('class_name');
-					$sStatus = $oTask->Get('status');
-					$sLastRunDate = $oTask->Get('latest_run_date');
-					$sNextRunDate = $oTask->Get('next_run_date');
-					$oP->p(sprintf('| %1$-25.25s | %2$-7s | %3$-19s | %4$-19s |', $sTaskName, $sStatus, $sLastRunDate, $sNextRunDate));
+				$sTaskName = $oTask->Get('class_name');
+				$oTaskMutex = new iTopMutex("cron_$sTaskName");
+				if ($oTaskMutex->IsLocked()) {
+					// Already running, ignore
+					continue;
 				}
+				$aTasks[] = $oTask;
+				$sStatus = $oTask->Get('status');
+				$sLastRunDate = $oTask->Get('latest_run_date');
+				$sNextRunDate = $oTask->Get('next_run_date');
+				$aDebugMessages[] = sprintf('Task Class: %1$-25.25s Status: %2$-7s Last Run: %3$-19s Next Run: %4$-19s', $sTaskName, $sStatus, $sLastRunDate, $sNextRunDate);
 			}
-			if ($bVerbose) {
-				$oP->p('+---------------------------+---------+---------------------+---------------------+');
+			$sCount = count($aDebugMessages);
+			CronLog::Trace("$sCount Tasks planned to run now ($sNow):");
+			foreach ($aDebugMessages as $sDebugMessage) {
+				CronLog::Trace($sDebugMessage);
 			}
 			$aRunTasks = [];
-			foreach ($aTasks as $oTask) {
+			while (count($aTasks) > 0) {
+				$oTask = array_shift($aTasks);
 				$sTaskClass = $oTask->Get('class_name');
+
+				// Check if the current task is running
+				$oTaskMutex = new iTopMutex("cron_$sTaskClass");
+				if (!$oTaskMutex->TryLock()) {
+					// Task is already running, try next one
+					continue;
+				}
+
 				$aRunTasks[] = $sTaskClass;
 
 				// N°3219 for each process will use a specific CMDBChange object with a specific track info
-				// Any BackgroundProcess can overrides this as needed
+				// Any BackgroundProcess can override this as needed
 				CMDBObject::SetCurrentChangeFromParams("Background task ($sTaskClass)");
 
 				// Run the task and record its next run time
-				if ($bVerbose) {
-					$oNow = new DateTime();
-					$oP->p(">> === ".$oNow->format('Y-m-d H:i:s').sprintf(" Starting:%-'=49s", ' '.$sTaskClass.' '));
-				}
+				$sDebugTaskClass = CronLog::GetDebugClassName($sTaskClass);
+				$oNow = new DateTime();
+				CronLog::Debug(sprintf("> Starting >>> %-'>49s", $sDebugTaskClass.' '));
 				try {
-					$sMessage = RunTask($aTasks[$sTaskClass], $iTimeLimit);
-				} catch (MySQLHasGoneAwayException $e) {
-					$oP->p("ERROR : 'MySQL has gone away' thrown when processing $sTaskClass  (error_code=".$e->getCode().")");
+					// The limit of time for this task corresponds to the time slot allowed for every task
+					// but limited to the cron job time limit
+					$sMessage = RunTask($oTask, min($iTimeLimit, time() + $iTimeSlot));
+				}
+				catch (MySQLHasGoneAwayException $e) {
+					CronLog::Error("ERROR : 'MySQL has gone away' thrown when processing $sDebugTaskClass  (error_code=".$e->getCode().")", CronLog::CHANNEL_DEFAULT, ['stack' => $e->getTraceAsString()]);
 					exit(EXIT_CODE_FATAL);
-				} catch (ProcessFatalException $e) {
-					$oP->p("ERROR : an exception was thrown when processing '$sTaskClass' (".$e->getInfoLog().")");
-					IssueLog::Error("Cron.php error : an exception was thrown when processing '$sTaskClass' (".$e->getInfoLog().')');
 				}
-				if ($bVerbose) {
-					if (!empty($sMessage)) {
-						$oP->p("$sTaskClass: $sMessage");
-					}
-					$oEnd = new DateTime();
-					$sNextRunDate = $oTask->Get('next_run_date');
-					$oP->p("<< === ".$oEnd->format('Y-m-d H:i:s').sprintf(" End of:  %-'=42s", ' '.$sTaskClass.' ')." Next: $sNextRunDate");
+				catch (ProcessFatalException $e) {
+					CronLog::Error("ERROR : an exception was thrown when processing '$sDebugTaskClass' (".$e->getInfoLog().")", CronLog::CHANNEL_DEFAULT, ['stack' => $e->getTraceAsString()]);
 				}
+				finally {
+					$oTaskMutex->Unlock();
+				}
+				if (!empty($sMessage)) {
+					CronLog::Debug("$sDebugTaskClass: $sMessage");
+				}
+				$oEnd = new DateTime();
+				$sNextRunDate = $oTask->Get('next_run_date');
+				CronLog::Debug(sprintf("< Ending <<<<< %-'<49s", $sDebugTaskClass.' ')." Next: $sNextRunDate");
 				if (time() > $iTimeLimit) {
 					break 2;
 				}
-				CheckMaintenanceMode($oP);
+				CheckMaintenanceMode();
+				if ($iMaxCronProcess > 1) {
+					// Reindex tasks every time
+					break;
+				}
 			}
 
 			// Tasks to run later
-			if ($bVerbose) {
-				$oP->p('--');
+			if (count($aTasks) == 0) {
 				$oSearch = new DBObjectSearch('BackgroundTask');
 				$oSearch->AddCondition('next_run_date', $sNow, '>');
 				$oSearch->AddCondition('status', 'active');
 				$oTasks = new DBObjectSet($oSearch, ['next_run_date' => true]);
 				while ($oTask = $oTasks->Fetch()) {
 					if (!in_array($oTask->Get('class_name'), $aRunTasks)) {
-						$oP->p(sprintf("-- Skipping task: %-'-40s", $oTask->Get('class_name').' ')." until: ".$oTask->Get('next_run_date'));
+						$sDebugTaskClass = CronLog::GetDebugClassName($oTask->Get('class_name'));
+						CronLog::Trace(sprintf("-- Skipping task: %-'-40s", $sDebugTaskClass.' ')." until: ".$oTask->Get('next_run_date'));
 					}
 				}
 			}
 		}
-
-		if ($bVerbose && $bWorkDone) {
-			$oP->p("Sleeping...\n");
+		if (count($aTasks) == 0) {
+			CronLog::Trace("sleeping...");
+			sleep($iCronSleep);
 		}
-		sleep($iCronSleep);
 	}
-	if ($bVerbose) {
-		$oP->p('');
-		DisplayStatus($oP, ['next_run_date' => true]);
-		$oP->p("Reached normal execution time limit (exceeded by ".(time() - $iTimeLimit)."s)");
-	}
+	CronLog::Trace("Reached normal execution time limit (exceeded by ".(time() - $iTimeLimit)."s)");
 }
 
-/**
- * @param WebPage $oP
- */
-function CheckMaintenanceMode(Page $oP)
+function CheckMaintenanceMode()
 {
-	// Verify files instead of reloading the full config each time
+// Verify files instead of reloading the full config each time
 	if (file_exists(MAINTENANCE_MODE_FILE) || file_exists(READONLY_MODE_FILE)) {
-		$oP->p("Maintenance detected, exiting");
+		CronLog::Info("Maintenance detected, exiting");
 		exit(EXIT_CODE_ERROR);
 	}
 }
@@ -318,7 +320,7 @@ function CheckMaintenanceMode(Page $oP)
  * @throws \MySQLException
  * @throws \OQLException
  */
-function DisplayStatus($oP, $aTaskOrderBy = [])
+function DisplayStatus($oP = null, $aTaskOrderBy = [])
 {
 	$oSearch = new DBObjectSearch('BackgroundTask');
 	$oTasks = new DBObjectSet($oSearch, $aTaskOrderBy);
@@ -346,8 +348,6 @@ function DisplayStatus($oP, $aTaskOrderBy = [])
 }
 
 /**
- * @param $oP
- * @param $bVerbose
  * @param $bDebug
  *
  * @throws \ArchivedObjectException
@@ -359,7 +359,7 @@ function DisplayStatus($oP, $aTaskOrderBy = [])
  * @throws \OQLException
  * @throws \ReflectionException
  */
-function ReSyncProcesses($oP, $bVerbose, $bDebug)
+function ReSyncProcesses($bDebug)
 {
 	// Enumerate classes implementing BackgroundProcess
 	//
@@ -394,10 +394,9 @@ function ReSyncProcesses($oP, $bVerbose, $bDebug)
 				// Background processes do start asap, i.e. "now"
 				$oTask->Set('next_run_date', $oNow->format('Y-m-d H:i:s'));
 			}
-			if ($bVerbose) {
-				$oP->p('Creating record for: '.$sTaskClass);
-				$oP->p('First execution planned at: '.$oTask->Get('next_run_date'));
-			}
+			$sDebugTaskClass = CronLog::GetDebugClassName($sTaskClass);
+			CronLog::Trace('Creating record for: '.$sDebugTaskClass);
+			CronLog::Trace('First execution planned at: '.$oTask->Get('next_run_date'));
 			$oTask->DBInsert();
 		} else {
 			/** @var \BackgroundTask $oTask */
@@ -430,14 +429,12 @@ function ReSyncProcesses($oP, $bVerbose, $bDebug)
 		}
 	}
 
-	if ($bVerbose) {
-		$aDisplayProcesses = [];
-		foreach ($aProcesses as $oExecInstance) {
-			$aDisplayProcesses[] = get_class($oExecInstance);
-		}
-		$sDisplayProcesses = implode(', ', $aDisplayProcesses);
-		$oP->p("Background processes: ".$sDisplayProcesses);
+	$aDisplayProcesses = [];
+	foreach ($aProcesses as $oExecInstance) {
+		$aDisplayProcesses[] = get_class($oExecInstance);
 	}
+	$sDisplayProcesses = implode(', ', $aDisplayProcesses);
+	CronLog::Trace("Background processes: ".$sDisplayProcesses);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -447,18 +444,23 @@ function ReSyncProcesses($oP, $bVerbose, $bDebug)
 
 set_time_limit(0); // Some background actions may really take long to finish (like backup)
 try {
-	$bIsModeCLI = utils::IsModeCLI();
-	if ($bIsModeCLI) {
-		$oP = new CLIPage("iTop - cron");
+$bIsModeCLI = utils::IsModeCLI();
+if ($bIsModeCLI) {
+	$oP = new CLIPage("iTop - cron");
 
 		SetupUtils::CheckPhpAndExtensionsForCli($oP, EXIT_CODE_FATAL);
 		utils::UseParamFile();
 	} else {
-		$oP = new WebPage("iTop - cron");
-	}
+	$oP = new WebPage("iTop - cron");
+}
 
-	$bVerbose = utils::ReadParam('verbose', false, true /* Allow CLI */);
-	$bDebug = utils::ReadParam('debug', false, true /* Allow CLI */);
+try {
+	utils::UseParamFile();
+
+	// Allow verbosity on output from 0 => none, 1 => debug, 2 => trace
+	// (writing debug messages to the cron.log file is configured with log_level_min config parameter)
+	$iVerbose = utils::ReadParam('verbose', 0, true /* Allow CLI */);
+	CronLog::SetDebug($oP, $iVerbose);
 
 	if ($bIsModeCLI) {
 		// Next steps:
@@ -491,31 +493,41 @@ try {
 	}
 
 	require_once(APPROOT.'core/mutex.class.inc.php');
-	$oP->p("Starting: ".time().' ('.date('Y-m-d H:i:s').')');
 } catch (Exception $e) {
 	$oP->p("Error: ".$e->GetMessage());
 	$oP->output();
 	exit(EXIT_CODE_FATAL);
 }
 
+CronLog::Enable(APPROOT.'/log/error.log');
 try {
-	$oMutex = new iTopMutex('cron');
 	if (!MetaModel::DBHasAccess(ACCESS_ADMIN_WRITE)) {
-		$oP->p("A maintenance is ongoing");
+		CronLog::Debug("A maintenance is ongoing");
 	} else {
-		if ($oMutex->TryLock()) {
-			CronExec($oP, $bVerbose, $bDebug);
+		// Limit the number of cron process to run in parallel
+		$iMaxCronProcess = max(MetaModel::GetConfig()->Get('cron.max_processes'), 1);
+		$bCanRun = false;
+		$iProcessNumber = 0;
+		for ($i = 0; $i < $iMaxCronProcess; $i++) {
+			$oMutex = new iTopMutex("cron#$i");
+			if ($oMutex->TryLock()) {
+				$iProcessNumber = $i + 1;
+				$bCanRun = true;
+				break;
+			}
+		}
+		if ($bCanRun) {
+			CronLog::$iProcessNumber = $iProcessNumber;
+			CronLog::Debug('Starting: '.time().' ('.date('Y-m-d H:i:s').')');
+			CronExec($iVerbose > 0);
 		} else {
-			// Exit silently
-			$oP->p("Already running...");
+			CronLog::$iProcessNumber = $iMaxCronProcess + 1;
+			CronLog::Trace("The limit of $iMaxCronProcess cron process running in parallel is already reached");
 		}
 	}
-} catch (Exception $e) {
-	$oP->p("ERROR: '".$e->getMessage()."'");
-	if ($bDebug) {
-		// Might contain verb parameters such a password...
-		$oP->p($e->getTraceAsString());
-	}
+}
+catch (Exception $e) {
+	CronLog::Error("ERROR: '".$e->getMessage()."'", CronLog::CHANNEL_DEFAULT, ['stack' => $e->getTraceAsString()]);
 } finally {
 	try {
 		$oMutex->Unlock();
@@ -528,5 +540,5 @@ try {
 	}
 }
 
-$oP->p("Exiting: ".time().' ('.date('Y-m-d H:i:s').')');
+CronLog::Debug("Exiting: ".time().' ('.date('Y-m-d H:i:s').')');
 $oP->Output();

--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -91,7 +91,6 @@ function RunTask(BackgroundTask $oTask, $iTimeLimit)
 	$oProcess = new $TaskClass();
 	$oRefClass = new ReflectionClass(get_class($oProcess));
 	$oDateStarted = new DateTime();
-	$oDatePlanned = new DateTime($oTask->Get('next_run_date'));
 	$fStart = microtime(true);
 	$oCtx = new ContextTag('CRON:Task:'.$TaskClass);
 
@@ -99,25 +98,34 @@ function RunTask(BackgroundTask $oTask, $iTimeLimit)
 	$oExceptionToThrow = null;
 	try {
 		// Record (when starting) that this task was started, just in case it crashes during the execution
+		if ($oTask->Get('total_exec_count') == 0) {
+			// First execution
+			$oTask->Set('first_run_date', $oDateStarted->format('Y-m-d H:i:s'));
+		}
 		$oTask->Set('latest_run_date', $oDateStarted->format('Y-m-d H:i:s'));
 		// Record the current user running the cron
 		$oTask->Set('system_user', utils::GetCurrentUserName());
 		$oTask->Set('running', 1);
-		$oTask->DBUpdate();
-		// Time in seconds allowed to the task
-		$iCurrTimeLimit = $iTimeLimit;
-		// Compute allowed time
-		if ($oRefClass->implementsInterface('iScheduledProcess') === false) {
-			// Periodic task, allow only X times ($iMaxTaskExecutionTime) its periodicity (GetPeriodicity())
-			$iMaxTaskExecutionTime = MetaModel::GetConfig()->Get('cron_task_max_execution_time');
-			$iTaskLimit = time() + $oProcess->GetPeriodicity() * $iMaxTaskExecutionTime;
-			// If our proposed time limit is less than cron limit, and cron_task_max_execution_time is > 0
-			if ($iTaskLimit < $iTimeLimit && $iMaxTaskExecutionTime > 0) {
-				$iCurrTimeLimit = $iTaskLimit;
+		// Compute the next run date
+		if ($oRefClass->implementsInterface('iScheduledProcess')) {
+			// Schedules process do repeat at specific moments
+			$oPlannedStart = $oProcess->GetNextOccurrence();
+		} else {
+			// Background processes do repeat periodically
+			$oDatePlanned = new DateTime($oTask->Get('next_run_date'));
+			$oPlannedStart = clone $oDatePlanned;
+			// Let's schedule from the previous planned date of execution to avoid shift
+			$oPlannedStart->modify('+'.$oProcess->GetPeriodicity().' seconds');
+			$oNow = new DateTime();
+			while ($oPlannedStart->format('U') <= $oNow->format('U')) {
+				// Next planned start is already in the past, increase it again by a period
+				$oPlannedStart = $oPlannedStart->modify('+'.$oProcess->GetPeriodicity().' seconds');
 			}
 		}
-		$sMessage = $oProcess->Process($iCurrTimeLimit);
-		$oTask->Set('running', 0);
+		$oTask->Set('next_run_date', $oPlannedStart->format('Y-m-d H:i:s'));
+		$oTask->DBUpdate();
+
+		$sMessage = $oProcess->Process($iTimeLimit);
 	} catch (MySQLHasGoneAwayException $e) {
 		throw $e;
 	} catch (ProcessFatalException $e) {
@@ -128,35 +136,12 @@ function RunTask(BackgroundTask $oTask, $iTimeLimit)
 		} else {
 			$sMessage = 'Processing failed with message: '.$e->getMessage();
 		}
+	} finally {
+		$oTask->Set('running', 0);
+		$fDuration = microtime(true) - $fStart;
+		$oTask->ComputeDurations($fDuration); // does increment the counter and compute statistics
+		$oTask->DBUpdate();
 	}
-	$fDuration = microtime(true) - $fStart;
-	if ($oTask->Get('total_exec_count') == 0) {
-		// First execution
-		$oTask->Set('first_run_date', $oDateStarted->format('Y-m-d H:i:s'));
-	}
-	$oTask->ComputeDurations($fDuration); // does increment the counter and compute statistics
-
-	// Update the timestamp since we want to be able to re-order the tasks based on the time they finished
-	$oDateEnded = new DateTime();
-	$oTask->Set('latest_run_date', $oDateEnded->format('Y-m-d H:i:s'));
-
-	if ($oRefClass->implementsInterface('iScheduledProcess')) {
-		// Schedules process do repeat at specific moments
-		$oPlannedStart = $oProcess->GetNextOccurrence();
-	} else {
-		// Background processes do repeat periodically
-		$oPlannedStart = clone $oDatePlanned;
-		// Let's schedule from the previous planned date of execution to avoid shift
-		$oPlannedStart->modify($oProcess->GetPeriodicity().' seconds');
-		$oEnd = new DateTime();
-		while ($oPlannedStart->format('U') < $oEnd->format('U')) {
-			// Next planned start is already in the past, increase it again by a period
-			$oPlannedStart = $oPlannedStart->modify('+'.$oProcess->GetPeriodicity().' seconds');
-		}
-	}
-
-	$oTask->Set('next_run_date', $oPlannedStart->format('Y-m-d H:i:s'));
-	$oTask->DBUpdate();
 
 	if ($oExceptionToThrow) {
 		throw $oExceptionToThrow;
@@ -190,6 +175,7 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 	$iMaxDuration = MetaModel::GetConfig()->Get('cron_max_execution_time');
 	$iTimeLimit = $iStarted + $iMaxDuration;
 	$iCronSleep = MetaModel::GetConfig()->Get('cron_sleep');
+	$iMaxCronProcess = MetaModel::GetConfig()->Get('cron.max_process');
 
 	if ($bVerbose) {
 		$oP->p("Planned duration = $iMaxDuration seconds");
@@ -235,6 +221,19 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 			$aRunTasks = [];
 			foreach ($aTasks as $oTask) {
 				$sTaskClass = $oTask->Get('class_name');
+
+				// Check if the current task is running
+				$oTaskMutex = new iTopMutex("cron_$sTaskClass");
+				if (!$oTaskMutex->TryLock()) {
+					// Task is already running, try next one
+					continue;
+				}
+
+				// Just to indicate to Itop that the cron is running for setup
+				// The mutex will be released when the process dies
+				$oCronMutex = new iTopMutex('cron');
+				$oCronMutex->TryLock();
+
 				$aRunTasks[] = $sTaskClass;
 
 				// N°3219 for each process will use a specific CMDBChange object with a specific track info
@@ -255,6 +254,9 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 					$oP->p("ERROR : an exception was thrown when processing '$sTaskClass' (".$e->getInfoLog().")");
 					IssueLog::Error("Cron.php error : an exception was thrown when processing '$sTaskClass' (".$e->getInfoLog().')');
 				}
+				finally {
+					$oTaskMutex->Unlock();
+				}
 				if ($bVerbose) {
 					if (!empty($sMessage)) {
 						$oP->p("$sTaskClass: $sMessage");
@@ -267,6 +269,10 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 					break 2;
 				}
 				CheckMaintenanceMode($oP);
+				if ($iMaxCronProcess > 1) {
+					// Reindex tasks every time
+					break;
+				}
 			}
 
 			// Tasks to run later
@@ -498,16 +504,28 @@ try {
 	exit(EXIT_CODE_FATAL);
 }
 
-try {
-	$oMutex = new iTopMutex('cron');
-	if (!MetaModel::DBHasAccess(ACCESS_ADMIN_WRITE)) {
+try
+{
+	if (!MetaModel::DBHasAccess(ACCESS_ADMIN_WRITE))
+	{
 		$oP->p("A maintenance is ongoing");
-	} else {
-		if ($oMutex->TryLock()) {
+	}
+	else
+	{
+		// Limit the number of cron process to run in parallel
+		$iMaxCronProcess = MetaModel::GetConfig()->Get('cron.max_process');
+		$bCanRun = false;
+		for ($i = 0; $i < $iMaxCronProcess; $i++) {
+			$oMutex = new iTopMutex("cron#$i");
+			if ($oMutex->TryLock()) {
+				$bCanRun = true;
+				break;
+			}
+		}
+		if ($bCanRun) {
 			CronExec($oP, $bVerbose, $bDebug);
 		} else {
-			// Exit silently
-			$oP->p("Already running...");
+			$oP->p("Already $iMaxCronProcess are running...");
 		}
 	}
 } catch (Exception $e) {

--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -67,7 +67,7 @@ function UsageAndExit($oP)
 
 	if ($bModeCLI) {
 		$oP->p("USAGE:\n");
-		$oP->p("php cron.php --auth_user=<login> --auth_pwd=<password> [--param_file=<file>] [--verbose=1] [--debug=1] [--status_only=1]\n");
+		$oP->p("php cron.php --auth_user=<login> --auth_pwd=<password> [--param_file=<file>] [--verbose=0] [--status_only=1]\n");
 	} else {
 		$oP->p("Optional parameters: verbose, param_file, status_only\n");
 	}
@@ -189,9 +189,9 @@ function CronExec($bDebug )
 	$iTotalAvailableTime = $iMaxDuration * $iMaxCronProcess;
 	$iTimeSlot = (int)($iTotalAvailableTime / max($iCount, 1));
 
-	CronLog::Debug("Planned duration = $iMaxDuration seconds");
-	CronLog::Debug("Planned duration per task = $iTimeSlot seconds");
-	CronLog::Debug("Loop pause = $iCronSleep seconds");
+	CronLog::Trace("Planned duration = $iMaxDuration seconds");
+	CronLog::Trace("Planned duration per task = $iTimeSlot seconds");
+	CronLog::Trace("Loop pause = $iCronSleep seconds");
 
 	ReSyncProcesses($bDebug);
 
@@ -222,9 +222,9 @@ function CronExec($bDebug )
 				$aDebugMessages[] = sprintf('Task Class: %1$-25.25s Status: %2$-7s Last Run: %3$-19s Next Run: %4$-19s', $sTaskName, $sStatus, $sLastRunDate, $sNextRunDate);
 			}
 			$sCount = count($aDebugMessages);
-			CronLog::Debug("$sCount Tasks planned to run now ($sNow):");
+			CronLog::Trace("$sCount Tasks planned to run now ($sNow):");
 			foreach ($aDebugMessages as $sDebugMessage) {
-				CronLog::Debug($sDebugMessage);
+				CronLog::Trace($sDebugMessage);
 			}
 			$aRunTasks = [];
 			while (count($aTasks) > 0) {
@@ -286,17 +286,17 @@ function CronExec($bDebug )
 				$oTasks = new DBObjectSet($oSearch, ['next_run_date' => true]);
 				while ($oTask = $oTasks->Fetch()) {
 					if (!in_array($oTask->Get('class_name'), $aRunTasks)) {
-						CronLog::Debug(sprintf("-- Skipping task: %-'-40s", $oTask->Get('class_name').' ')." until: ".$oTask->Get('next_run_date'));
+						CronLog::Trace(sprintf("-- Skipping task: %-'-40s", $oTask->Get('class_name').' ')." until: ".$oTask->Get('next_run_date'));
 					}
 				}
 			}
 		}
 		if (count($aTasks) == 0) {
-			CronLog::Debug("sleeping...");
+			CronLog::Trace("sleeping...");
 			sleep($iCronSleep);
 		}
 	}
-	CronLog::Debug("Reached normal execution time limit (exceeded by ".(time() - $iTimeLimit)."s)");
+	CronLog::Trace("Reached normal execution time limit (exceeded by ".(time() - $iTimeLimit)."s)");
 }
 
 function CheckMaintenanceMode()
@@ -392,8 +392,8 @@ function ReSyncProcesses($bDebug)
 				// Background processes do start asap, i.e. "now"
 				$oTask->Set('next_run_date', $oNow->format('Y-m-d H:i:s'));
 			}
-			CronLog::Debug('Creating record for: '.$sTaskClass);
-			CronLog::Debug('First execution planned at: '.$oTask->Get('next_run_date'));
+			CronLog::Trace('Creating record for: '.$sTaskClass);
+			CronLog::Trace('First execution planned at: '.$oTask->Get('next_run_date'));
 			$oTask->DBInsert();
 		} else {
 			/** @var \BackgroundTask $oTask */
@@ -431,7 +431,7 @@ function ReSyncProcesses($bDebug)
 		$aDisplayProcesses[] = get_class($oExecInstance);
 	}
 	$sDisplayProcesses = implode(', ', $aDisplayProcesses);
-	CronLog::Debug("Background processes: ".$sDisplayProcesses);
+	CronLog::Trace("Background processes: ".$sDisplayProcesses);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -454,12 +454,10 @@ if ($bIsModeCLI) {
 try {
 	utils::UseParamFile();
 
-	// Allow verbosity on output (writing debug messages to the cron.log file is configured with log_level_min config parameter)
-	$bVerbose = utils::ReadParam('verbose', false, true /* Allow CLI */);
-	CronLog::SetDebug($oP, $bVerbose);
-
-	// Used to launch the BackgroundTask in debug mode
-	$bDebug = utils::ReadParam('debug', false, true /* Allow CLI */);
+	// Allow verbosity on output from 0 => none, 1 => debug, 2 => trace
+	// (writing debug messages to the cron.log file is configured with log_level_min config parameter)
+	$iVerbose = utils::ReadParam('verbose', 0, true /* Allow CLI */);
+	CronLog::SetDebug($oP, $iVerbose);
 
 	if ($bIsModeCLI) {
 		// Next steps:
@@ -518,10 +516,10 @@ try {
 		if ($bCanRun) {
 			CronLog::$iProcessNumber = $iProcessNumber;
 			CronLog::Info('Starting: '.time().' ('.date('Y-m-d H:i:s').')');
-			CronExec($bDebug);
+			CronExec($iVerbose > 0);
 		} else {
 			CronLog::$iProcessNumber = $iMaxCronProcess + 1;
-			CronLog::Debug("The limit of $iMaxCronProcess cron process running in parallel is already reached");
+			CronLog::Trace("The limit of $iMaxCronProcess cron process running in parallel is already reached");
 		}
 	}
 }

--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -193,12 +193,12 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 		$oSearch->AddCondition('next_run_date', $sNow, '<=');
 		$oSearch->AddCondition('status', 'active');
 		$oTasks = new DBObjectSet($oSearch, ['next_run_date' => true]);
-		$bWorkDone = false;
 
-		if ($oTasks->CountExceeds(0)) {
-			$bWorkDone = true;
-			$aTasks = [];
-			if ($bVerbose) {
+		$aTasks = [];
+		if ($oTasks->CountExceeds(0))
+		{
+			if ($bVerbose)
+			{
 				$sCount = $oTasks->Count();
 				$oP->p("$sCount Tasks planned to run now ($sNow):");
 				$oP->p('+---------------------------+---------+---------------------+---------------------+');
@@ -206,9 +206,15 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 				$oP->p('+---------------------------+---------+---------------------+---------------------+');
 			}
 			while ($oTask = $oTasks->Fetch()) {
-				$aTasks[$oTask->Get('class_name')] = $oTask;
-				if ($bVerbose) {
-					$sTaskName = $oTask->Get('class_name');
+				$sTaskName = $oTask->Get('class_name');
+				$oTaskMutex = new iTopMutex("cron_$sTaskName");
+				if ($oTaskMutex->IsLocked()) {
+					// Already running, ignore
+					continue;
+				}
+				$aTasks[] = $oTask;
+				if ($bVerbose)
+				{
 					$sStatus = $oTask->Get('status');
 					$sLastRunDate = $oTask->Get('latest_run_date');
 					$sNextRunDate = $oTask->Get('next_run_date');
@@ -219,7 +225,8 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 				$oP->p('+---------------------------+---------+---------------------+---------------------+');
 			}
 			$aRunTasks = [];
-			foreach ($aTasks as $oTask) {
+			while ($aTasks != []) {
+				$oTask = array_shift($aTasks);
 				$sTaskClass = $oTask->Get('class_name');
 
 				// Check if the current task is running
@@ -228,11 +235,6 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 					// Task is already running, try next one
 					continue;
 				}
-
-				// Just to indicate to Itop that the cron is running for setup
-				// The mutex will be released when the process dies
-				$oCronMutex = new iTopMutex('cron');
-				$oCronMutex->TryLock();
 
 				$aRunTasks[] = $sTaskClass;
 
@@ -246,7 +248,7 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 					$oP->p(">> === ".$oNow->format('Y-m-d H:i:s').sprintf(" Starting:%-'=49s", ' '.$sTaskClass.' '));
 				}
 				try {
-					$sMessage = RunTask($aTasks[$sTaskClass], $iTimeLimit);
+					$sMessage = RunTask($oTask, $iTimeLimit);
 				} catch (MySQLHasGoneAwayException $e) {
 					$oP->p("ERROR : 'MySQL has gone away' thrown when processing $sTaskClass  (error_code=".$e->getCode().")");
 					exit(EXIT_CODE_FATAL);
@@ -276,7 +278,7 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 			}
 
 			// Tasks to run later
-			if ($bVerbose) {
+			if ($bVerbose && $aTasks == []) {
 				$oP->p('--');
 				$oSearch = new DBObjectSearch('BackgroundTask');
 				$oSearch->AddCondition('next_run_date', $sNow, '>');
@@ -289,11 +291,12 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 				}
 			}
 		}
-
-		if ($bVerbose && $bWorkDone) {
-			$oP->p("Sleeping...\n");
+		if ($aTasks == []) {
+			if ($bVerbose) {
+				$oP->p("Sleeping...\n");
+			}
+			sleep($iCronSleep);
 		}
-		sleep($iCronSleep);
 	}
 	if ($bVerbose) {
 		$oP->p('');

--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -23,7 +23,9 @@ use Combodo\iTop\Application\WebPage\WebPage;
 use Combodo\iTop\Service\Cron\CronLog;
 use Combodo\iTop\Service\InterfaceDiscovery\InterfaceDiscovery;
 
-if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
+if (!defined('__DIR__')) {
+	define('__DIR__', dirname(__FILE__));
+}
 
 require_once(__DIR__.'/../approot.inc.php');
 
@@ -138,7 +140,8 @@ function RunTask(BackgroundTask $oTask, $iTimeLimit)
 		} else {
 			$sMessage = 'Processing failed with message: '.$e->getMessage();
 		}
-	} finally {
+	}
+	finally {
 		$oTask->Set('running', 0);
 		$fDuration = microtime(true) - $fStart;
 		$oTask->ComputeDurations($fDuration); // does increment the counter and compute statistics
@@ -244,31 +247,28 @@ function CronExec($bDebug )
 				// Run the task and record its next run time
 				$oNow = new DateTime();
 				CronLog::Debug(">> === ".$oNow->format('Y-m-d H:i:s').sprintf(" Start task:%-'=49s", ' '.$sTaskClass.' '));
-				try
-				{
+				try {
 					// The limit of time for this task corresponds to the time slot allowed for every task
 					// but limited to the cron job time limit
 					$sMessage = RunTask($oTask, min($iTimeLimit, time() + $iTimeSlot));
-				} catch (MySQLHasGoneAwayException $e)
-				{
+				}
+				catch (MySQLHasGoneAwayException $e) {
 					CronLog::Error("ERROR : 'MySQL has gone away' thrown when processing $sTaskClass  (error_code=".$e->getCode().")");
 					exit(EXIT_CODE_FATAL);
-				} catch (ProcessFatalException $e)
-				{
+				}
+				catch (ProcessFatalException $e) {
 					CronLog::Error("ERROR : an exception was thrown when processing '$sTaskClass' (".$e->getInfoLog().")");
 				}
 				finally {
 					$oTaskMutex->Unlock();
 				}
-				if (!empty($sMessage))
-				{
+				if (!empty($sMessage)) {
 					CronLog::Debug("$sTaskClass: $sMessage");
 				}
 				$oEnd = new DateTime();
 				$sNextRunDate = $oTask->Get('next_run_date');
 				CronLog::Debug("<< === ".$oEnd->format('Y-m-d H:i:s').sprintf(" End of:    %-'=49s", ' '.$sTaskClass.' ')." Next: $sNextRunDate");
-				if (time() > $iTimeLimit)
-				{
+				if (time() > $iTimeLimit) {
 					break 2;
 				}
 				CheckMaintenanceMode();
@@ -279,8 +279,7 @@ function CronExec($bDebug )
 			}
 
 			// Tasks to run later
-			if (count($aTasks) == 0)
-			{
+			if (count($aTasks) == 0) {
 				$oSearch = new DBObjectSearch('BackgroundTask');
 				$oSearch->AddCondition('next_run_date', $sNow, '>');
 				$oSearch->AddCondition('status', 'active');
@@ -302,7 +301,7 @@ function CronExec($bDebug )
 
 function CheckMaintenanceMode()
 {
-	// Verify files instead of reloading the full config each time
+// Verify files instead of reloading the full config each time
 	if (file_exists(MAINTENANCE_MODE_FILE) || file_exists(READONLY_MODE_FILE)) {
 		CronLog::Info("Maintenance detected, exiting");
 		exit(EXIT_CODE_ERROR);
@@ -442,18 +441,17 @@ function ReSyncProcesses($bDebug)
 
 set_time_limit(0); // Some background actions may really take long to finish (like backup)
 try {
-	$bIsModeCLI = utils::IsModeCLI();
-	if ($bIsModeCLI) {
-		$oP = new CLIPage("iTop - cron");
+$bIsModeCLI = utils::IsModeCLI();
+if ($bIsModeCLI) {
+	$oP = new CLIPage("iTop - cron");
 
 		SetupUtils::CheckPhpAndExtensionsForCli($oP, EXIT_CODE_FATAL);
 		utils::UseParamFile();
 	} else {
-		$oP = new WebPage("iTop - cron");
-	}
+	$oP = new WebPage("iTop - cron");
+}
 
-try
-{
+try {
 	utils::UseParamFile();
 
 	// Allow verbosity on output (writing debug messages to the cron.log file is configured with log_level_min config parameter)
@@ -501,14 +499,10 @@ try
 }
 
 CronLog::Enable(APPROOT.'/log/cron.log');
-try
-{
-	if (!MetaModel::DBHasAccess(ACCESS_ADMIN_WRITE))
-	{
+try {
+	if (!MetaModel::DBHasAccess(ACCESS_ADMIN_WRITE)) {
 		CronLog::Info("A maintenance is ongoing");
-	}
-	else
-	{
+	} else {
 		// Limit the number of cron process to run in parallel
 		$iMaxCronProcess = max(MetaModel::GetConfig()->Get('cron.max_processes'), 1);
 		$bCanRun = false;
@@ -531,8 +525,7 @@ try
 		}
 	}
 }
-catch (Exception $e)
-{
+catch (Exception $e) {
 	CronLog::Error("ERROR: '".$e->getMessage()."'");
 	// Might contain verb parameters such a password...
 	CronLog::Debug($e->getTraceAsString());

--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -191,10 +191,8 @@ function CronExec($bDebug )
 		$oTasks = new DBObjectSet($oSearch, ['next_run_date' => true]);
 
 		$aTasks = [];
-		if ($oTasks->CountExceeds(0))
-		{
-			$sCount = $oTasks->Count();
-			CronLog::Debug("$sCount Tasks planned to run now ($sNow):");
+		if ($oTasks->CountExceeds(0)) {
+			$aDebugMessages = [];
 			while ($oTask = $oTasks->Fetch()) {
 				$sTaskName = $oTask->Get('class_name');
 				$oTaskMutex = new iTopMutex("cron_$sTaskName");
@@ -206,7 +204,12 @@ function CronExec($bDebug )
 				$sStatus = $oTask->Get('status');
 				$sLastRunDate = $oTask->Get('latest_run_date');
 				$sNextRunDate = $oTask->Get('next_run_date');
-				CronLog::Debug(sprintf('Task Class: %1$-25.25s Status: %2$-7s Last Run: %3$-19s Next Run: %4$-19s', $sTaskName, $sStatus, $sLastRunDate, $sNextRunDate));
+				$aDebugMessages[] = sprintf('Task Class: %1$-25.25s Status: %2$-7s Last Run: %3$-19s Next Run: %4$-19s', $sTaskName, $sStatus, $sLastRunDate, $sNextRunDate);
+			}
+			$sCount = count($aDebugMessages);
+			CronLog::Debug("$sCount Tasks planned to run now ($sNow):");
+			foreach ($aDebugMessages as $sDebugMessage) {
+				CronLog::Debug($sDebugMessage);
 			}
 			$aRunTasks = [];
 			while ($aTasks != []) {
@@ -248,7 +251,7 @@ function CronExec($bDebug )
 				}
 				$oEnd = new DateTime();
 				$sNextRunDate = $oTask->Get('next_run_date');
-				CronLog::Debug("<< === ".$oEnd->format('Y-m-d H:i:s').sprintf(" End of:  %-'=42s", ' '.$sTaskClass.' ')." Next: $sNextRunDate");
+				CronLog::Debug("<< === ".$oEnd->format('Y-m-d H:i:s').sprintf(" End of:    %-'=49s", ' '.$sTaskClass.' ')." Next: $sNextRunDate");
 				if (time() > $iTimeLimit)
 				{
 					break 2;
@@ -275,6 +278,7 @@ function CronExec($bDebug )
 			}
 		}
 		if (count($aTasks) == 0) {
+			CronLog::Debug("sleeping...");
 			sleep($iCronSleep);
 		}
 	}
@@ -437,6 +441,11 @@ try
 {
 	utils::UseParamFile();
 
+	// Allow verbosity on output (writing debug messages to the cron.log file is configured with log_level_min config parameter)
+	$bVerbose = utils::ReadParam('verbose', false, true /* Allow CLI */);
+	CronLog::SetDebug($oP, $bVerbose);
+
+	// Used to launch the BackgroundTask in debug mode
 	$bDebug = utils::ReadParam('debug', false, true /* Allow CLI */);
 
 	if ($bIsModeCLI) {
@@ -502,7 +511,8 @@ try
 			CronLog::Info('Starting: '.time().' ('.date('Y-m-d H:i:s').')');
 			CronExec($bDebug);
 		} else {
-			CronLog::Debug("Already $iMaxCronProcess are running...");
+			CronLog::$iProcessNumber = $iMaxCronProcess + 1;
+			CronLog::Debug("The limit of $iMaxCronProcess cron process running in parallel is already reached");
 		}
 	}
 }

--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -156,6 +156,8 @@ function RunTask(BackgroundTask $oTask, $iTimeLimit)
 
 /**
  *
+ * @param bool $bDebug
+ *
  * @throws \ArchivedObjectException
  * @throws \CoreCannotSaveObjectException
  * @throws \CoreException
@@ -173,9 +175,19 @@ function CronExec($bDebug )
 	$iMaxDuration = MetaModel::GetConfig()->Get('cron_max_execution_time');
 	$iTimeLimit = $iStarted + $iMaxDuration;
 	$iCronSleep = MetaModel::GetConfig()->Get('cron_sleep');
-	$iMaxCronProcess = MetaModel::GetConfig()->Get('cron.max_processes');
+	$iMaxCronProcess = max(MetaModel::GetConfig()->Get('cron.max_processes'), 1);
+
+	// Allow a time slot for every task
+	// knowing that there are $iMaxCronProcess running in parallel for the amount of tasks
+	$oSearch = new DBObjectSearch('BackgroundTask');
+	$oSearch->AddCondition('status', 'active');
+	$oTasks = new DBObjectSet($oSearch);
+	$iCount = $oTasks->Count();
+	$iTotalAvailableTime = $iMaxDuration * $iMaxCronProcess;
+	$iTimeSlot = (int)($iTotalAvailableTime / max($iCount, 1));
 
 	CronLog::Debug("Planned duration = $iMaxDuration seconds");
+	CronLog::Debug("Planned duration per task = $iTimeSlot seconds");
 	CronLog::Debug("Loop pause = $iCronSleep seconds");
 
 	ReSyncProcesses($bDebug);
@@ -212,7 +224,7 @@ function CronExec($bDebug )
 				CronLog::Debug($sDebugMessage);
 			}
 			$aRunTasks = [];
-			while ($aTasks != []) {
+			while (count($aTasks) > 0) {
 				$oTask = array_shift($aTasks);
 				$sTaskClass = $oTask->Get('class_name');
 
@@ -226,14 +238,17 @@ function CronExec($bDebug )
 				$aRunTasks[] = $sTaskClass;
 
 				// N°3219 for each process will use a specific CMDBChange object with a specific track info
-				// Any BackgroundProcess can overrides this as needed
+				// Any BackgroundProcess can override this as needed
 				CMDBObject::SetCurrentChangeFromParams("Background task ($sTaskClass)");
 
 				// Run the task and record its next run time
 				$oNow = new DateTime();
 				CronLog::Debug(">> === ".$oNow->format('Y-m-d H:i:s').sprintf(" Start task:%-'=49s", ' '.$sTaskClass.' '));
-				try {
-					$sMessage = RunTask($oTask, $iTimeLimit);
+				try
+				{
+					// The limit of time for this task corresponds to the time slot allowed for every task
+					// but limited to the cron job time limit
+					$sMessage = RunTask($oTask, min($iTimeLimit, time() + $iTimeSlot));
 				} catch (MySQLHasGoneAwayException $e)
 				{
 					CronLog::Error("ERROR : 'MySQL has gone away' thrown when processing $sTaskClass  (error_code=".$e->getCode().")");
@@ -495,7 +510,7 @@ try
 	else
 	{
 		// Limit the number of cron process to run in parallel
-		$iMaxCronProcess = MetaModel::GetConfig()->Get('cron.max_processes');
+		$iMaxCronProcess = max(MetaModel::GetConfig()->Get('cron.max_processes'), 1);
 		$bCanRun = false;
 		$iProcessNumber = 0;
 		for ($i = 0; $i < $iMaxCronProcess; $i++) {

--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -19,9 +19,11 @@
  */
 
 use Combodo\iTop\Application\WebPage\CLIPage;
-use Combodo\iTop\Application\WebPage\Page;
 use Combodo\iTop\Application\WebPage\WebPage;
+use Combodo\iTop\Service\Cron\CronLog;
 use Combodo\iTop\Service\InterfaceDiscovery\InterfaceDiscovery;
+
+if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
 
 require_once(__DIR__.'/../approot.inc.php');
 
@@ -153,10 +155,6 @@ function RunTask(BackgroundTask $oTask, $iTimeLimit)
 }
 
 /**
- * @param CLIPage|WebPage $oP
- * @param boolean $bVerbose
- *
- * @param bool $bDebug
  *
  * @throws \ArchivedObjectException
  * @throws \CoreCannotSaveObjectException
@@ -169,7 +167,7 @@ function RunTask(BackgroundTask $oTask, $iTimeLimit)
  * @throws \OQLException
  * @throws \ReflectionException
  */
-function CronExec($oP, $bVerbose, $bDebug = false)
+function CronExec($bDebug )
 {
 	$iStarted = time();
 	$iMaxDuration = MetaModel::GetConfig()->Get('cron_max_execution_time');
@@ -177,15 +175,13 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 	$iCronSleep = MetaModel::GetConfig()->Get('cron_sleep');
 	$iMaxCronProcess = MetaModel::GetConfig()->Get('cron.max_processes');
 
-	if ($bVerbose) {
-		$oP->p("Planned duration = $iMaxDuration seconds");
-		$oP->p("Loop pause = $iCronSleep seconds");
-	}
+	CronLog::Debug("Planned duration = $iMaxDuration seconds");
+	CronLog::Debug("Loop pause = $iCronSleep seconds");
 
-	ReSyncProcesses($oP, $bVerbose, $bDebug);
+	ReSyncProcesses($bDebug);
 
 	while (time() < $iTimeLimit) {
-		CheckMaintenanceMode($oP);
+		CheckMaintenanceMode();
 
 		$oNow = new DateTime();
 		$sNow = $oNow->format('Y-m-d H:i:s');
@@ -197,14 +193,8 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 		$aTasks = [];
 		if ($oTasks->CountExceeds(0))
 		{
-			if ($bVerbose)
-			{
-				$sCount = $oTasks->Count();
-				$oP->p("$sCount Tasks planned to run now ($sNow):");
-				$oP->p('+---------------------------+---------+---------------------+---------------------+');
-				$oP->p('| Task Class                | Status  | Last Run            | Next Run            |');
-				$oP->p('+---------------------------+---------+---------------------+---------------------+');
-			}
+			$sCount = $oTasks->Count();
+			CronLog::Debug("$sCount Tasks planned to run now ($sNow):");
 			while ($oTask = $oTasks->Fetch()) {
 				$sTaskName = $oTask->Get('class_name');
 				$oTaskMutex = new iTopMutex("cron_$sTaskName");
@@ -213,16 +203,10 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 					continue;
 				}
 				$aTasks[] = $oTask;
-				if ($bVerbose)
-				{
-					$sStatus = $oTask->Get('status');
-					$sLastRunDate = $oTask->Get('latest_run_date');
-					$sNextRunDate = $oTask->Get('next_run_date');
-					$oP->p(sprintf('| %1$-25.25s | %2$-7s | %3$-19s | %4$-19s |', $sTaskName, $sStatus, $sLastRunDate, $sNextRunDate));
-				}
-			}
-			if ($bVerbose) {
-				$oP->p('+---------------------------+---------+---------------------+---------------------+');
+				$sStatus = $oTask->Get('status');
+				$sLastRunDate = $oTask->Get('latest_run_date');
+				$sNextRunDate = $oTask->Get('next_run_date');
+				CronLog::Debug(sprintf('Task Class: %1$-25.25s Status: %2$-7s Last Run: %3$-19s Next Run: %4$-19s', $sTaskName, $sStatus, $sLastRunDate, $sNextRunDate));
 			}
 			$aRunTasks = [];
 			while ($aTasks != []) {
@@ -243,34 +227,33 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 				CMDBObject::SetCurrentChangeFromParams("Background task ($sTaskClass)");
 
 				// Run the task and record its next run time
-				if ($bVerbose) {
-					$oNow = new DateTime();
-					$oP->p(">> === ".$oNow->format('Y-m-d H:i:s').sprintf(" Starting:%-'=49s", ' '.$sTaskClass.' '));
-				}
+				$oNow = new DateTime();
+				CronLog::Debug(">> === ".$oNow->format('Y-m-d H:i:s').sprintf(" Start task:%-'=49s", ' '.$sTaskClass.' '));
 				try {
 					$sMessage = RunTask($oTask, $iTimeLimit);
-				} catch (MySQLHasGoneAwayException $e) {
-					$oP->p("ERROR : 'MySQL has gone away' thrown when processing $sTaskClass  (error_code=".$e->getCode().")");
+				} catch (MySQLHasGoneAwayException $e)
+				{
+					CronLog::Error("ERROR : 'MySQL has gone away' thrown when processing $sTaskClass  (error_code=".$e->getCode().")");
 					exit(EXIT_CODE_FATAL);
-				} catch (ProcessFatalException $e) {
-					$oP->p("ERROR : an exception was thrown when processing '$sTaskClass' (".$e->getInfoLog().")");
-					IssueLog::Error("Cron.php error : an exception was thrown when processing '$sTaskClass' (".$e->getInfoLog().')');
+				} catch (ProcessFatalException $e)
+				{
+					CronLog::Error("ERROR : an exception was thrown when processing '$sTaskClass' (".$e->getInfoLog().")");
 				}
 				finally {
 					$oTaskMutex->Unlock();
 				}
-				if ($bVerbose) {
-					if (!empty($sMessage)) {
-						$oP->p("$sTaskClass: $sMessage");
-					}
-					$oEnd = new DateTime();
-					$sNextRunDate = $oTask->Get('next_run_date');
-					$oP->p("<< === ".$oEnd->format('Y-m-d H:i:s').sprintf(" End of:  %-'=42s", ' '.$sTaskClass.' ')." Next: $sNextRunDate");
+				if (!empty($sMessage))
+				{
+					CronLog::Debug("$sTaskClass: $sMessage");
 				}
-				if (time() > $iTimeLimit) {
+				$oEnd = new DateTime();
+				$sNextRunDate = $oTask->Get('next_run_date');
+				CronLog::Debug("<< === ".$oEnd->format('Y-m-d H:i:s').sprintf(" End of:  %-'=42s", ' '.$sTaskClass.' ')." Next: $sNextRunDate");
+				if (time() > $iTimeLimit)
+				{
 					break 2;
 				}
-				CheckMaintenanceMode($oP);
+				CheckMaintenanceMode();
 				if ($iMaxCronProcess > 1) {
 					// Reindex tasks every time
 					break;
@@ -278,41 +261,31 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 			}
 
 			// Tasks to run later
-			if ($bVerbose && count($aTasks) == 0) {
-				$oP->p('--');
+			if (count($aTasks) == 0)
+			{
 				$oSearch = new DBObjectSearch('BackgroundTask');
 				$oSearch->AddCondition('next_run_date', $sNow, '>');
 				$oSearch->AddCondition('status', 'active');
 				$oTasks = new DBObjectSet($oSearch, ['next_run_date' => true]);
 				while ($oTask = $oTasks->Fetch()) {
 					if (!in_array($oTask->Get('class_name'), $aRunTasks)) {
-						$oP->p(sprintf("-- Skipping task: %-'-40s", $oTask->Get('class_name').' ')." until: ".$oTask->Get('next_run_date'));
+						CronLog::Debug(sprintf("-- Skipping task: %-'-40s", $oTask->Get('class_name').' ')." until: ".$oTask->Get('next_run_date'));
 					}
 				}
 			}
 		}
 		if (count($aTasks) == 0) {
-			if ($bVerbose) {
-				$oP->p("Sleeping...\n");
-			}
 			sleep($iCronSleep);
 		}
 	}
-	if ($bVerbose) {
-		$oP->p('');
-		DisplayStatus($oP, ['next_run_date' => true]);
-		$oP->p("Reached normal execution time limit (exceeded by ".(time() - $iTimeLimit)."s)");
-	}
+	CronLog::Debug("Reached normal execution time limit (exceeded by ".(time() - $iTimeLimit)."s)");
 }
 
-/**
- * @param WebPage $oP
- */
-function CheckMaintenanceMode(Page $oP)
+function CheckMaintenanceMode()
 {
 	// Verify files instead of reloading the full config each time
 	if (file_exists(MAINTENANCE_MODE_FILE) || file_exists(READONLY_MODE_FILE)) {
-		$oP->p("Maintenance detected, exiting");
+		CronLog::Info("Maintenance detected, exiting");
 		exit(EXIT_CODE_ERROR);
 	}
 }
@@ -327,7 +300,7 @@ function CheckMaintenanceMode(Page $oP)
  * @throws \MySQLException
  * @throws \OQLException
  */
-function DisplayStatus($oP, $aTaskOrderBy = [])
+function DisplayStatus($oP = null, $aTaskOrderBy = [])
 {
 	$oSearch = new DBObjectSearch('BackgroundTask');
 	$oTasks = new DBObjectSet($oSearch, $aTaskOrderBy);
@@ -355,8 +328,6 @@ function DisplayStatus($oP, $aTaskOrderBy = [])
 }
 
 /**
- * @param $oP
- * @param $bVerbose
  * @param $bDebug
  *
  * @throws \ArchivedObjectException
@@ -368,7 +339,7 @@ function DisplayStatus($oP, $aTaskOrderBy = [])
  * @throws \OQLException
  * @throws \ReflectionException
  */
-function ReSyncProcesses($oP, $bVerbose, $bDebug)
+function ReSyncProcesses($bDebug)
 {
 	// Enumerate classes implementing BackgroundProcess
 	//
@@ -403,10 +374,8 @@ function ReSyncProcesses($oP, $bVerbose, $bDebug)
 				// Background processes do start asap, i.e. "now"
 				$oTask->Set('next_run_date', $oNow->format('Y-m-d H:i:s'));
 			}
-			if ($bVerbose) {
-				$oP->p('Creating record for: '.$sTaskClass);
-				$oP->p('First execution planned at: '.$oTask->Get('next_run_date'));
-			}
+			CronLog::Debug('Creating record for: '.$sTaskClass);
+			CronLog::Debug('First execution planned at: '.$oTask->Get('next_run_date'));
 			$oTask->DBInsert();
 		} else {
 			/** @var \BackgroundTask $oTask */
@@ -439,14 +408,12 @@ function ReSyncProcesses($oP, $bVerbose, $bDebug)
 		}
 	}
 
-	if ($bVerbose) {
-		$aDisplayProcesses = [];
-		foreach ($aProcesses as $oExecInstance) {
-			$aDisplayProcesses[] = get_class($oExecInstance);
-		}
-		$sDisplayProcesses = implode(', ', $aDisplayProcesses);
-		$oP->p("Background processes: ".$sDisplayProcesses);
+	$aDisplayProcesses = [];
+	foreach ($aProcesses as $oExecInstance) {
+		$aDisplayProcesses[] = get_class($oExecInstance);
 	}
+	$sDisplayProcesses = implode(', ', $aDisplayProcesses);
+	CronLog::Debug("Background processes: ".$sDisplayProcesses);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -466,7 +433,10 @@ try {
 		$oP = new WebPage("iTop - cron");
 	}
 
-	$bVerbose = utils::ReadParam('verbose', false, true /* Allow CLI */);
+try
+{
+	utils::UseParamFile();
+
 	$bDebug = utils::ReadParam('debug', false, true /* Allow CLI */);
 
 	if ($bIsModeCLI) {
@@ -500,43 +470,47 @@ try {
 	}
 
 	require_once(APPROOT.'core/mutex.class.inc.php');
-	$oP->p("Starting: ".time().' ('.date('Y-m-d H:i:s').')');
 } catch (Exception $e) {
 	$oP->p("Error: ".$e->GetMessage());
 	$oP->output();
 	exit(EXIT_CODE_FATAL);
 }
 
+CronLog::Enable(APPROOT.'/log/cron.log');
 try
 {
 	if (!MetaModel::DBHasAccess(ACCESS_ADMIN_WRITE))
 	{
-		$oP->p("A maintenance is ongoing");
+		CronLog::Info("A maintenance is ongoing");
 	}
 	else
 	{
 		// Limit the number of cron process to run in parallel
-		$iMaxCronProcess = MetaModel::GetConfig()->Get('cron.max_process');
+		$iMaxCronProcess = MetaModel::GetConfig()->Get('cron.max_processes');
 		$bCanRun = false;
+		$iProcessNumber = 0;
 		for ($i = 0; $i < $iMaxCronProcess; $i++) {
 			$oMutex = new iTopMutex("cron#$i");
 			if ($oMutex->TryLock()) {
+				$iProcessNumber = $i + 1;
 				$bCanRun = true;
 				break;
 			}
 		}
 		if ($bCanRun) {
-			CronExec($oP, $bVerbose, $bDebug);
+			CronLog::$iProcessNumber = $iProcessNumber;
+			CronLog::Info('Starting: '.time().' ('.date('Y-m-d H:i:s').')');
+			CronExec($bDebug);
 		} else {
-			$oP->p("Already $iMaxCronProcess are running...");
+			CronLog::Debug("Already $iMaxCronProcess are running...");
 		}
 	}
-} catch (Exception $e) {
-	$oP->p("ERROR: '".$e->getMessage()."'");
-	if ($bDebug) {
-		// Might contain verb parameters such a password...
-		$oP->p($e->getTraceAsString());
-	}
+}
+catch (Exception $e)
+{
+	CronLog::Error("ERROR: '".$e->getMessage()."'");
+	// Might contain verb parameters such a password...
+	CronLog::Debug($e->getTraceAsString());
 } finally {
 	try {
 		$oMutex->Unlock();
@@ -549,5 +523,5 @@ try
 	}
 }
 
-$oP->p("Exiting: ".time().' ('.date('Y-m-d H:i:s').')');
+CronLog::Info("Exiting: ".time().' ('.date('Y-m-d H:i:s').')');
 $oP->Output();

--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -175,7 +175,7 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 	$iMaxDuration = MetaModel::GetConfig()->Get('cron_max_execution_time');
 	$iTimeLimit = $iStarted + $iMaxDuration;
 	$iCronSleep = MetaModel::GetConfig()->Get('cron_sleep');
-	$iMaxCronProcess = MetaModel::GetConfig()->Get('cron.max_process');
+	$iMaxCronProcess = MetaModel::GetConfig()->Get('cron.max_processes');
 
 	if ($bVerbose) {
 		$oP->p("Planned duration = $iMaxDuration seconds");

--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -245,29 +245,30 @@ function CronExec($bDebug )
 				CMDBObject::SetCurrentChangeFromParams("Background task ($sTaskClass)");
 
 				// Run the task and record its next run time
+				$sDebugTaskClass = CronLog::GetDebugClassName($sTaskClass);
 				$oNow = new DateTime();
-				CronLog::Debug(">> === ".$oNow->format('Y-m-d H:i:s').sprintf(" Start task:%-'=49s", ' '.$sTaskClass.' '));
+				CronLog::Debug(sprintf("> Starting >>> %-'>49s", $sDebugTaskClass.' '));
 				try {
 					// The limit of time for this task corresponds to the time slot allowed for every task
 					// but limited to the cron job time limit
 					$sMessage = RunTask($oTask, min($iTimeLimit, time() + $iTimeSlot));
 				}
 				catch (MySQLHasGoneAwayException $e) {
-					CronLog::Error("ERROR : 'MySQL has gone away' thrown when processing $sTaskClass  (error_code=".$e->getCode().")");
+					CronLog::Error("ERROR : 'MySQL has gone away' thrown when processing $sDebugTaskClass  (error_code=".$e->getCode().")", CronLog::CHANNEL_DEFAULT, ['stack' => $e->getTraceAsString()]);
 					exit(EXIT_CODE_FATAL);
 				}
 				catch (ProcessFatalException $e) {
-					CronLog::Error("ERROR : an exception was thrown when processing '$sTaskClass' (".$e->getInfoLog().")");
+					CronLog::Error("ERROR : an exception was thrown when processing '$sDebugTaskClass' (".$e->getInfoLog().")", CronLog::CHANNEL_DEFAULT, ['stack' => $e->getTraceAsString()]);
 				}
 				finally {
 					$oTaskMutex->Unlock();
 				}
 				if (!empty($sMessage)) {
-					CronLog::Debug("$sTaskClass: $sMessage");
+					CronLog::Debug("$sDebugTaskClass: $sMessage");
 				}
 				$oEnd = new DateTime();
 				$sNextRunDate = $oTask->Get('next_run_date');
-				CronLog::Debug("<< === ".$oEnd->format('Y-m-d H:i:s').sprintf(" End of:    %-'=49s", ' '.$sTaskClass.' ')." Next: $sNextRunDate");
+				CronLog::Debug(sprintf("< Ending <<<<< %-'<49s", $sDebugTaskClass.' ')." Next: $sNextRunDate");
 				if (time() > $iTimeLimit) {
 					break 2;
 				}
@@ -286,7 +287,8 @@ function CronExec($bDebug )
 				$oTasks = new DBObjectSet($oSearch, ['next_run_date' => true]);
 				while ($oTask = $oTasks->Fetch()) {
 					if (!in_array($oTask->Get('class_name'), $aRunTasks)) {
-						CronLog::Trace(sprintf("-- Skipping task: %-'-40s", $oTask->Get('class_name').' ')." until: ".$oTask->Get('next_run_date'));
+						$sDebugTaskClass = CronLog::GetDebugClassName($oTask->Get('class_name'));
+						CronLog::Trace(sprintf("-- Skipping task: %-'-40s", $sDebugTaskClass.' ')." until: ".$oTask->Get('next_run_date'));
 					}
 				}
 			}
@@ -392,7 +394,8 @@ function ReSyncProcesses($bDebug)
 				// Background processes do start asap, i.e. "now"
 				$oTask->Set('next_run_date', $oNow->format('Y-m-d H:i:s'));
 			}
-			CronLog::Trace('Creating record for: '.$sTaskClass);
+			$sDebugTaskClass = CronLog::GetDebugClassName($sTaskClass);
+			CronLog::Trace('Creating record for: '.$sDebugTaskClass);
 			CronLog::Trace('First execution planned at: '.$oTask->Get('next_run_date'));
 			$oTask->DBInsert();
 		} else {
@@ -496,10 +499,10 @@ try {
 	exit(EXIT_CODE_FATAL);
 }
 
-CronLog::Enable(APPROOT.'/log/cron.log');
+CronLog::Enable(APPROOT.'/log/error.log');
 try {
 	if (!MetaModel::DBHasAccess(ACCESS_ADMIN_WRITE)) {
-		CronLog::Info("A maintenance is ongoing");
+		CronLog::Debug("A maintenance is ongoing");
 	} else {
 		// Limit the number of cron process to run in parallel
 		$iMaxCronProcess = max(MetaModel::GetConfig()->Get('cron.max_processes'), 1);
@@ -515,7 +518,7 @@ try {
 		}
 		if ($bCanRun) {
 			CronLog::$iProcessNumber = $iProcessNumber;
-			CronLog::Info('Starting: '.time().' ('.date('Y-m-d H:i:s').')');
+			CronLog::Debug('Starting: '.time().' ('.date('Y-m-d H:i:s').')');
 			CronExec($iVerbose > 0);
 		} else {
 			CronLog::$iProcessNumber = $iMaxCronProcess + 1;
@@ -524,9 +527,7 @@ try {
 	}
 }
 catch (Exception $e) {
-	CronLog::Error("ERROR: '".$e->getMessage()."'");
-	// Might contain verb parameters such a password...
-	CronLog::Debug($e->getTraceAsString());
+	CronLog::Error("ERROR: '".$e->getMessage()."'", CronLog::CHANNEL_DEFAULT, ['stack' => $e->getTraceAsString()]);
 } finally {
 	try {
 		$oMutex->Unlock();
@@ -539,5 +540,5 @@ catch (Exception $e) {
 	}
 }
 
-CronLog::Info("Exiting: ".time().' ('.date('Y-m-d H:i:s').')');
+CronLog::Debug("Exiting: ".time().' ('.date('Y-m-d H:i:s').')');
 $oP->Output();

--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -278,7 +278,7 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 			}
 
 			// Tasks to run later
-			if ($bVerbose && $aTasks == []) {
+			if ($bVerbose && count($aTasks) == 0) {
 				$oP->p('--');
 				$oSearch = new DBObjectSearch('BackgroundTask');
 				$oSearch->AddCondition('next_run_date', $sNow, '>');
@@ -291,7 +291,7 @@ function CronExec($oP, $bVerbose, $bDebug = false)
 				}
 			}
 		}
-		if ($aTasks == []) {
+		if (count($aTasks) == 0) {
 			if ($bVerbose) {
 				$oP->p("Sleeping...\n");
 			}


### PR DESCRIPTION
Allow cron process to execute in parallel running different tasks.

Each task is only executed once at a time, but different tasks can run in parallel if multiple cron are executed.
The maximum number of parallel cron processes is configurable in iTop configuration.

The number of concurrent cron processes is obtained by configuring the 'cron_max_execution_time' and playing with the period of the cron. For example if the cron process last 10 minutes and the cron is launched every minute there will be roughly 10 parallel  cron running.

Another change is that the 'next_run_date' is calculated before running the task in order to have an update in case of problem and avoid running the same task again and again.