### PR TITLE
N°6104 - Fix exception thrown if 'item_class' has 'org_id' attcode mapped to another attcode not present in Person class

### DIFF
--- a/datamodels/2.x/itop-attachments/datamodel.itop-attachments.xml
+++ b/datamodels/2.x/itop-attachments/datamodel.itop-attachments.xml
@@ -176,18 +176,18 @@
 		$aCallSpec = array($sClass, 'MapContextParam');
 		if (is_callable($aCallSpec))
 		{
-			$sAttCode = call_user_func($aCallSpec, 'org_id'); // Returns null when there is no mapping for this parameter					
+			$sAttCode = call_user_func($aCallSpec, 'org_id'); // Returns null when there is no mapping for this parameter
 			if (MetaModel::IsValidAttCode($sClass, $sAttCode))
 			{
 				// Second: check that the organization CAN be fetched from the current user
 				//
 				if (MetaModel::IsValidClass('Person'))
 				{
-					$aCallSpec = array($sClass, 'MapContextParam');
+					$aCallSpec = array('Person', 'MapContextParam');
 					if (is_callable($aCallSpec))
 					{
-						$sAttCode = call_user_func($aCallSpec, 'org_id'); // Returns null when there is no mapping for this parameter					
-						if (MetaModel::IsValidAttCode($sClass, $sAttCode))
+						$sAttCode = call_user_func($aCallSpec, 'org_id'); // Returns null when there is no mapping for this parameter
+						if (MetaModel::IsValidAttCode('Person', $sAttCode))
 						{
 							// OK - try it
 							//


### PR DESCRIPTION
Hello!
If a class from Attachment.item_class has the MapContextParam method that returns an attribute code not present in the Person class, the execution fails on `$oCurrentPerson->Get($sAttCode)` with the unknown attribute exception and attachments are not saved.
In my case I faced with the problem in the UserRequest when mapping via MapContextParam the org_id to a newly created provider_org_id. The Person class obviously don't have the provider_org_id attcode but the second MetaModel::IsValidAttCode in the code checks the class from item_class again and not the Person class.