### PR TITLE
N°5343 - Avoid crash when 1st level menu group is not actually a MenuGroup

### DIFF
--- a/application/menunode.class.inc.php
+++ b/application/menunode.class.inc.php
@@ -265,6 +265,14 @@ class ApplicationMenu
 			/** @var \MenuGroup $oMenuNode */
 			$oMenuNode = static::GetMenuNode($sMenuGroupIdx);
 
+			if (!($oMenuNode instanceof MenuGroup)) {
+				IssueLog::Error('Menu node was not displayed as a menu group as it is actually not a menu group', LogChannels::CONSOLE, [
+					'menu_node_class' => get_class($oMenuNode),
+					'menu_node_label' => $oMenuNode->GetLabel(),
+				]);
+				continue;
+			}
+
 			$aMenuGroups[] = [
 				'sId' => $oMenuNode->GetMenuID(),
 				'sIconCssClasses' => $oMenuNode->GetDecorationClasses(),


### PR DESCRIPTION
**Symptom**
When logging in an iTop, the following error occurs: "Call to undefined method WebPageMenuNode::GetDecorationClasses()" and the user can't do anything. If often happens after adding a new extension which bring a menu entry in the backoffice.

**Cause**
If an extension brings a sub menu but the user doesn't have permission to see its parent menu, the sub menu will then try to be set as the parent menu, which in case of a 1st level menu crash because only MenuGroup have the `GetDecorationClasses()` method.

**Proposed solution**
Harden the core by ignoring sub menus concerned by this issue. An explicit log message would be logged to ease debugging.

```
2022-07-21 16:50:10 | Error   | 2349  | Menu node was not displayed as a menu group as it is actually not a menu group | console |||
array (
  'menu_node_class' => 'WebPageMenuNode',
  'menu_node_label' => 'SAML Configuration',
)
```