### PR TITLE
N°5281 - Portal: Add method to declare brick controller since Symfony 5.4 migration

### DIFF
--- a/datamodels/2.x/itop-portal-base/portal/config/services.php
+++ b/datamodels/2.x/itop-portal-base/portal/config/services.php
@@ -28,7 +28,7 @@ use Combodo\iTop\Portal\Routing\ItopExtensionsExtraRoutes;
  * @since 3.1.0
  * @package Symfony\Component\DependencyInjection\Loader\Configurator
  */
-return static function (ContainerConfigurator $container) {
+return static function (ContainerConfigurator $oContainer) {
 
 	// retrieve extension controller classes
 	$aControllersClasses = ItopExtensionsExtraRoutes::GetControllersClasses();
@@ -37,7 +37,7 @@ return static function (ContainerConfigurator $container) {
 	foreach ($aControllersClasses as $sController) {
 
 		// register as service
-		$container->services()->set($sController, $sController)
+		$oContainer->services()->set($sController, $sController)
 			->public()
 			->tag('controller.service_arguments')
 			->tag('container.service_suscriber')

--- a/datamodels/2.x/itop-portal-base/portal/config/services.php
+++ b/datamodels/2.x/itop-portal-base/portal/config/services.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright (C) 2013-2022 Combodo SARL
+ *
+ * This file is part of iTop.
+ *
+ * iTop is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * iTop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Combodo\iTop\Portal\Routing\ItopExtensionsExtraRoutes;
+
+/**
+ * Extensions controllers registration.
+ *
+ * @author Benjamin Dalsass
+ * @since 3.1.0
+ * @package Symfony\Component\DependencyInjection\Loader\Configurator
+ */
+return static function (ContainerConfigurator $container) {
+
+	// retrieve extension controller classes
+	$aControllersClasses = ItopExtensionsExtraRoutes::GetControllersClasses();
+
+	// iterate throw extensions controller classes...
+	foreach ($aControllersClasses as $sController) {
+
+		// register as service
+		$container->services()->set($sController, $sController)
+			->public()
+			->tag('controller.service_arguments')
+			->tag('container.service_suscriber')
+			->autowire()
+			->autoconfigure();
+	}
+
+};

--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
@@ -589,6 +589,8 @@ class ObjectController extends BrickController
 		$oSecurityHelper = $this->get('security_helper');
 		/** @var \Combodo\iTop\Portal\Helper\ScopeValidatorHelper $oScopeValidator */
 		$oScopeValidator = $this->get('scope_validator');
+		/** @var \Combodo\iTop\Portal\Helper\ObjectFormHandlerHelper $oFormHandlerHelper */
+		$oFormHandlerHelper = $this->get('object_form_handler');
 
 		$aData = array(
 			'results' => array(
@@ -640,16 +642,14 @@ class ObjectController extends BrickController
 		// Updating host object with form data / values
 		$sFormManagerClass = $aRequestContent['formmanager_class'];
 		$sFormManagerData = $aRequestContent['formmanager_data'];
-		if (!empty($sFormManagerClass) && !empty($sFormManagerData))
-		{
+		if (!empty($sFormManagerClass) && !empty($sFormManagerData)) {
 			/** @var \Combodo\iTop\Portal\Form\ObjectFormManager $oFormManager */
 			$oFormManager = $sFormManagerClass::FromJSON($sFormManagerData);
-			$oFormManager->SetContainer($this->container);
+			$oFormManager->SetObjectFormHandlerHelper($oFormHandlerHelper);
 			$oFormManager->SetObject($oHostObject);
 
 			// Applying action rules if present
-			if (($oFormManager->GetActionRulesToken() !== null) && ($oFormManager->GetActionRulesToken() !== ''))
-			{
+			if (($oFormManager->GetActionRulesToken() !== null) && ($oFormManager->GetActionRulesToken() !== '')) {
 				$aActionRules = ContextManipulatorHelper::DecodeRulesToken($oFormManager->GetActionRulesToken());
 				$oObj = $oFormManager->GetObject();
 				$oContextManipulator->PrepareObject($aActionRules, $oObj);
@@ -769,13 +769,14 @@ class ObjectController extends BrickController
 		$oSecurityHelper = $this->get('security_helper');
 		/** @var \Combodo\iTop\Portal\Helper\ScopeValidatorHelper $oScopeValidator */
 		$oScopeValidator = $this->get('scope_validator');
-
+		/** @var \Combodo\iTop\Portal\Helper\ObjectFormHandlerHelper $oFormHandlerHelper */
+		$oFormHandlerHelper = $this->get('object_form_handler');
 
 		$aData = array(
-			'sMode' => 'search_regular',
-			'sTargetAttCode' => $sTargetAttCode,
-			'sHostObjectClass' => $sHostObjectClass,
-			'sHostObjectId' => $sHostObjectId,
+			'sMode'             => 'search_regular',
+			'sTargetAttCode'    => $sTargetAttCode,
+			'sHostObjectClass'  => $sHostObjectClass,
+			'sHostObjectId'     => $sHostObjectId,
 			'sActionRulesToken' => $oRequestManipulator->ReadParam('ar_token', ''),
 		);
 
@@ -807,16 +808,14 @@ class ObjectController extends BrickController
 		// Updating host object with form data / values
 		$sFormManagerClass = $oRequestManipulator->ReadParam('formmanager_class', '', FILTER_UNSAFE_RAW);
 		$sFormManagerData = $oRequestManipulator->ReadParam('formmanager_data', '', FILTER_UNSAFE_RAW);
-		if (!empty($sFormManagerClass) && !empty($sFormManagerData))
-		{
+		if (!empty($sFormManagerClass) && !empty($sFormManagerData)) {
 			/** @var \Combodo\iTop\Portal\Form\ObjectFormManager $oFormManager */
 			$oFormManager = $sFormManagerClass::FromJSON($sFormManagerData);
-			$oFormManager->SetContainer($this->container);
+			$oFormManager->SetObjectFormHandlerHelper($oFormHandlerHelper);
 			$oFormManager->SetObject($oHostObject);
 
 			// Applying action rules if present
-			if (($oFormManager->GetActionRulesToken() !== null) && ($oFormManager->GetActionRulesToken() !== ''))
-			{
+			if (($oFormManager->GetActionRulesToken() !== null) && ($oFormManager->GetActionRulesToken() !== '')) {
 				$aActionRules = ContextManipulatorHelper::DecodeRulesToken($oFormManager->GetActionRulesToken());
 				$oObj = $oFormManager->GetObject();
 				$oContextManipulator->PrepareObject($aActionRules, $oObj);

--- a/datamodels/2.x/itop-portal-base/portal/src/EventListener/ExceptionListener.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/EventListener/ExceptionListener.php
@@ -117,9 +117,13 @@ class ExceptionListener implements ContainerAwareInterface
 		$oResponse->setStatusCode($iStatusCode);
 
 		// HttpExceptionInterface is a special type of exception that holds status code and header details
-		if ($oException instanceof HttpExceptionInterface)
-		{
+		if ($oException instanceof HttpExceptionInterface) {
 			$oResponse->headers->replace($oException->getHeaders());
+		}
+
+		// display original error page when app debug is on
+		if (($_SERVER['APP_DEBUG'] == 1)) {
+			return;
 		}
 
 		// Send the modified response object to the event

--- a/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
@@ -735,7 +735,7 @@ class ObjectFormManager extends FormManager
 						array('Combodo\\iTop\\Form\\Field\\SelectObjectField', 'Combodo\\iTop\\Form\\Field\\LinkedSetField'))) {
 						/** @var \Combodo\iTop\Form\Field\SelectObjectField|\Combodo\iTop\Form\Field\LinkedSetField $oField */
 						if ($this->oFormHandlerHelper !== null) {
-							$sSearchEndpoint = $this->oFormHandlerHelper->getUrlGenerator()->generate('p_object_search_generic', array(
+							$sSearchEndpoint = $this->oFormHandlerHelper->GetUrlGenerator()->generate('p_object_search_generic', array(
 								'sTargetAttCode'   => $oAttDef->GetCode(),
 								'sHostObjectClass' => get_class($this->oObject),
 								'sHostObjectId'    => ($this->oObject->IsNew()) ? null : $this->oObject->GetKey(),

--- a/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
@@ -759,7 +759,7 @@ class ObjectFormManager extends FormManager
 							$oScopeOriginal = ($oField->GetSearch() !== null) ? $oField->GetSearch() : DBSearch::FromOQL($oAttDef->GetValuesDef()->GetFilterExpression());
 
 							/** @var \DBSearch $oScopeSearch */
-							$oScopeSearch = $this->oFormHandlerHelper->getScopeValidator()->GetScopeFilterForProfiles(UserRights::ListProfiles(),
+							$oScopeSearch = $this->oFormHandlerHelper->GetScopeValidator()->GetScopeFilterForProfiles(UserRights::ListProfiles(),
 								$oScopeOriginal->GetClass(), UR_ACTION_READ);
 							if ($oScopeSearch === null) {
 								IssueLog::Info(__METHOD__.' at line '.__LINE__.' : User #'.UserRights::GetUserId().' has no scope query for '.$oScopeOriginal->GetClass().' class.');

--- a/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
@@ -748,7 +748,7 @@ class ObjectFormManager extends FormManager
 					if (in_array(get_class($oField), array('Combodo\\iTop\\Form\\Field\\LinkedSetField'))) {
 						/** @var \Combodo\iTop\Form\Field\LinkedSetField $oField */
 						if ($this->oFormHandlerHelper !== null) {
-							$oField->SetInformationEndpoint($this->oFormHandlerHelper->getUrlGenerator()->generate('p_object_get_information_json'));
+							$oField->SetInformationEndpoint($this->oFormHandlerHelper->GetUrlGenerator()->generate('p_object_get_information_json'));
 						}
 					}
 					// - Field that require to apply scope on its DM OQL

--- a/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
@@ -803,7 +803,7 @@ class ObjectFormManager extends FormManager
 										/** @var \Combodo\iTop\Form\Field\SelectObjectField $oCustomField */
 										if ($this->oFormHandlerHelper->getUrlGenerator() !== null) {
 
-											$sSearchEndpoint = $this->oFormHandlerHelper->getUrlGenerator()->generate('p_object_search_generic',
+											$sSearchEndpoint = $this->oFormHandlerHelper->GetUrlGenerator()->generate('p_object_search_generic',
 												array(
 													'sTargetAttCode'   => $oAttDef->GetCode(),
 													'sHostObjectClass' => get_class($this->oObject),

--- a/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
@@ -31,6 +31,7 @@ use Combodo\iTop\Form\Field\LabelField;
 use Combodo\iTop\Form\Form;
 use Combodo\iTop\Form\FormManager;
 use Combodo\iTop\Portal\Helper\ApplicationHelper;
+use Combodo\iTop\Portal\Helper\ObjectFormHandlerHelper;
 use DBObject;
 use DBObjectSearch;
 use DBObjectSet;
@@ -42,7 +43,6 @@ use Exception;
 use InlineImage;
 use IssueLog;
 use MetaModel;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use UserRights;
@@ -65,8 +65,6 @@ class ObjectFormManager extends FormManager
 	/** @var string ENUM_MODE_APPLY_STIMULUS */
 	const ENUM_MODE_APPLY_STIMULUS = 'apply_stimulus';
 
-	/** @var \Symfony\Component\DependencyInjection\ContainerInterface $oContainer */
-	protected $oContainer;
 	/** @var \cmdbAbstractObject $oObject */
 	protected $oObject;
 	/** @var string $sMode */
@@ -84,6 +82,15 @@ class ObjectFormManager extends FormManager
 	 * @since 2.7.5
 	 */
 	protected $aHiddenFieldsId = array();
+
+	/**
+	 * Replace container. Allow access to others applications services.
+	 *
+	 * @var ObjectFormHandlerHelper $oFormHandlerHelper
+	 * @since 3.1
+	 */
+	private $oFormHandlerHelper;
+
 
 	/**
 	 * @param string|array $formManagerData value of the formmanager_data portal parameter, either JSON or object
@@ -172,23 +179,15 @@ class ObjectFormManager extends FormManager
 	}
 
 	/**
-	 *
-	 * @return \Symfony\Component\DependencyInjection\ContainerInterface
-	 */
-	public function GetContainer()
-	{
-		return $this->oContainer;
-	}
-
-	/**
-	 *
-	 * @param \Symfony\Component\DependencyInjection\ContainerInterface $oContainer
+	 * @param \Combodo\iTop\Portal\Helper\ObjectFormHandlerHelper $oFormHandlerHelper
 	 *
 	 * @return $this
+	 * @since 3.1
+	 *
 	 */
-	public function SetContainer(ContainerInterface $oContainer)
+	public function SetObjectFormHandlerHelper(ObjectFormHandlerHelper $oFormHandlerHelper)
 	{
-		$this->oContainer = $oContainer;
+		$this->oFormHandlerHelper = $oFormHandlerHelper;
 
 		return $this;
 	}
@@ -429,28 +428,21 @@ class ObjectFormManager extends FormManager
 				break;
 		}
 		// - The layout
-		if ($this->aFormProperties['layout'] !== null)
-		{
+		if ($this->aFormProperties['layout'] !== null) {
 			// Checking if we need to render the template from twig to html in order to parse the fields
-			if ($this->aFormProperties['layout']['type'] === 'twig')
-			{
-				if ($this->oContainer !== null)
-				{
+			if ($this->aFormProperties['layout']['type'] === 'twig') {
+
+				if ($this->oFormHandlerHelper !== null) {
 					/** @var \Combodo\iTop\Portal\Helper\ObjectFormHandlerHelper $oObjectFormHandler */
-					$oObjectFormHandler = $this->oContainer->get('object_form_handler');
-					$sRendered = $oObjectFormHandler->RenderFormFromTwig(
+					$sRendered = $this->oFormHandlerHelper->RenderFormFromTwig(
 						$oForm->GetId(),
 						$this->aFormProperties['layout']['content'],
 						array('oRenderer' => $this->oRenderer, 'oObject' => $this->oObject)
 					);
-				}
-				else
-				{
+				} else {
 					$sRendered = 'Form not rendered because of missing container';
 				}
-			}
-			else
-			{
+			} else {
 				$sRendered = $this->aFormProperties['layout']['content'];
 			}
 
@@ -742,42 +734,36 @@ class ObjectFormManager extends FormManager
 					}
 					// - Field that require a search endpoint
 					if (in_array(get_class($oField),
-						array('Combodo\\iTop\\Form\\Field\\SelectObjectField', 'Combodo\\iTop\\Form\\Field\\LinkedSetField')))
-					{
+						array('Combodo\\iTop\\Form\\Field\\SelectObjectField', 'Combodo\\iTop\\Form\\Field\\LinkedSetField'))) {
 						/** @var \Combodo\iTop\Form\Field\SelectObjectField|\Combodo\iTop\Form\Field\LinkedSetField $oField */
-						if ($this->oContainer !== null)
-						{
-							$sSearchEndpoint = $this->oContainer->get('url_generator')->generate('p_object_search_generic', array(
-								'sTargetAttCode' => $oAttDef->GetCode(),
+						if ($this->oFormHandlerHelper !== null) {
+							$sSearchEndpoint = $this->oFormHandlerHelper->getUrlGenerator()->generate('p_object_search_generic', array(
+								'sTargetAttCode'   => $oAttDef->GetCode(),
 								'sHostObjectClass' => get_class($this->oObject),
-								'sHostObjectId' => ($this->oObject->IsNew()) ? null : $this->oObject->GetKey(),
-								'ar_token' => $this->GetActionRulesToken(),
+								'sHostObjectId'    => ($this->oObject->IsNew()) ? null : $this->oObject->GetKey(),
+								'ar_token'         => $this->GetActionRulesToken(),
 							));
 							$oField->SetSearchEndpoint($sSearchEndpoint);
 						}
 					}
 					// - Field that require an information endpoint
-					if (in_array(get_class($oField), array('Combodo\\iTop\\Form\\Field\\LinkedSetField')))
-					{
+					if (in_array(get_class($oField), array('Combodo\\iTop\\Form\\Field\\LinkedSetField'))) {
 						/** @var \Combodo\iTop\Form\Field\LinkedSetField $oField */
-						if ($this->oContainer !== null)
-						{
-							$oField->SetInformationEndpoint($this->oContainer->get('url_generator')->generate('p_object_get_information_json'));
+						if ($this->oFormHandlerHelper !== null) {
+							$oField->SetInformationEndpoint($this->oFormHandlerHelper->getUrlGenerator()->generate('p_object_get_information_json'));
 						}
 					}
 					// - Field that require to apply scope on its DM OQL
 					if (in_array(get_class($oField), array('Combodo\\iTop\\Form\\Field\\SelectObjectField')))
 					{
 						/** @var \Combodo\iTop\Form\Field\SelectObjectField $oField */
-						if ($this->oContainer !== null)
-						{
+						if ($this->oFormHandlerHelper !== null) {
 							$oScopeOriginal = ($oField->GetSearch() !== null) ? $oField->GetSearch() : DBSearch::FromOQL($oAttDef->GetValuesDef()->GetFilterExpression());
 
 							/** @var \DBSearch $oScopeSearch */
-							$oScopeSearch = $this->oContainer->get('scope_validator')->GetScopeFilterForProfiles(UserRights::ListProfiles(),
+							$oScopeSearch = $this->oFormHandlerHelper->getScopeValidator()->GetScopeFilterForProfiles(UserRights::ListProfiles(),
 								$oScopeOriginal->GetClass(), UR_ACTION_READ);
-							if ($oScopeSearch === null)
-							{
+							if ($oScopeSearch === null) {
 								IssueLog::Info(__METHOD__.' at line '.__LINE__.' : User #'.UserRights::GetUserId().' has no scope query for '.$oScopeOriginal->GetClass().' class.');
 								throw new HttpException(Response::HTTP_NOT_FOUND, Dict::S('UI:ObjectDoesNotExist'));
 							}
@@ -817,15 +803,14 @@ class ObjectFormManager extends FormManager
 									if (in_array(get_class($oCustomField), array('Combodo\\iTop\\Form\\Field\\SelectObjectField')))
 									{
 										/** @var \Combodo\iTop\Form\Field\SelectObjectField $oCustomField */
-										if ($this->oContainer !== null)
-										{
+										if ($this->oFormHandlerHelper->getUrlGenerator() !== null) {
 
-											$sSearchEndpoint = $this->oContainer->get('url_generator')->generate('p_object_search_generic',
+											$sSearchEndpoint = $this->oFormHandlerHelper->getUrlGenerator()->generate('p_object_search_generic',
 												array(
-													'sTargetAttCode' => $oAttDef->GetCode(),
+													'sTargetAttCode'   => $oAttDef->GetCode(),
 													'sHostObjectClass' => get_class($this->oObject),
-													'sHostObjectId' => ($this->oObject->IsNew()) ? null : $this->oObject->GetKey(),
-													'ar_token' => $this->GetActionRulesToken(),
+													'sHostObjectId'    => ($this->oObject->IsNew()) ? null : $this->oObject->GetKey(),
+													'ar_token'         => $this->GetActionRulesToken(),
 												));
 											$oCustomField->SetSearchEndpoint($sSearchEndpoint);
 										}
@@ -860,15 +845,13 @@ class ObjectFormManager extends FormManager
 					/** @var \Combodo\iTop\Form\Field\LinkedSetField $oField */
 					/** @var \AttributeLinkedSetIndirect $oAttDef */
 					//   - Overriding attributes to display
-					if ($this->oContainer !== null)
-					{
+					if ($this->oFormHandlerHelper !== null) {
 						// Note : This snippet is inspired from AttributeLinkedSet::MakeFormField()
-						$aAttCodesToDisplay = ApplicationHelper::GetLoadedListFromClass($this->oContainer->getParameter('combodo.portal.instance.conf')['lists'],
+						$aAttCodesToDisplay = ApplicationHelper::GetLoadedListFromClass($this->oFormHandlerHelper->getCombodoPortalConf()['lists'],
 							$oField->GetTargetClass(), 'list');
 						// - Adding friendlyname attribute to the list is not already in it
 						$sTitleAttCode = 'friendlyname';
-						if (($sTitleAttCode !== null) && !in_array($sTitleAttCode, $aAttCodesToDisplay))
-						{
+						if (($sTitleAttCode !== null) && !in_array($sTitleAttCode, $aAttCodesToDisplay)) {
 							$aAttCodesToDisplay = array_merge(array($sTitleAttCode), $aAttCodesToDisplay);
 						}
 						// - Adding attribute labels
@@ -881,25 +864,19 @@ class ObjectFormManager extends FormManager
 						$oField->SetAttributesToDisplay($aAttributesToDisplay);
 					}
 					//    - Filtering links regarding scopes
-					if ($this->oContainer !== null)
-					{
+					if ($this->oFormHandlerHelper !== null) {
 						$aLimitedAccessItemIDs = array();
 
 						/** @var \ormLinkSet $oFieldOriginalSet */
 						$oFieldOriginalSet = $oField->GetCurrentValue();
-						while ($oLink = $oFieldOriginalSet->Fetch())
-						{
-							if ($oField->IsIndirect())
-							{
+						while ($oLink = $oFieldOriginalSet->Fetch()) {
+							if ($oField->IsIndirect()) {
 								$iRemoteKey = $oLink->Get($oAttDef->GetExtKeyToRemote());
-							}
-							else
-							{
+							} else {
 								$iRemoteKey = $oLink->GetKey();
 							}
 
-							if (!$this->oContainer->get('security_helper')->IsActionAllowed(UR_ACTION_READ, $oField->GetTargetClass(), $iRemoteKey))
-							{
+							if (!$this->oFormHandlerHelper->getSecurityHelper()->IsActionAllowed(UR_ACTION_READ, $oField->GetTargetClass(), $iRemoteKey)) {
 								$aLimitedAccessItemIDs[] = $iRemoteKey;
 							}
 						}
@@ -921,23 +898,22 @@ class ObjectFormManager extends FormManager
 				if (in_array(get_class($oField), array('Combodo\\iTop\\Form\\Field\\BlobField', 'Combodo\\iTop\\Form\\Field\\ImageField')))
 				{
 					//   - Overriding attributes to display
-					if ($this->oContainer !== null)
-					{
+					if ($this->oFormHandlerHelper !== null) {
 						// Override hardcoded URLs in ormDocument pointing to back office console
 						$oOrmDoc = $this->oObject->Get($sAttCode);
-						$sDisplayUrl = $this->oContainer->get('url_generator')->generate('p_object_document_display', [
+						$sDisplayUrl = $this->oFormHandlerHelper->getUrlGenerator()->generate('p_object_document_display', [
 							'sObjectClass' => get_class($this->oObject),
-							'sObjectId' => $this->oObject->GetKey(),
+							'sObjectId'    => $this->oObject->GetKey(),
 							'sObjectField' => $sAttCode,
-							'cache' => 86400,
-							's' => $oOrmDoc->GetSignature(),
-							]);
-						$sDownloadUrl = $this->oContainer->get('url_generator')->generate('p_object_document_download', [
+							'cache'        => 86400,
+							's'            => $oOrmDoc->GetSignature(),
+						]);
+						$sDownloadUrl = $this->oFormHandlerHelper->getUrlGenerator()->generate('p_object_document_download', [
 							'sObjectClass' => get_class($this->oObject),
-							'sObjectId' => $this->oObject->GetKey(),
+							'sObjectId'    => $this->oObject->GetKey(),
 							'sObjectField' => $sAttCode,
-							'cache' => 86400,
-							's' => $oOrmDoc->GetSignature(),
+							'cache'        => 86400,
+							's'            => $oOrmDoc->GetSignature(),
 						]);
 						/** @var \Combodo\iTop\Form\Field\BlobField $oField */
 						$oField->SetDisplayUrl($sDisplayUrl)
@@ -1024,11 +1000,11 @@ class ObjectFormManager extends FormManager
 				// set id to a unique key - avoid collisions with another attribute that could exist with the name 'attachments'
 				$oField = new FileUploadField('attachments_plugin');
 				$oField->SetLabel(Dict::S('Portal:Attachments'))
-					->SetUploadEndpoint($this->oContainer->get('url_generator')->generate('p_object_attachment_add'))
-					->SetDownloadEndpoint($this->oContainer->get('url_generator')->generate('p_object_attachment_download',
+					->SetUploadEndpoint($this->oFormHandlerHelper->getUrlGenerator()->generate('p_object_attachment_add'))
+					->SetDownloadEndpoint($this->oFormHandlerHelper->getUrlGenerator()->generate('p_object_attachment_download',
 						array('sAttachmentId' => '-sAttachmentId-')))
 					->SetTransactionId($oForm->GetTransactionId())
-					->SetAllowDelete($this->oContainer->getParameter('combodo.portal.instance.conf')['properties']['attachments']['allow_delete'])
+					->SetAllowDelete($this->oFormHandlerHelper->getCombodoPortalConf()['properties']['attachments']['allow_delete'])
 					->SetObject($this->oObject);
 
 				// Checking if we can edit attachments in the current state
@@ -1148,7 +1124,7 @@ class ObjectFormManager extends FormManager
 			$bActivateTriggers = (!$bIsNew && $bWasModified);
 
 			// Forcing allowed writing on the object if necessary. This is used in some particular cases.
-			$bAllowWrite = $this->oContainer->get('security_helper')->IsActionAllowed($bIsNew ? UR_ACTION_CREATE : UR_ACTION_MODIFY, $sObjectClass, $this->oObject->GetKey());
+			$bAllowWrite = $this->oFormHandlerHelper->getSecurityHelper()->IsActionAllowed($bIsNew ? UR_ACTION_CREATE : UR_ACTION_MODIFY, $sObjectClass, $this->oObject->GetKey());
 			if ($bAllowWrite) {
 				$this->oObject->AllowWrite(true);
 			}
@@ -1181,7 +1157,7 @@ class ObjectFormManager extends FormManager
 			// Activating triggers only on update
 			if ($bActivateTriggers)
 			{
-				$sTriggersQuery = $this->oContainer->getParameter('combodo.portal.instance.conf')['properties']['triggers_query'];
+				$sTriggersQuery = $this->oFormHandlerHelper->getCombodoPortalConf()['properties']['triggers_query'];
 				if ($sTriggersQuery !== null)
 				{
 					$aParentClasses = MetaModel::EnumParentClasses($sObjectClass, ENUM_PARENT_CLASSES_ALL);

--- a/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
@@ -84,10 +84,8 @@ class ObjectFormManager extends FormManager
 	protected $aHiddenFieldsId = array();
 
 	/**
-	 * Replace container. Allow access to others applications services.
-	 *
 	 * @var ObjectFormHandlerHelper $oFormHandlerHelper
-	 * @since 3.1
+	 * @since 3.1.0 Replace container. Allow access to others applications services.
 	 */
 	private $oFormHandlerHelper;
 

--- a/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
@@ -180,7 +180,7 @@ class ObjectFormManager extends FormManager
 	 * @param \Combodo\iTop\Portal\Helper\ObjectFormHandlerHelper $oFormHandlerHelper
 	 *
 	 * @return $this
-	 * @since 3.1
+	 * @since 3.1.0
 	 *
 	 */
 	public function SetObjectFormHandlerHelper(ObjectFormHandlerHelper $oFormHandlerHelper)

--- a/datamodels/2.x/itop-portal-base/portal/src/Helper/ObjectFormHandlerHelper.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Helper/ObjectFormHandlerHelper.php
@@ -81,8 +81,6 @@ class ObjectFormHandlerHelper
 	private $sPortalId;
 	/** @var \Combodo\iTop\Portal\Twig\AppExtension $oAppExtension */
 	private $oAppExtension;
-	/** @var \Symfony\Component\DependencyInjection\ContainerInterface $oContainer */
-	private $oContainer;
 
 	/**
 	 * ObjectFormHandlerHelper constructor.
@@ -96,9 +94,11 @@ class ObjectFormHandlerHelper
 	 * @param array $aCombodoPortalInstanceConf
 	 * @param string $sPortalId
 	 * @param \Combodo\iTop\Portal\Twig\AppExtension $oAppExtension
-	 * @param \Symfony\Component\DependencyInjection\ContainerInterface $oContainer
 	 */
-	public function __construct(RequestManipulatorHelper $oRequestManipulator, ContextManipulatorHelper $oContextManipulator, NavigationRuleHelper $oNavigationRuleHelper, ScopeValidatorHelper $oScopeValidator, SecurityHelper $oSecurityHelper, UrlGeneratorInterface $oUrlGenerator, $aCombodoPortalInstanceConf, $sPortalId, AppExtension $oAppExtension, ContainerInterface $oContainer)
+	public function __construct(
+		RequestManipulatorHelper $oRequestManipulator, ContextManipulatorHelper $oContextManipulator, NavigationRuleHelper $oNavigationRuleHelper, ScopeValidatorHelper $oScopeValidator, SecurityHelper $oSecurityHelper, UrlGeneratorInterface $oUrlGenerator, $aCombodoPortalInstanceConf, $sPortalId,
+		AppExtension $oAppExtension
+	)
 	{
 		$this->oRequestManipulator = $oRequestManipulator;
 		$this->oContextManipulator = $oContextManipulator;
@@ -109,7 +109,6 @@ class ObjectFormHandlerHelper
 		$this->aCombodoPortalInstanceConf = $aCombodoPortalInstanceConf;
 		$this->sPortalId = $sPortalId;
 		$this->oAppExtension = $oAppExtension;
-		$this->oContainer = $oContainer;
 	}
 
 	/**
@@ -271,13 +270,13 @@ class ObjectFormHandlerHelper
 			}
 
 			$oFormRenderer = new BsFormRenderer();
-			if($sFormEndpoint !== null)
-			{
+			if ($sFormEndpoint !== null) {
 				$oFormRenderer->SetEndpoint($sFormEndpoint);
 			}
 
 			$oFormManager = new ObjectFormManager();
-			$oFormManager->SetContainer($this->oContainer)
+			$oFormManager
+				->SetObjectFormHandlerHelper($this)
 				->SetObject($oObject)
 				->SetMode($sMode)
 				->SetActionRulesToken($sActionRulesToken)
@@ -301,7 +300,7 @@ class ObjectFormHandlerHelper
 
 			$this->CheckReadFormDataAllowed($sFormManagerData);
 			$oFormManager = $sFormManagerClass::FromJSON($sFormManagerData);
-			$oFormManager->SetContainer($this->oContainer);
+			$oFormManager->SetObjectFormHandlerHelper($this);
 
 			// Applying action rules if present
 			if (($oFormManager->GetActionRulesToken() !== null) && ($oFormManager->GetActionRulesToken() !== '')) {
@@ -474,5 +473,45 @@ class ObjectFormHandlerHelper
 			static::ENUM_MODE_EDIT,
 			static::ENUM_MODE_CREATE,
 		);
+	}
+
+	/**
+	 * @return \Combodo\iTop\Portal\Routing\UrlGenerator|\Symfony\Component\Routing\Generator\UrlGeneratorInterface
+	 * @since 3.1
+	 *
+	 */
+	public function getUrlGenerator()
+	{
+		return $this->oUrlGenerator;
+	}
+
+	/**
+	 * @return \Combodo\iTop\Portal\Helper\SecurityHelper
+	 * @since 3.1
+	 *
+	 */
+	public function getSecurityHelper(): SecurityHelper
+	{
+		return $this->oSecurityHelper;
+	}
+
+	/**
+	 * @return \Combodo\iTop\Portal\Helper\ScopeValidatorHelper
+	 * @since 3.1
+	 *
+	 */
+	public function getScopeValidator(): ScopeValidatorHelper
+	{
+		return $this->oScopeValidator;
+	}
+
+	/**
+	 * @return array
+	 * @since 3.1
+	 *
+	 */
+	public function getCombodoPortalConf(): array
+	{
+		return $this->aCombodoPortalInstanceConf;
 	}
 }

--- a/datamodels/2.x/itop-portal-base/portal/src/Helper/ObjectFormHandlerHelper.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Helper/ObjectFormHandlerHelper.php
@@ -497,7 +497,7 @@ class ObjectFormHandlerHelper
 
 	/**
 	 * @return \Combodo\iTop\Portal\Helper\ScopeValidatorHelper
-	 * @since 3.1
+	 * @since 3.1.0
 	 *
 	 */
 	public function getScopeValidator(): ScopeValidatorHelper

--- a/datamodels/2.x/itop-portal-base/portal/src/Helper/ObjectFormHandlerHelper.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Helper/ObjectFormHandlerHelper.php
@@ -500,7 +500,7 @@ class ObjectFormHandlerHelper
 	 * @since 3.1.0
 	 *
 	 */
-	public function getScopeValidator(): ScopeValidatorHelper
+	public function GetScopeValidator(): ScopeValidatorHelper
 	{
 		return $this->oScopeValidator;
 	}

--- a/datamodels/2.x/itop-portal-base/portal/src/Helper/ObjectFormHandlerHelper.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Helper/ObjectFormHandlerHelper.php
@@ -507,7 +507,7 @@ class ObjectFormHandlerHelper
 
 	/**
 	 * @return array
-	 * @since 3.1
+	 * @since 3.1.0
 	 *
 	 */
 	public function getCombodoPortalConf(): array

--- a/datamodels/2.x/itop-portal-base/portal/src/Helper/ObjectFormHandlerHelper.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Helper/ObjectFormHandlerHelper.php
@@ -510,7 +510,7 @@ class ObjectFormHandlerHelper
 	 * @since 3.1.0
 	 *
 	 */
-	public function getCombodoPortalConf(): array
+	public function GetCombodoPortalConf(): array
 	{
 		return $this->aCombodoPortalInstanceConf;
 	}

--- a/datamodels/2.x/itop-portal-base/portal/src/Routing/ItopExtensionsExtraRoutes.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Routing/ItopExtensionsExtraRoutes.php
@@ -35,14 +35,19 @@ class ItopExtensionsExtraRoutes
 	static private $aRoutes = array();
 
 	/**
+	 * @var array $aControllersClasses
+	 * @since 3.1.0
+	 */
+	static private $aControllersClasses = array();
+
+	/**
 	 * @param array $extraRoutes
 	 *
 	 * @throws Exception
 	 */
 	public static function AddRoutes($extraRoutes)
 	{
-		if (!is_array($extraRoutes))
-		{
+		if (!is_array($extraRoutes)) {
 			throw new Exception('Only array are allowed as parameter to '.__METHOD__);
 		}
 
@@ -55,5 +60,28 @@ class ItopExtensionsExtraRoutes
 	public static function GetRoutes()
 	{
 		return self::$aRoutes;
+	}
+
+	/**
+	 * @param array $extraControllersClasses
+	 *
+	 * @throws Exception
+	 */
+	public static function AddControllersClasses($extraControllersClasses)
+	{
+		if (!is_array($extraControllersClasses)) {
+			throw new Exception('Only array are allowed as parameter to '.__METHOD__);
+		}
+
+		self::$aControllersClasses = array_merge(self::$aControllersClasses, $extraControllersClasses);
+	}
+
+	/**
+	 * @return array
+	 * @since 3.1.0
+	 */
+	public static function GetControllersClasses()
+	{
+		return self::$aControllersClasses;
 	}
 }

--- a/datamodels/2.x/itop-portal-base/portal/src/Routing/ItopExtensionsExtraRoutes.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Routing/ItopExtensionsExtraRoutes.php
@@ -66,6 +66,7 @@ class ItopExtensionsExtraRoutes
 	 * @param array $extraControllersClasses
 	 *
 	 * @throws Exception
+	 * @since 3.1.0
 	 */
 	public static function AddControllersClasses($extraControllersClasses)
 	{


### PR DESCRIPTION
Add Controllers declaration via ItopExtensionsExtraRoutes.

Extensions that define a controller need to declare them alongside route definition.

Impacted extension have been updated with bug
[N°5281 - Symfony 5.4 extensions controllers registration](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=5281&)