### PR TITLE
N°5281 - Symfony 5.4 extensions controllers registration

### DIFF
--- a/datamodels/2.x/itop-portal-base/portal/config/bootstrap.php
+++ b/datamodels/2.x/itop-portal-base/portal/config/bootstrap.php
@@ -56,7 +56,7 @@ if (file_exists(dirname(__DIR__).'/.env.local.php')) {
 
 	// load all the .env files
 	if (method_exists($oDotenv, 'loadEnv')) {
-		$oDotenv->loadEnv($sPath);
+		$oDotenv->loadEnv($sPath, null, 'prod');
 	} else {
 		// fallback code in case your Dotenv component is not 4.2 or higher (when loadEnv() was added)
 

--- a/datamodels/2.x/itop-portal-base/portal/config/bootstrap.php
+++ b/datamodels/2.x/itop-portal-base/portal/config/bootstrap.php
@@ -85,12 +85,6 @@ if (file_exists(dirname(__DIR__).'/.env.local.php')) {
 	}
 }
 
-// Set debug mode only when necessary
-if (utils::ReadParam('debug', 'false') === 'true')
-{
-	$_SERVER['APP_DEBUG'] = true;
-}
-
 $_SERVER += $_ENV;
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = (isset($_SERVER['APP_ENV']) ? $_SERVER['APP_ENV'] : (isset($_ENV['APP_ENV']) ? $_ENV['APP_ENV'] : null)) ?: 'prod';
 $_SERVER['APP_DEBUG'] = isset($_SERVER['APP_DEBUG']) ? $_SERVER['APP_DEBUG'] : (isset($_ENV['APP_DEBUG']) ? $_ENV['APP_DEBUG'] : ('prod' !== $_SERVER['APP_ENV']));

--- a/datamodels/2.x/itop-portal-base/portal/src/Kernel.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Kernel.php
@@ -21,11 +21,10 @@ namespace Combodo\iTop\Portal;
 
 use DeprecatedCallsLog;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
-use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileResource;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
-use Symfony\Component\Routing\RouteCollectionBuilder;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use utils;
 
 /**
@@ -36,7 +35,7 @@ use utils;
  */
 class Kernel extends BaseKernel
 {
-    use MicroKernelTrait;
+	use MicroKernelTrait;
 
     /** @var string CONFIG_EXTS */
     const CONFIG_EXTS = '.{php,xml,yaml,yml}';
@@ -45,11 +44,11 @@ class Kernel extends BaseKernel
 	 * @return string
 	 */
 	public function getCacheDir()
-    {
-	    $cacheDir = $_ENV['PORTAL_ID'] . '-' . $this->environment;
+	{
+		$cacheDir = $_ENV['PORTAL_ID'].'-'.$this->environment;
 
-	    return utils::GetCachePath() . "/portals/$cacheDir";
-    }
+		return utils::GetCachePath()."/portals/$cacheDir";
+	}
 
 	/**
 	 * @return string
@@ -69,42 +68,43 @@ class Kernel extends BaseKernel
         $contents = require $this->getProjectDir().'/config/bundles.php';
         foreach ($contents as $class => $envs) {
             if (isset($envs[$this->environment]) || isset($envs['all'])) {
-                yield new $class();
+	            yield new $class();
             }
         }
     }
 
 	/**
-	 * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-	 * @param \Symfony\Component\Config\Loader\LoaderInterface        $loader
+	 * @param \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $container
 	 *
-	 * @throws \Exception
+	 * @return void
 	 */
-	protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
-    {
-        $container->addResource(new FileResource($this->getProjectDir().'/config/bundles.php'));
-        $container->setParameter('container.dumper.inline_class_loader', true);
-        $confDir = $this->getProjectDir().'/config';
+	protected function configureContainer(ContainerConfigurator $container)
+	{
+		$confDir = '../config';
 
-        $loader->load($confDir.'/{packages}/*'.self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir.'/{packages}/'.$this->environment.'/**/*'.self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir.'/{services}'.self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir.'/{services}_'.$this->environment.self::CONFIG_EXTS, 'glob');
-    }
+		$container->import(new FileResource($this->getProjectDir().'/config/bundles.php'));
+		$container->parameters()->set('container.dumper.inline_class_loader', true);
+
+		$container->import($confDir.'/{packages}/*'.self::CONFIG_EXTS);
+		$container->import($confDir.'/{packages}/'.$this->environment.'/**/*'.self::CONFIG_EXTS);
+		$container->import($confDir.'/{services}'.self::CONFIG_EXTS);
+		$container->import($confDir.'/{services}_'.$this->environment.self::CONFIG_EXTS);
+	}
 
 	/**
-	 * @param \Symfony\Component\Routing\RouteCollectionBuilder $routes
+	 * @param \Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator $routes
 	 *
-	 * @throws \Symfony\Component\Config\Exception\FileLoaderLoadException
+	 * @return void
 	 */
-	protected function configureRoutes(RouteCollectionBuilder $routes)
-    {
-        $confDir = $this->getProjectDir().'/config';
+	protected function configureRoutes(RoutingConfigurator $routes)
+	{
+		$confDir = '../config';
 
-        $routes->import($confDir.'/{routes}/'.$this->environment.'/**/*'.self::CONFIG_EXTS, '/', 'glob');
-        $routes->import($confDir.'/{routes}/*'.self::CONFIG_EXTS, '/', 'glob');
-        $routes->import($confDir.'/{routes}'.self::CONFIG_EXTS, '/', 'glob');
-    }
+		$routes->import($confDir.'/{routes}/'.$this->environment.'/**/*'.self::CONFIG_EXTS);
+		$routes->import($confDir.'/{routes}/*'.self::CONFIG_EXTS);
+		$routes->import($confDir.'/{routes}'.self::CONFIG_EXTS);
+	}
+
 
 	/**
 	 * Checks if a given class name belongs to an active bundle.

--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -94,7 +94,7 @@ class CheckResult {
 class SetupUtils
 {
 	// -- Minimum versions (requirements : forbids installation if not met)
-	const PHP_MIN_VERSION             = '7.2.5'; // 7 will be supported until the end of 2019 (see http://php.net/supported-versions.php)
+	const PHP_MIN_VERSION             = '7.2.5';
 	const MYSQL_MIN_VERSION           = '5.7.0'; // 5.6 is no longer supported
 	const MYSQL_NOT_VALIDATED_VERSION = ''; // MySQL 8 is now OK (N°2010 in 2.7.0) but has no query cache so mind the perf on large volumes !
 


### PR DESCRIPTION
Symfony upgrade to 5.4 improvements:

- Set default env var value (prod)
- Remove switch env by request param (&debug=true)
- Remove kernel deprecation calls