### PR TITLE
N°3390 - Cleanup "debug" param remains by moving logs to debug level / portal channel

### DIFF
--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/AggregatePageBrickController.class.inc.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/AggregatePageBrickController.class.inc.php
@@ -22,9 +22,11 @@ namespace Combodo\iTop\Portal\Controller;
 
 use Combodo\iTop\Portal\Brick\BrickNotFoundException;
 use IssueLog;
+use LogChannels;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use UserRights;
 
 
 /**
@@ -91,10 +93,10 @@ class AggregatePageBrickController extends BrickController
 			}
 			catch (BrickNotFoundException $oException)
 			{
-				if ($this->get('kernel')->isDebug())
-				{
-					IssueLog::Warning('AggregatePageBrick: Could not display "'.$sBrickId.'", either wrong id or user profile not allowed');
-				}
+				IssueLog::Debug('AggregatePageBrick: Could not display brick, either wrong id or user profile not allowed', LogChannels::PORTAL, [
+					'brick_id' => $sBrickId,
+					'user_profiles' => UserRights::ListProfiles(),
+				]);
 				continue;
 			}
 

--- a/datamodels/2.x/itop-portal-base/portal/src/Helper/SecurityHelper.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Helper/SecurityHelper.php
@@ -20,6 +20,7 @@
 
 namespace Combodo\iTop\Portal\Helper;
 
+use LogChannels;
 use UserRights;
 use IssueLog;
 use MetaModel;
@@ -95,11 +96,7 @@ class SecurityHelper
 		// Checking action type
 		if (!in_array($sAction, array(UR_ACTION_READ, UR_ACTION_MODIFY, UR_ACTION_CREATE)))
 		{
-			if ($this->bDebug)
-			{
-				IssueLog::Info($sDebugTracePrefix.' as the action value could not be understood ('.UR_ACTION_READ.'/'.UR_ACTION_MODIFY.'/'.UR_ACTION_CREATE.' expected');
-			}
-
+			IssueLog::Debug($sDebugTracePrefix.' as the action value could not be understood ('.UR_ACTION_READ.'/'.UR_ACTION_MODIFY.'/'.UR_ACTION_CREATE.' expected', LogChannels::PORTAL);
 			return false;
 		}
 
@@ -116,11 +113,7 @@ class SecurityHelper
 		$oScopeQuery = $this->oScopeValidator->GetScopeFilterForProfiles(UserRights::ListProfiles(), $sObjectClass, $sScopeAction);
 		if ($oScopeQuery === null)
 		{
-			if ($this->bDebug)
-			{
-				IssueLog::Info($sDebugTracePrefix.' as there was no scope defined for action '.$sScopeAction.' and profiles '.implode('/', UserRights::ListProfiles()));
-			}
-
+			IssueLog::Debug($sDebugTracePrefix.' as there was no scope defined for action '.$sScopeAction.' and profiles '.implode('/', UserRights::ListProfiles()), LogChannels::PORTAL);
 			return false;
 		}
 		// - If action != create we do some additionnal checks
@@ -134,11 +127,7 @@ class SecurityHelper
 				{
 					if (static::$aAllowedScopeObjectsCache[$sScopeAction][$sObjectClass][$sObjectId] === false)
 					{
-						if ($this->bDebug)
-						{
-							IssueLog::Info($sDebugTracePrefix.' as it was denied in the scope objects cache');
-						}
-
+						IssueLog::Debug($sDebugTracePrefix.' as it was denied in the scope objects cache', LogChannels::PORTAL);
 						return false;
 					}
 				}
@@ -163,11 +152,7 @@ class SecurityHelper
 						// Updating cache
 						static::$aAllowedScopeObjectsCache[$sScopeAction][$sObjectClass][$sObjectId] = false;
 
-						if ($this->bDebug)
-						{
-							IssueLog::Info($sDebugTracePrefix.' as there was no result for the following scope query : '.$oScopeQuery->ToOQL(true));
-						}
-
+						IssueLog::Debug($sDebugTracePrefix.' as there was no result for the following scope query : '.$oScopeQuery->ToOQL(true), LogChannels::PORTAL);
 						return false;
 					}
 
@@ -180,13 +165,9 @@ class SecurityHelper
 		// Checking reading security layer. The object could be listed, check if it is actually allowed to view it
 		if (UserRights::IsActionAllowed($sObjectClass, $sAction) == UR_ALLOWED_NO)
 		{
-			// For security reasons, we don't want to give the user too many informations on why he cannot access the object.
+			// For security reasons, we don't want to give the user too many information on why he cannot access the object.
 			//throw new SecurityException('User not allowed to view this object', array('class' => $sObjectClass, 'id' => $sObjectId));
-			if ($this->bDebug)
-			{
-				IssueLog::Info($sDebugTracePrefix.' as the user is not allowed to access this object according to the datamodel security (cf. Console settings)');
-			}
-
+			IssueLog::Debug($sDebugTracePrefix.' as the user is not allowed to access this object according to the datamodel security (cf. Console settings)', LogChannels::PORTAL);
 			return false;
 		}
 

--- a/datamodels/2.x/itop-portal-base/portal/templates/layout.html.twig
+++ b/datamodels/2.x/itop-portal-base/portal/templates/layout.html.twig
@@ -312,7 +312,7 @@
 							{% block pNavigationSideMenuLogo %}
 								{# This is a debug helper to know in which screen size we are #}
 								{% if app['kernel'].debug == true %}
-									<div style="position: fixed; bottom: 0px; left: 0px; z-index: 9999;">Debug : Taille <span class="hidden-sm hidden-md hidden-lg">XS</span><span class="hidden-xs hidden-md hidden-lg">SM</span><span class="hidden-xs hidden-sm hidden-lg">MD</span><span class="hidden-xs hidden-sm hidden-md">LG</span></div>
+									<div style="position: fixed; bottom: 0px; left: 0px; z-index: 9999;">Debug: Screen size <span class="hidden-sm hidden-md hidden-lg">XS</span><span class="hidden-xs hidden-md hidden-lg">SM</span><span class="hidden-xs hidden-sm hidden-lg">MD</span><span class="hidden-xs hidden-sm hidden-md">LG</span></div>
 								{% endif %}
 								<a href="{{ get_config_parameter('app_icon_url') }}" title="{{ app['combodo.portal.instance.conf'].properties.name|dict_s }}">
 									<img src="{{ app['combodo.portal.instance.conf'].properties.logo }}" alt="{{ app['combodo.portal.instance.conf'].properties.name|dict_s }}" />


### PR DESCRIPTION
As the "&debug=true" param doesn't have any effect anymore in the user portal, this aims at cleaning what is left of it.

  * Debug messages now use the "Debug" level and "portal" channel instead of relying on the URL parameter