### PR TITLE
N°4792 - memory limit is reached when an AttributeExternalKey is pointing to a class with an AttributeBlob

### DIFF
--- a/application/ui.extkeywidget.class.inc.php
+++ b/application/ui.extkeywidget.class.inc.php
@@ -211,7 +211,7 @@ class UIExtKeyWidget
 			$sClassAllowed = $oAllowedValues->GetClass();
 			$bAddingValue = false;
 
-			// #4792 - load only the required fields
+			// N°4792 - load only the required fields
 			$aFieldsToLoad = [];
 
 			$aComplementAttributeSpec = MetaModel::GetNameSpec($oAllowedValues->GetClass(), FriendlyNameType::COMPLEMENTARY);
@@ -220,7 +220,7 @@ class UIExtKeyWidget
 
 			if (count($aAdditionalField) > 0) {
 				$bAddingValue = true;
-				$aFieldsToLoad = $aComplementAttributeSpec;
+				$aFieldsToLoad[$sClassAllowed] = $aAdditionalField;
 			}
 			$sObjectImageAttCode = MetaModel::GetImageAttributeCode($sClassAllowed);
 			if (!empty($sObjectImageAttCode)) {

--- a/application/ui.extkeywidget.class.inc.php
+++ b/application/ui.extkeywidget.class.inc.php
@@ -211,14 +211,23 @@ class UIExtKeyWidget
 			$sClassAllowed = $oAllowedValues->GetClass();
 			$bAddingValue = false;
 
+			// #4792 - load only the required fields
+			$aFieldsToLoad = [];
+
 			$aComplementAttributeSpec = MetaModel::GetNameSpec($oAllowedValues->GetClass(), FriendlyNameType::COMPLEMENTARY);
 			$sFormatAdditionalField = $aComplementAttributeSpec[0];
 			$aAdditionalField = $aComplementAttributeSpec[1];
 
 			if (count($aAdditionalField) > 0) {
 				$bAddingValue = true;
+				$aFieldsToLoad = $aComplementAttributeSpec;
 			}
 			$sObjectImageAttCode = MetaModel::GetImageAttributeCode($sClassAllowed);
+			if (!empty($sObjectImageAttCode)) {
+				$aFieldsToLoad[$sClassAllowed][] = $sObjectImageAttCode;
+			}
+			$aFieldsToLoad[$sClassAllowed][] = 'friendlyname';
+			$oAllowedValues->OptimizeColumnLoad($aFieldsToLoad);
 			$bInitValue = false;
 			while ($oObj = $oAllowedValues->Fetch()) {
 				$aOption = [];

--- a/core/dbsearch.class.php
+++ b/core/dbsearch.class.php
@@ -1724,4 +1724,16 @@ abstract class DBSearch
 	{
 		$this->SetShowObsoleteData(utils::ShowObsoleteData());
 	}
+
+	/**
+	 * To ease the debug of filters
+	 * @internal
+	 *
+	 * @return string
+	 *
+	 */
+	public function __toString()
+	{
+		return $this->ToOQL();
+	}
 }


### PR DESCRIPTION
What was done:
  * When requesting values for external keys in the case of combobox (request all possible values) the columns fetched are limitted to the minimum to avoid loading the full objects including blobs
  * __toString() was also added to DBSearch to ease debug