### PR TITLE
N°5375 - XML custo on Semantic field with hierarchy, breaks at compilation

### DIFF
--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -2012,7 +2012,11 @@ EOF
 			// Note: We can't use ModelFactory::GetField() as the current clas doesn't seem to be loaded yet.
 			$oField = $this->oFactory->GetNodes('field[@id="'.$sStateAttCode.'"]', $oFields)->item(0);
 			if ($oField == null) {
-				throw new DOMFormatException("Non existing attribute '$sStateAttCode'", null, null, $oStateAttribute);
+				// Search field in parent class
+				$oField = $this->GetFieldInParentClasses($oClass, $sStateAttCode);
+				if ($oField == null) {
+					throw new DOMFormatException("Non existing attribute '$sStateAttCode'", null, null, $oStateAttribute);
+				}
 			}
 			$oValues = $oField->GetUniqueElement('values');
 			$oValueNodes = $oValues->getElementsByTagName('value');
@@ -3735,5 +3739,20 @@ EOF;
 		}
 
 		return $sValue;
+	}
+
+	private function GetFieldInParentClasses($oClass, $sAttCode)
+	{
+		$sParentClass = $oClass->GetChildText('parent', 'DBObject');
+		if ($sParentClass != 'DBObject') {
+			$oParent = $this->oFactory->GetClass($sParentClass);
+			$oParentFields = $oParent->GetOptionalElement('fields');
+			$oField = $this->oFactory->GetNodes('field[@id="'.$sAttCode.'"]', $oParentFields)->item(0);
+			if ($oField != null) {
+				return $oField;
+			}
+			return $this->GetFieldInParentClasses($oParent, $sAttCode);
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
When fields_semantic/state_attribute refers an attribute of the parent class, the compile stops.

What was done:
  * search the attribute in the parent classes rather than only in the current class