### PR TITLE
N°5009 - Invalid XML for class Attachment (icon node)

### DIFF
--- a/datamodels/2.x/authent-ldap/datamodel.authent-ldap.xml
+++ b/datamodels/2.x/authent-ldap/datamodel.authent-ldap.xml
@@ -27,7 +27,9 @@
                     </attributes>
                 </naming>
                 <display_template/>
-                <icon/>
+                <style>
+                  <icon/>
+                </style>
                 <reconciliation>
                     <attributes>
                         <attribute id="login"/>

--- a/datamodels/2.x/itop-attachments/datamodel.itop-attachments.xml
+++ b/datamodels/2.x/itop-attachments/datamodel.itop-attachments.xml
@@ -27,7 +27,9 @@
             <attribute id="temp_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id=""/>

--- a/datamodels/2.x/itop-bridge-cmdb-ticket/datamodel.itop-bridge-cmdb-ticket.xml
+++ b/datamodels/2.x/itop-bridge-cmdb-ticket/datamodel.itop-bridge-cmdb-ticket.xml
@@ -18,7 +18,9 @@
             <attribute id="functionalci_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="ticket_id"/>
@@ -133,7 +135,9 @@
             <attribute id="functionalci_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="providercontract_id"/>
@@ -213,7 +217,9 @@
             <attribute id="functionalci_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="service_id"/>

--- a/datamodels/2.x/itop-bridge-virtualization-storage/datamodel.itop-bridge-virtualization-storage.xml
+++ b/datamodels/2.x/itop-bridge-virtualization-storage/datamodel.itop-bridge-virtualization-storage.xml
@@ -16,7 +16,9 @@
             <attribute id="volume_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
           </attributes>

--- a/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
+++ b/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
@@ -3889,7 +3889,9 @@
 						<attribute id="document_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="licence_id"/>
@@ -3968,7 +3970,9 @@
 						<attribute id="name"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="name"/>
@@ -4034,7 +4038,9 @@
 						<attribute id="name"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="name"/>
@@ -4081,7 +4087,9 @@
 						<attribute id="name"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="name"/>
@@ -4148,7 +4156,9 @@
 						<attribute id="name"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="name"/>
@@ -4306,7 +4316,9 @@
 						<attribute id="name"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="name"/>
@@ -4366,7 +4378,9 @@
 						<attribute id="name"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="name"/>
@@ -4434,7 +4448,9 @@
 						<attribute id="contact_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="functionalci_id"/>
@@ -4514,7 +4530,9 @@
 						<attribute id="document_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="patch_id"/>
@@ -4594,7 +4612,9 @@
 						<attribute id="softwareinstance_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="softwarepatch_id"/>
@@ -4674,7 +4694,9 @@
 						<attribute id="functionalci_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="ospatch_id"/>
@@ -4754,7 +4776,9 @@
 						<attribute id="document_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="software_id"/>
@@ -4834,7 +4858,9 @@
 						<attribute id="document_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="functionalci_id"/>
@@ -5228,7 +5254,9 @@
 						<attribute id="vlan_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="subnet_id"/>
@@ -5644,7 +5672,9 @@
 						<attribute id="vlan_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="physicalinterface_id"/>
@@ -5732,7 +5762,9 @@
 						<attribute id="connectableci_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="networkdevice_id"/>
@@ -5992,7 +6024,9 @@
 						<attribute id="functionalci_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="applicationsolution_id"/>
@@ -6072,7 +6106,9 @@
 						<attribute id="applicationsolution_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="businessprocess_id"/>
@@ -6320,7 +6356,9 @@
 						<attribute id="group_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="group_id"/>

--- a/datamodels/2.x/itop-faq-light/datamodel.itop-faq-light.xml
+++ b/datamodels/2.x/itop-faq-light/datamodel.itop-faq-light.xml
@@ -155,7 +155,9 @@
             <attribute id="name"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="name"/>

--- a/datamodels/2.x/itop-knownerror-mgmt/datamodel.itop-knownerror-mgmt.xml
+++ b/datamodels/2.x/itop-knownerror-mgmt/datamodel.itop-knownerror-mgmt.xml
@@ -248,7 +248,9 @@
         <naming>
           <attributes/>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="functionalci_id"/>
@@ -341,7 +343,9 @@
             <attribute id="link_type"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="document_id"/>

--- a/datamodels/2.x/itop-service-mgmt-provider/datamodel.itop-service-mgmt-provider.xml
+++ b/datamodels/2.x/itop-service-mgmt-provider/datamodel.itop-service-mgmt-provider.xml
@@ -362,7 +362,9 @@ public function PrefillSearchForm(&$aContextParam)
             <attribute id="name"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="name"/>
@@ -765,7 +767,9 @@ public function PrefillSearchForm(&$aContextParam)
             <attribute id="contact_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="contract_id"/>
@@ -845,7 +849,9 @@ public function PrefillSearchForm(&$aContextParam)
             <attribute id="document_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="contract_id"/>
@@ -1213,7 +1219,9 @@ public function PrefillSearchForm(&$aContextParam)
             <attribute id="document_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="service_id"/>
@@ -1293,7 +1301,9 @@ public function PrefillSearchForm(&$aContextParam)
             <attribute id="contact_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="service_id"/>
@@ -1848,7 +1858,9 @@ public function PrefillSearchForm(&$aContextParam)
             <attribute id="slt_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="sla_id"/>
@@ -1968,7 +1980,9 @@ public function PrefillSearchForm(&$aContextParam)
             <attribute id="service_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="customercontract_id"/>
@@ -2064,7 +2078,9 @@ public function PrefillSearchForm(&$aContextParam)
             <attribute id="providercontract_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="customercontract_id"/>
@@ -2144,7 +2160,9 @@ public function PrefillSearchForm(&$aContextParam)
             <attribute id="functionalci_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="customercontract_id"/>
@@ -2330,7 +2348,9 @@ public function PrefillSearchForm(&$aContextParam)
             <attribute id="contact_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="deliverymodel_id"/>

--- a/datamodels/2.x/itop-service-mgmt/datamodel.itop-service-mgmt.xml
+++ b/datamodels/2.x/itop-service-mgmt/datamodel.itop-service-mgmt.xml
@@ -362,9 +362,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="name"/>
 					</attributes>
 				</naming>
-        <style>
-          <icon/>
-        </style>
+		<style>
+			<icon/>
+		</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="name"/>
@@ -739,9 +739,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="contact_id"/>
 					</attributes>
 				</naming>
-        <style>
-          <icon/>
-        </style>
+		<style>
+			<icon/>
+		</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="contract_id"/>
@@ -821,9 +821,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="document_id"/>
 					</attributes>
 				</naming>
-        <style>
-          <icon/>
-        </style>
+		<style>
+			<icon/>
+		</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="contract_id"/>
@@ -1213,9 +1213,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="document_id"/>
 					</attributes>
 				</naming>
-        <style>
-          <icon/>
-        </style>
+		<style>
+			<icon/>
+		</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="service_id"/>
@@ -1295,9 +1295,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="contact_id"/>
 					</attributes>
 				</naming>
-        <style>
-          <icon/>
-        </style>
+		<style>
+			<icon/>
+		</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="service_id"/>
@@ -1852,9 +1852,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="slt_id"/>
 					</attributes>
 				</naming>
-        <style>
-          <icon/>
-        </style>
+		<style>
+			<icon/>
+		</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="sla_id"/>
@@ -1974,9 +1974,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="service_id"/>
 					</attributes>
 				</naming>
-        <style>
-          <icon/>
-        </style>
+		<style>
+			<icon/>
+		</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="customercontract_id"/>
@@ -2072,9 +2072,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="providercontract_id"/>
 					</attributes>
 				</naming>
-        <style>
-          <icon/>
-        </style>
+		<style>
+			<icon/>
+		</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="service_id"/>
@@ -2259,9 +2259,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="contact_id"/>
 					</attributes>
 				</naming>
-        <style>
-          <icon/>
-        </style>
+		<style>
+			<icon/>
+		</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="deliverymodel_id"/>

--- a/datamodels/2.x/itop-service-mgmt/datamodel.itop-service-mgmt.xml
+++ b/datamodels/2.x/itop-service-mgmt/datamodel.itop-service-mgmt.xml
@@ -362,9 +362,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="name"/>
 					</attributes>
 				</naming>
-		<style>
-			<icon/>
-		</style>
+				<style>
+					<icon/>
+				</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="name"/>
@@ -739,9 +739,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="contact_id"/>
 					</attributes>
 				</naming>
-		<style>
-			<icon/>
-		</style>
+				<style>
+					<icon/>
+				</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="contract_id"/>
@@ -821,9 +821,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="document_id"/>
 					</attributes>
 				</naming>
-		<style>
-			<icon/>
-		</style>
+				<style>
+					<icon/>
+				</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="contract_id"/>
@@ -1213,9 +1213,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="document_id"/>
 					</attributes>
 				</naming>
-		<style>
-			<icon/>
-		</style>
+				<style>
+					<icon/>
+				</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="service_id"/>
@@ -1295,9 +1295,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="contact_id"/>
 					</attributes>
 				</naming>
-		<style>
-			<icon/>
-		</style>
+				<style>
+					<icon/>
+				</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="service_id"/>
@@ -1852,9 +1852,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="slt_id"/>
 					</attributes>
 				</naming>
-		<style>
-			<icon/>
-		</style>
+				<style>
+					<icon/>
+				</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="sla_id"/>
@@ -1974,9 +1974,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="service_id"/>
 					</attributes>
 				</naming>
-		<style>
-			<icon/>
-		</style>
+				<style>
+					<icon/>
+				</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="customercontract_id"/>
@@ -2072,9 +2072,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="providercontract_id"/>
 					</attributes>
 				</naming>
-		<style>
-			<icon/>
-		</style>
+				<style>
+					<icon/>
+				</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="service_id"/>
@@ -2259,9 +2259,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="contact_id"/>
 					</attributes>
 				</naming>
-		<style>
-			<icon/>
-		</style>
+				<style>
+					<icon/>
+				</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="deliverymodel_id"/>

--- a/datamodels/2.x/itop-service-mgmt/datamodel.itop-service-mgmt.xml
+++ b/datamodels/2.x/itop-service-mgmt/datamodel.itop-service-mgmt.xml
@@ -362,7 +362,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="name"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="name"/>
@@ -737,7 +739,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="contact_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="contract_id"/>
@@ -817,7 +821,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="document_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="contract_id"/>
@@ -1207,7 +1213,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="document_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="service_id"/>
@@ -1287,7 +1295,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="contact_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="service_id"/>
@@ -1842,7 +1852,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="slt_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="sla_id"/>
@@ -1962,7 +1974,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="service_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="customercontract_id"/>
@@ -2058,7 +2072,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="providercontract_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="service_id"/>
@@ -2243,7 +2259,9 @@ public function PrefillSearchForm(&$aContextParam)
 						<attribute id="contact_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="deliverymodel_id"/>

--- a/datamodels/2.x/itop-storage-mgmt/datamodel.itop-storage-mgmt.xml
+++ b/datamodels/2.x/itop-storage-mgmt/datamodel.itop-storage-mgmt.xml
@@ -1479,7 +1479,9 @@
             <attribute id="volume_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="volume_id"/>
@@ -1569,7 +1571,9 @@
             <attribute id="san_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="san_id"/>

--- a/datamodels/2.x/itop-structure/datamodel.itop-structure.xml
+++ b/datamodels/2.x/itop-structure/datamodel.itop-structure.xml
@@ -1012,7 +1012,9 @@
             <attribute id="person_id"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="team_id"/>
@@ -1109,7 +1111,9 @@
             <attribute id="name"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="name"/>
@@ -1633,7 +1637,9 @@
             <attribute id="name"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="name"/>
@@ -1680,7 +1686,9 @@
             <attribute id="name"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="name"/>

--- a/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
+++ b/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
@@ -27,7 +27,9 @@
 						<attribute id="ref"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="ref"/>
@@ -393,7 +395,9 @@
 						<attribute id="contact_id"/>
 					</attributes>
 				</naming>
-				<icon/>
+        <style>
+          <icon/>
+        </style>
 				<reconciliation>
 					<attributes>
 						<attribute id="ticket_id"/>

--- a/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
+++ b/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
@@ -27,9 +27,9 @@
 						<attribute id="ref"/>
 					</attributes>
 				</naming>
-		<style>
-			<icon/>
-		</style>
+				<style>
+					<icon/>
+				</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="ref"/>
@@ -395,9 +395,9 @@
 						<attribute id="contact_id"/>
 					</attributes>
 				</naming>
-		<style>
-			<icon/>
-		</style>
+				<style>
+					<icon/>
+				</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="ticket_id"/>

--- a/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
+++ b/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
@@ -27,9 +27,9 @@
 						<attribute id="ref"/>
 					</attributes>
 				</naming>
-        <style>
-          <icon/>
-        </style>
+		<style>
+			<icon/>
+		</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="ref"/>
@@ -395,9 +395,9 @@
 						<attribute id="contact_id"/>
 					</attributes>
 				</naming>
-        <style>
-          <icon/>
-        </style>
+		<style>
+			<icon/>
+		</style>
 				<reconciliation>
 					<attributes>
 						<attribute id="ticket_id"/>

--- a/datamodels/2.x/itop-virtualization-mgmt/datamodel.itop-virtualization-mgmt.xml
+++ b/datamodels/2.x/itop-virtualization-mgmt/datamodel.itop-virtualization-mgmt.xml
@@ -18,7 +18,9 @@
         <fields_semantic>
             <state_attribute>status</state_attribute>
         </fields_semantic>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="name"/>
@@ -151,7 +153,9 @@
             <attribute id="name"/>
           </attributes>
         </naming>
-        <icon/>
+        <style>
+          <icon/>
+        </style>
         <reconciliation>
           <attributes>
             <attribute id="name"/>


### PR DESCRIPTION
Realign all XML files  into datamodels/2.X to match the format 3.0

 * moved class/properties/icon to class/properties/style/icon

This allows previous redefinition of icons (they failed in 3.0-3.0.1)