### PR TITLE
N°3979 - Handle initial values on dependent fields

### DIFF
--- a/js/console_form_handler.js
+++ b/js/console_form_handler.js
@@ -35,8 +35,7 @@ $(function()
         {
             var me = this;
             
-            this.element
-                .append('<div class="last-error"></div>')
+            this.element.append('<div class="last-error"></div>')
                 .addClass('console_form_handler');
 
             this.options.oWizardHelper = window[this.options.wizard_helper_var_name];
@@ -48,13 +47,25 @@ $(function()
         // revert other modifications here
         _destroy: function()
         {
-            this.element
-            .removeClass('console_form_handler');
+            this.element.removeClass('console_form_handler');
             this._super();
         },
+	    _updatePreviousValues: function()
+	    {
+		    let me=this;
+	    	if(this.element.find('[data-attribute-previous-value]').length>0) {
+	    		let aPreviousValues = {};
+			    $(this.element.find('[data-attribute-previous-value]')).each(function (idx, elt) {
+				    aPreviousValues[$(elt).data('field-id')] = $(elt).data('attribute-previous-value');
+			    });
+			    me.element.find('[data-field-id=previous_values]').find('input[type=hidden]').val(JSON.stringify(aPreviousValues));
+		    }
+
+	    },
         _onUpdateFields: function(event, data)
         {
             var me = this;
+	        me._updatePreviousValues();
             var sFormPath = data.form_path;
             var sUpdateUrl = GetAbsoluteUrlAppRoot()+'pages/ajax.render.php';
 
@@ -64,7 +75,6 @@ $(function()
                 {
                     operation: 'custom_fields_update',
                     attcode: this.options.custom_field_attcode,
-                    //current_values: this.getCurrentValues(),
                     requested_fields: data.requested_fields,
                     form_path: sFormPath,
                     json_obj: this.options.oWizardHelper.UpdateWizardToJSON()
@@ -85,6 +95,7 @@ $(function()
                         me.element.find('.last-error').text(data.error);
                     }
                     me._onUpdateAlways(data, sFormPath);
+	                me.element.find('[data-field-id=previous_values]').find('input[type=hidden]').val('{}');
                 });
         },
         // On initialization or update

--- a/js/console_form_handler.js
+++ b/js/console_form_handler.js
@@ -83,7 +83,7 @@ $(function()
                         me.element.find('.last-error').text(data.error);
                     }
                     me._onUpdateAlways(data, sFormPath);
-	                me.element.find('[data-field-id=previous_values]').find('input[type=hidden]').val('{}');
+	                me.element.find('[data-field-id="previous_values"]').find('input[type="hidden"]').val('{}');
                 });
         },
         // On initialization or update

--- a/js/console_form_handler.js
+++ b/js/console_form_handler.js
@@ -50,18 +50,6 @@ $(function()
             this.element.removeClass('console_form_handler');
             this._super();
         },
-	    _updatePreviousValues: function()
-	    {
-		    let me=this;
-	    	if(this.element.find('[data-attribute-previous-value]').length>0) {
-	    		let aPreviousValues = {};
-			    $(this.element.find('[data-attribute-previous-value]')).each(function (idx, elt) {
-				    aPreviousValues[$(elt).data('field-id')] = $(elt).data('attribute-previous-value');
-			    });
-			    me.element.find('[data-field-id=previous_values]').find('input[type=hidden]').val(JSON.stringify(aPreviousValues));
-		    }
-
-	    },
         _onUpdateFields: function(event, data)
         {
             var me = this;

--- a/js/form_handler.js
+++ b/js/form_handler.js
@@ -95,7 +95,7 @@ $(function()
 
 		_updatePreviousValues: function()
 		{
-			let me=this;
+			let me = this;
 			if(this.element.find('[data-attribute-previous-value]').length>0) {
 				let aPreviousValues = {};
 				$(this.element.find('[data-attribute-previous-value]')).each(function (idx, elt) {

--- a/js/form_handler.js
+++ b/js/form_handler.js
@@ -101,7 +101,7 @@ $(function()
 				$(this.element.find('[data-attribute-previous-value]')).each(function (idx, elt) {
 					aPreviousValues[$(elt).data('field-id')] = $(elt).data('attribute-previous-value');
 				});
-				me.element.find('[data-field-id=previous_values]').find('input[type=hidden]').val(JSON.stringify(aPreviousValues));
+				me.element.find('[data-field-id="previous_values"]').find('input[type="hidden"]').val(JSON.stringify(aPreviousValues));
 			}
 		},
 		// Events callback

--- a/js/form_handler.js
+++ b/js/form_handler.js
@@ -93,11 +93,23 @@ $(function()
 			return this.options.field_set.triggerHandler('get_current_values');
 		},
 
+		_updatePreviousValues: function()
+		{
+			let me=this;
+			if(this.element.find('[data-attribute-previous-value]').length>0) {
+				let aPreviousValues = {};
+				$(this.element.find('[data-attribute-previous-value]')).each(function (idx, elt) {
+					aPreviousValues[$(elt).data('field-id')] = $(elt).data('attribute-previous-value');
+				});
+				me.element.find('[data-field-id=previous_values]').find('input[type=hidden]').val(JSON.stringify(aPreviousValues));
+			}
+		},
 		// Events callback
 		// - Update fields depending on the update ones
 		_onUpdateFields: function(oEvent, oData)
 		{
 			var me = this;
+			me._updatePreviousValues();
 			var sFormPath = oData.form_path;
 
 			// Data checks

--- a/js/form_handler.js
+++ b/js/form_handler.js
@@ -92,7 +92,7 @@ $(function()
 		{
 			return this.options.field_set.triggerHandler('get_current_values');
 		},
-
+		//since 3.0.2 3.1.0
 		_updatePreviousValues: function()
 		{
 			let me = this;

--- a/sources/Renderer/Console/FieldRenderer/ConsoleSimpleFieldRenderer.php
+++ b/sources/Renderer/Console/FieldRenderer/ConsoleSimpleFieldRenderer.php
@@ -121,7 +121,7 @@ class ConsoleSimpleFieldRenderer extends FieldRenderer
 					else
 					{
 						$oText = new TextArea("",$this->oField->GetCurrentValue(),$this->oField->GetGlobalId(),40,8);
-						$oText->AddCSSClass('ibo-input-field-wrapper ibo-input');
+						$oText->AddCSSClasses(['ibo-input-field-wrapper', 'ibo-input']);
 						$oValue->AddSubBlock($oText);
 						// Some additional stuff if we are displaying it with a rich editor
 						if ($bRichEditor)

--- a/sources/Renderer/Console/FieldRenderer/ConsoleSimpleFieldRenderer.php
+++ b/sources/Renderer/Console/FieldRenderer/ConsoleSimpleFieldRenderer.php
@@ -25,6 +25,7 @@ use AttributeDuration;
 use Combodo\iTop\Application\Helper\WebResourcesHelper;
 use Combodo\iTop\Application\UI\Base\Component\Field\FieldUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Component\Html\Html;
+use Combodo\iTop\Application\UI\Base\Component\Html\HtmlFactory;
 use Combodo\iTop\Application\UI\Base\Component\Input\InputUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Component\Input\Select\SelectOptionUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Component\Input\SelectUIBlockFactory;
@@ -111,15 +112,17 @@ class ConsoleSimpleFieldRenderer extends FieldRenderer
 
 					$bRichEditor = ($this->oField->GetFormat() === TextAreaField::ENUM_FORMAT_HTML);
 
-					$oText = new TextArea("",$this->oField->GetCurrentValue(),$this->oField->GetGlobalId(),40,8);
-					$oText->AddCSSClass('ibo-input-field-wrapper ibo-input');
-					$oValue->AddSubBlock($oText);
+
 					if ($this->oField->GetReadOnly())
 					{
-						$oText->SetIsDisabled(true);
+						$oValue->AddSubBlock(UIContentBlockUIBlockFactory::MakeStandard())->AddSubBlock(HtmlFactory::MakeHtmlContent($this->oField->GetCurrentValue()));
+						$oValue->AddSubBlock(InputUIBlockFactory::MakeForHidden("",$this->oField->GetCurrentValue(), $this->oField->GetGlobalId()));
 					}
 					else
 					{
+						$oText = new TextArea("",$this->oField->GetCurrentValue(),$this->oField->GetGlobalId(),40,8);
+						$oText->AddCSSClass('ibo-input-field-wrapper ibo-input');
+						$oValue->AddSubBlock($oText);
 						// Some additional stuff if we are displaying it with a rich editor
 						if ($bRichEditor)
 						{


### PR DESCRIPTION
When a field is hidden (due to display conditions), his initial (or previous) value is kept in metadata and post in a new field named previous_value. 
Some changes for this feature are in templates-base extension.