### PR TITLE
N°5318 - Fix DBObject::CheckValue() messages being HTML encoded when not necessary

### DIFF
--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -4735,11 +4735,15 @@ EOF
 			$sCSSClass = $bResult ? HILIGHT_CLASS_NONE : HILIGHT_CLASS_CRITICAL;
 			$sChecked = $bResult ? 'checked' : '';
 			$sDisabled = $bResult ? '' : 'disabled';
+
+			$aErrorsToDisplay = array_map(function($sError) {
+				return utils::HtmlEntities($sError);
+			}, $aErrors);
 			$aRows[] = array(
 				'form::select' => "<input type=\"checkbox\" class=\"selectList\" $sChecked $sDisabled\"></input>",
 				'object' => $oObj->GetHyperlink(),
 				'status' => $sStatus,
-				'errors' => '<p>'.($bResult ? '' : utils::HtmlEntities(implode('</p><p>', $aErrors))).'</p>',
+				'errors' => '<p>'.($bResult ? '' : utils::HtmlEntities(implode('</p><p>', $aErrorsToDisplay))).'</p>',
 				'@class' => $sCSSClass,
 			);
 			if ($bResult && (!$bPreview))

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -4739,7 +4739,7 @@ EOF
 				'form::select' => "<input type=\"checkbox\" class=\"selectList\" $sChecked $sDisabled\"></input>",
 				'object' => $oObj->GetHyperlink(),
 				'status' => $sStatus,
-				'errors' => '<p>'.($bResult ? '' : implode('</p><p>', $aErrors)).'</p>',
+				'errors' => '<p>'.($bResult ? '' : utils::HtmlEntities(implode('</p><p>', $aErrors))).'</p>',
 				'@class' => $sCSSClass,
 			);
 			if ($bResult && (!$bPreview))

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -4743,7 +4743,7 @@ EOF
 				'form::select' => "<input type=\"checkbox\" class=\"selectList\" $sChecked $sDisabled\"></input>",
 				'object' => $oObj->GetHyperlink(),
 				'status' => $sStatus,
-				'errors' => '<p>'.($bResult ? '' : utils::HtmlEntities(implode('</p><p>', $aErrorsToDisplay))).'</p>',
+				'errors' => '<p>'.($bResult ? '' : implode('</p><p>', $aErrorsToDisplay)).'</p>',
 				'@class' => $sCSSClass,
 			);
 			if ($bResult && (!$bPreview))

--- a/core/coreexception.class.inc.php
+++ b/core/coreexception.class.inc.php
@@ -165,19 +165,15 @@ class CoreCannotSaveObjectException extends CoreException
 	public function getHtmlMessage()
 	{
 		$sTitle = Dict::S('UI:Error:SaveFailed');
-		$sContent = "<span><strong>{$sTitle}</strong></span>";
+		$sContent = "<span><strong>".utils::HtmlEntities($sTitle)."</strong></span>";
 
-		if (count($this->aIssues) == 1)
-		{
+		if (count($this->aIssues) == 1) {
 			$sIssue = reset($this->aIssues);
-			$sContent .= " <span>{$sIssue}</span>";
-		}
-		else
-		{
+			$sContent .= " <span>".utils::HtmlEntities($sIssue)."</span>";
+		} else {
 			$sContent .= '<ul>';
-			foreach ($this->aIssues as $sError)
-			{
-				$sContent .= "<li>$sError</li>";
+			foreach ($this->aIssues as $sError) {
+				$sContent .= "<li>".utils::HtmlEntities($sError)."</li>";
 			}
 			$sContent .= '</ul>';
 		}

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -1880,7 +1880,7 @@ abstract class DBObject implements iDisplay
 				$oTargetObj = MetaModel::GetObject($sTargetClass, $toCheck, false /*must be found*/, true /*allow all data*/);
 				if (is_null($oTargetObj))
 				{
-					return "Target object not found (".utils::HtmlEntities($sTargetClass).".::".utils::HtmlEntities($toCheck).")";
+					return "Target object not found ($sTargetClass::$toCheck)";
 				}
 			}
 			if ($oAtt->IsHierarchicalKey())
@@ -1889,7 +1889,7 @@ abstract class DBObject implements iDisplay
 				$aValues = $oAtt->GetAllowedValues(array('this' => $this));
 				if (!array_key_exists($toCheck, $aValues))
 				{
-					return "Value not allowed [". utils::HtmlEntities($toCheck)."]";
+					return "Value not allowed [$toCheck]";
 				}
 			}
 		}
@@ -1903,7 +1903,7 @@ abstract class DBObject implements iDisplay
 					$oTag->SetValues(explode(' ', $toCheck));
 				} catch (Exception $e)
 				{
-					return "Tag value [". utils::HtmlEntities($toCheck)."] is not a valid tag list";
+					return "Tag value '$toCheck' is not a valid tag list";
 				}
 
 				return true;
@@ -1931,7 +1931,7 @@ abstract class DBObject implements iDisplay
 					$oTag->SetValues($aValues);
 				} catch (Exception $e)
 				{
-					return "Set value[". utils::HtmlEntities($toCheck)."] is not a valid set";
+					return "Set value '$toCheck' is not a valid set";
 				}
 
 				return true;
@@ -1951,7 +1951,7 @@ abstract class DBObject implements iDisplay
 			{
 				if (!array_key_exists($toCheck, $aValues))
 				{
-					return "Value not allowed [". utils::HtmlEntities($toCheck)."]";
+					return "Value not allowed [$toCheck]";
 				}
 			}
 			if (!is_null($iMaxSize = $oAtt->GetMaxSize()))
@@ -1964,7 +1964,7 @@ abstract class DBObject implements iDisplay
 			}
 			if (!$oAtt->CheckFormat($toCheck))
 			{
-				return "Wrong format [". utils::HtmlEntities($toCheck)."]";
+				return "Wrong format [$toCheck]";
 			}
 		}
 		else

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -1614,7 +1614,10 @@ EOF
 								}
 								else
 								{
-									$sError = '<p>'.utils::HtmlEntities(implode('</p></p>',$aErrors))."</p>\n";
+									$aErrorsToDisplay = array_map(function($sError) {
+										return utils::HtmlEntities($sError);
+									}, $aErrors);
+									$sError = '<p>'.implode('</p></p>',$aErrorsToDisplay)."</p>\n";
 								}
 							}
 							else

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -1614,7 +1614,7 @@ EOF
 								}
 								else
 								{
-									$sError = '<p>'.implode('</p></p>',$aErrors)."</p>\n";
+									$sError = '<p>'.utils::HtmlEntities(implode('</p></p>',$aErrors))."</p>\n";
 								}
 							}
 							else


### PR DESCRIPTION
for 2.7.8 and 3.02