### PR TITLE
N°5389 - Email Notification templates with AttributeLinkedSetIndirect failed

### DIFF
--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -4589,7 +4589,7 @@ class AttributeCaseLog extends AttributeLongText
 				{
 					//N°5135 - add impersonation information in caselog
 					if (UserRights::IsImpersonated()){
-						$sOnBehalfOf = $sUserString = Dict::Format('UI:Archive_User_OnBehalfOf_User', UserRights::GetRealUserFriendlyName(), UserRights::GetUserFriendlyName());
+						$sOnBehalfOf = Dict::Format('UI:Archive_User_OnBehalfOf_User', UserRights::GetRealUserFriendlyName(), UserRights::GetUserFriendlyName());
 						$oCaseLog->AddLogEntry($proposedValue, $sOnBehalfOf, UserRights::GetConnectedUserId());
 					} else {
 						$oCaseLog->AddLogEntry($proposedValue);

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -3201,15 +3201,15 @@ abstract class DBObject implements iDisplay
 			// - TriggerOnObjectMention
 			$this->ActivateOnMentionTriggers(false);
 
-			$bHasANewExternalKeyValue = false;
+			$bNeedReload = false;
 			$aHierarchicalKeys = array();
 			$aDBChanges = array();
 			foreach ($aChanges as $sAttCode => $valuecurr)
 			{
 				$oAttDef = MetaModel::GetAttributeDef(get_class($this), $sAttCode);
-				if ($oAttDef->IsExternalKey())
+				if ($oAttDef->IsExternalKey() || $oAttDef->IsLinkSet())
 				{
-					$bHasANewExternalKeyValue = true;
+					$bNeedReload = true;
 				}
 				if ($oAttDef->IsBasedOnDBColumns())
 				{
@@ -3367,24 +3367,10 @@ abstract class DBObject implements iDisplay
 			$this->m_aModifiedAtt = array();
 
 			try {
-				// - TriggerOnObjectUpdate
-				$aParams = array('class_list' => MetaModel::EnumParentClasses($sClass, ENUM_PARENT_CLASSES_ALL));
-				$oSet = new DBObjectSet(DBObjectSearch::FromOQL("SELECT TriggerOnObjectUpdate AS t WHERE t.target_class IN (:class_list)"),
-					array(), $aParams);
-				while ($oTrigger = $oSet->Fetch()) {
-					/** @var \TriggerOnObjectUpdate $oTrigger */
-					try {
-						$oTrigger->DoActivate($this->ToArgs('this'));
-					}
-					catch (Exception $e) {
-						utils::EnrichRaisedException($oTrigger, $e);
-					}
-				}
-
 				$this->AfterUpdate();
 
 				// Reload to get the external attributes
-				if ($bHasANewExternalKeyValue) {
+				if ($bNeedReload) {
 					$this->Reload(true /* AllowAllData */);
 				} else {
 					// Reset original values although the object has not been reloaded
@@ -3395,6 +3381,20 @@ abstract class DBObject implements iDisplay
 							$value = $this->m_aCurrValues[$sAttCode];
 							$this->m_aOrigValues[$sAttCode] = is_object($value) ? clone $value : $value;
 						}
+					}
+				}
+
+				// - TriggerOnObjectUpdate
+				$aParams = array('class_list' => MetaModel::EnumParentClasses($sClass, ENUM_PARENT_CLASSES_ALL));
+				$oSet = new DBObjectSet(DBObjectSearch::FromOQL('SELECT TriggerOnObjectUpdate AS t WHERE t.target_class IN (:class_list)'),
+					array(), $aParams);
+				while ($oTrigger = $oSet->Fetch()) {
+					/** @var \TriggerOnObjectUpdate $oTrigger */
+					try {
+						$oTrigger->DoActivate($this->ToArgs('this'));
+					}
+					catch (Exception $e) {
+						utils::EnrichRaisedException($oTrigger, $e);
 					}
 				}
 			}


### PR DESCRIPTION
What was done in DBObject::DBUpdate()
  * force reload of the object when a linkSet is modified
  * Call the triggers OnObjectUpdate *after* the reload

Risks: the change of calls ordering between triggers and callback AfterUpdate() may change some extension behaviour