### PR TITLE
N°4947 Fix \EMail::LoadConfig (v2)

### DIFF
--- a/core/email.class.inc.php
+++ b/core/email.class.inc.php
@@ -34,6 +34,12 @@ define ('EMAIL_SEND_ERROR', 2);
 
 class EMail implements iEMail
 {
+	/**
+	 * @see self::LoadConfig()
+	 * @var Config
+	 * @since 2.7.7 3.0.2 3.1.0 N°3169 N°5102 Move attribute to children classes
+	 * @since 2.7.8 3.0.3 3.1.0 N°4947 pull up the attribute back to the Email class as config init is done here
+	 */
 	protected static $m_oConfig = null;
 	protected $oMailer;
 
@@ -56,7 +62,8 @@ class EMail implements iEMail
 	 *
 	 * @uses utils::GetConfig()
 	 *
-	 * @since 2.7.8 3.0.3 3.1.0 N°4947
+	 * @since 2.7.7 3.0.2 3.1.0 N°3169 N°5102 Move method to children classes
+	 * @since 2.7.8 3.0.3 3.1.0 N°4947 Pull up to the parent class, and remove `$sConfigFile` param
 	 */
 	public function LoadConfig()
 	{
@@ -67,6 +74,12 @@ class EMail implements iEMail
 		return static::$m_oConfig;
 	}
 
+	/**
+	 * @return void
+	 * @throws \ConfigException
+	 * @throws \CoreException
+	 * @since 2.7.>8 3.0.3 3.1.0 N°4947 Method creation, to factorize same code in children classes
+	 */
 	protected function InitRecipientFrom()
 	{
 		$oConfig = $this->LoadConfig();

--- a/core/email.class.inc.php
+++ b/core/email.class.inc.php
@@ -56,9 +56,9 @@ class EMail implements iEMail
 	 *
 	 * @uses utils::GetConfig()
 	 *
-	 * @since 2.7.8 3.0.2 3.1.0 N°4947
+	 * @since 2.7.8 3.0.3 3.1.0 N°4947
 	 */
-	public function LoadConfig($sConfigFile = ITOP_DEFAULT_CONFIG_FILE)
+	public function LoadConfig()
 	{
 		if (is_null(static::$m_oConfig)) {
 			static::$m_oConfig = utils::GetConfig();

--- a/core/email.class.inc.php
+++ b/core/email.class.inc.php
@@ -34,6 +34,7 @@ define ('EMAIL_SEND_ERROR', 2);
 
 class EMail implements iEMail
 {
+	protected static $m_oConfig = null;
 	protected $oMailer;
 
 	// Serialization formats
@@ -44,6 +45,35 @@ class EMail implements iEMail
 	public function __construct()
 	{
 		$this->oMailer = EmailFactory::GetMailer();
+	}
+
+	/**
+	 * Sets {@see m_oConfig} if current attribute is null
+	 *
+	 * @returns \Config the current {@see m_oConfig} value
+	 * @throws \ConfigException
+	 * @throws \CoreException
+	 *
+	 * @uses utils::GetConfig()
+	 *
+	 * @since 2.7.8 3.0.2 3.1.0 N°4947
+	 */
+	public function LoadConfig($sConfigFile = ITOP_DEFAULT_CONFIG_FILE)
+	{
+		if (is_null(static::$m_oConfig)) {
+			static::$m_oConfig = utils::GetConfig();
+		}
+
+		return static::$m_oConfig;
+	}
+
+	protected function InitRecipientFrom()
+	{
+		$oConfig = $this->LoadConfig();
+		$this->SetRecipientFrom(
+			$oConfig->Get('email_default_sender_address'),
+			$oConfig->Get('email_default_sender_label')
+		);
 	}
 
 	/**
@@ -146,5 +176,4 @@ class EMail implements iEMail
 	{
 		$this->oMailer->SetRecipientReplyTo($sAddress);
 	}
-
 }

--- a/sources/Core/Email/EmailLaminas.php
+++ b/sources/Core/Email/EmailLaminas.php
@@ -45,25 +45,21 @@ class EMailLaminas extends Email
 	// Did not work with attachements since their binary representation cannot be stored as a valid UTF-8 string
 	const FORMAT_V2 = 2; // New format, only the raw data are serialized (base64 encoded if needed)
 
-	protected static $m_oConfig = null;
 	protected $m_aData; // For storing data to serialize
-
-	public static function LoadConfig($sConfigFile = ITOP_DEFAULT_CONFIG_FILE)
-	{
-		if (is_null(self::$m_oConfig)) {
-			self::$m_oConfig = new Config($sConfigFile);
-		}
-	}
 
 	protected $m_oMessage;
 
-	/** @noinspection PhpMissingParentConstructorInspection */
+	/**
+	 * @noinspection PhpMissingParentConstructorInspection
+	 * @noinspection MagicMethodsValidityInspection
+	 */
 	public function __construct()
 	{
 		$this->m_aData = array();
 		$this->m_oMessage = new Message();
 		$this->m_oMessage->setEncoding('UTF-8');
-		$this->SetRecipientFrom(MetaModel::GetConfig()->Get('email_default_sender_address'), MetaModel::GetConfig()->Get('email_default_sender_label'));
+
+		$this->InitRecipientFrom();
 	}
 
 	/**


### PR DESCRIPTION
This replaces #278, as the Email class was refactored a lot during 2.7.7.
The goal is to now load the config always using the standard `\utils::GetConfig` method.