### PR TITLE
🐛 N°5522 - Fix session storage (breadcrumbs) not cleared on logout

### DIFF
--- a/pages/logoff.php
+++ b/pages/logoff.php
@@ -37,6 +37,7 @@ if ($operation == 'do_logoff')
 	// Note the redirection MUST NOT be made via an HTTP "header" since onunload is called only when the actual content of the DOM
 	// is replaced by some other content. So the "bouncing" page must provide some content (in our case a script making the redirection).
 	$oPage = new AjaxPage('');
+	$oPage->add_script("sessionStorage.clear();");
 	$oPage->add_script("window.location.href='{$sUrl}pages/logoff.php?portal=$bPortal'");
 	$oPage->output();
 	exit;

--- a/pages/logoff.php
+++ b/pages/logoff.php
@@ -37,7 +37,6 @@ if ($operation == 'do_logoff')
 	// Note the redirection MUST NOT be made via an HTTP "header" since onunload is called only when the actual content of the DOM
 	// is replaced by some other content. So the "bouncing" page must provide some content (in our case a script making the redirection).
 	$oPage = new AjaxPage('');
-	$oPage->add_script("sessionStorage.clear();");
 	$oPage->add_script("window.location.href='{$sUrl}pages/logoff.php?portal=$bPortal'");
 	$oPage->output();
 	exit;

--- a/templates/pages/login/logout.html.twig
+++ b/templates/pages/login/logout.html.twig
@@ -13,6 +13,8 @@
 {% endblock %}
 
 {% block script %}
+    {{ parent() }}
+    
 	sessionStorage.clear();
 {% endblock %}
 

--- a/templates/pages/login/logout.html.twig
+++ b/templates/pages/login/logout.html.twig
@@ -12,6 +12,10 @@
 	</div>
 {% endblock %}
 
+{% block script %}
+	sessionStorage.clear();
+{% endblock %}
+
 {% block ready_script %}
     {{ parent() }}
 


### PR DESCRIPTION
Hi everyone,

there is existing cleanup of PHP SESSION variable on logout, but session storage with breadcrumb stays there. This makes the session storage stick between logins and more importantly, between users. 

I am logged in as admin, have a breadcrumb of admin operations, then log out. Another user can theoretically go onto my computer and my session, login as user account and see, what I was doing as admin in the breadcrumb. There are of course proper security checks in place, so the user cannot get anywhere he shouldn't get. 

This is minor security concern, as it can apply only if browser is left open after logout and stays in the same tab/context. Even if this can be exploited in some way, the user can only see friendlynames of objects, that other used accessed.

This is more a matter of proper cleanup, and a minor security concern.

Thanks for consideration,
Richard