### PR TITLE
N°5085 - Move menu is impossible - Error after compilation

### DIFF
--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -487,11 +487,14 @@ EOF;
 				foreach($aMenusByModule[$sModuleName] as $sMenuId)
 				{
 					$oMenuNode = $aMenuNodes[$sMenuId];
-					if ($sParent = $oMenuNode->GetChildText('parent', null))
-					{
-						$aMenusToLoad[] = $sParent;
-						$aParentMenus[] = $sParent;
+					// compute parent hierarchy
+					$aParentIdHierarchy = [];
+					while ($sParent = $oMenuNode->GetChildText('parent', null)) {
+						array_unshift($aParentIdHierarchy, $sParent);
+						$oMenuNode = $aMenuNodes[$sParent];
 					}
+					$aMenusToLoad = array_merge($aMenusToLoad, $aParentIdHierarchy);
+					$aParentMenus = array_merge($aParentMenus, $aParentIdHierarchy);
 					// Note: the order matters: the parents must be defined BEFORE
 					$aMenusToLoad[] = $sMenuId;
 				}


### PR DESCRIPTION
Add all hierarchy of the menus (to prevent having a parent with its own parent undeclared)