### PR TITLE
N°5523 - Setup wizard : use the ITOP_APPLICATION constant instead of hardcoded "iTop" string

### DIFF
--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -658,8 +658,9 @@ EOF
 			);
 			if ($oMutex->IsLocked())
 			{
+                $sCronMessage = '<div class="message">An '.ITOP_APPLICATION.' cron process is being executed on the target database. '.ITOP_APPLICATION.' cron process will be stopped during the setup execution.</div>';
 				$oPage->add(<<<HTML
-<div class="message">An iTop cron process is being executed on the target database. iTop cron process will be stopped during the setup execution.</div>
+$sCronMessage
 HTML
 				);
 			}
@@ -756,8 +757,8 @@ EOF
         $sChecked = ($this->oWizard->GetParameter('accept_license', 'no') == 'yes') ? ' checked ' : '';
         $oPage->p('<input type="checkbox" class="check_select" name="accept_license" id="accept" value="yes" '.$sChecked.'><label for="accept">&nbsp;I accept the terms of the licenses of the '.count($aLicenses).' components mentioned above.</label>');
 	    if ($this->NeedsRgpdConsent()) {
-		    $oPage->add('<div id="rgpd_message" class="message message-info">iTop software is compliant with the processing of personal data according to the European General Data Protection Regulation (GDPR).<p></p>
-By installing iTop you agree that some information will be collected by Combodo to help you manage your instances and for statistical purposes.
+		    $oPage->add('<div id="rgpd_message" class="message message-info">'.ITOP_APPLICATION.' software is compliant with the processing of personal data according to the European General Data Protection Regulation (GDPR).<p></p>
+By installing '.ITOP_APPLICATION.' you agree that some information will be collected by Combodo to help you manage your instances and for statistical purposes.
 This data remains anonymous until it is associated to a user account on iTop Hub.</p>
 <p>List of collected data available in our <a target="_blank" href="https://www.itophub.io/page/data-privacy">Data privacy section.</p></a>');
 		    $oPage->add('<input type="checkbox" class="check_select" id="rgpd_consent">');

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -658,7 +658,7 @@ EOF
 			);
 			if ($oMutex->IsLocked())
 			{
-				$oPage->add('<div class="message">An '.ITOP_APPLICATION.' cron process is being executed on the target database. '.ITOP_APPLICATION.' cron process will be stopped during the setup execution.</div>');
+				$oPage->add('<div class="message">'.ITOP_APPLICATION.' cron process is being executed on the target database. '.ITOP_APPLICATION.' cron process will be stopped during the setup execution.</div>');
 			}
 		}
 	}

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -658,11 +658,7 @@ EOF
 			);
 			if ($oMutex->IsLocked())
 			{
-                $sCronMessage = '<div class="message">An '.ITOP_APPLICATION.' cron process is being executed on the target database. '.ITOP_APPLICATION.' cron process will be stopped during the setup execution.</div>';
-				$oPage->add(<<<HTML
-$sCronMessage
-HTML
-				);
+				$oPage->add('<div class="message">An '.ITOP_APPLICATION.' cron process is being executed on the target database. '.ITOP_APPLICATION.' cron process will be stopped during the setup execution.</div>');
 			}
 		}
 	}


### PR DESCRIPTION
These changes replace, where it makes sense, the usage of iTop as a product name to the variable ITOP_APPLICATION as it is already done in most of the setup process.