### PR TITLE
N°5758 - GDPR consent: Apply to all instances containing the Hub connector

### DIFF
--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -1595,6 +1595,16 @@ JS
 	}
 
 	/**
+	 * @param array $aModules List of available module codes
+	 *
+	 * @return bool true if the Hub connector is installed
+	 */
+	public static function IsItopHubInstance($aModules)
+	{
+		return array_key_exists('itop-hub-connector', $aModules);
+	}
+
+	/**
 	 * @param array $aModules Available modules with code as key and metadata array as values
 	 *    Same structure as the one returned by {@link \RunTimeEnvironment::AnalyzeInstallation}
 	 * @param string $sExtensionsDir In the setup, get value with the 'extensions_dir' parameter

--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -1599,7 +1599,7 @@ JS
 	 *
 	 * @return bool true if the Hub connector is installed
 	 */
-	public static function IsItopHubInstance($aModules)
+	public static function IsConnectableToITopHub($aModules)
 	{
 		return array_key_exists('itop-hub-connector', $aModules);
 	}

--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -1598,6 +1598,8 @@ JS
 	 * @param array $aModules List of available module codes
 	 *
 	 * @return bool true if the Hub connector is installed
+	 *
+	 * @since 2.7.8 3.0.3 3.1.0 N°5758 method creation
 	 */
 	public static function IsConnectableToITopHub($aModules)
 	{

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -716,7 +716,7 @@ class WizStepLicense extends WizardStep
 		$sMode = $this->oWizard->GetParameter('install_mode');
 		$aModules = SetupUtils::AnalyzeInstallation($this->oWizard);
 
-		return (($sMode === 'install') && SetupUtils::IsItopHubInstance($aModules));
+		return (($sMode === 'install') && SetupUtils::IsConnectableToITopHub($aModules));
 	}
 
     /**

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -715,7 +715,7 @@ class WizStepLicense extends WizardStep
 	{
 		$sMode = $this->oWizard->GetParameter('install_mode');
 		$aModules = SetupUtils::AnalyzeInstallation($this->oWizard);
-		return $sMode == 'install' && !SetupUtils::IsProductVersion($aModules);
+		return $sMode == 'install' && array_key_exists('itop-hub-connector', $aModules);
 	}
 
     /**

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -709,7 +709,8 @@ class WizStepLicense extends WizardStep
 	/**
 	 * @return bool true if we need to display a GDPR confirmation
 	 * @throws \Exception
-	 * @since 2.7.7 3.0.2 3.1.0 N°5037
+	 * @since 2.7.7 3.0.2 3.1.0 N°5037 method creation
+	 * @since 2.7.8 3.0.3 3.1.0 N°5758 rename from NeedsRgpdConsent to NeedsGdprConsent
 	 */
 	private function NeedsGdprConsent()
 	{

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -715,7 +715,7 @@ class WizStepLicense extends WizardStep
 	{
 		$sMode = $this->oWizard->GetParameter('install_mode');
 		$aModules = SetupUtils::AnalyzeInstallation($this->oWizard);
-		return $sMode == 'install' && array_key_exists('itop-hub-connector', $aModules);
+		return $sMode == 'install' && SetupUtils::IsItopHubInstance($aModules);
 	}
 
     /**

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -707,15 +707,16 @@ class WizStepLicense extends WizardStep
 	}
 
 	/**
-	 * @return bool
+	 * @return bool true if we need to display a GDPR confirmation
 	 * @throws \Exception
-	 * @since 2.7.7 3.0.2 3.1.0
+	 * @since 2.7.7 3.0.2 3.1.0 N°5037
 	 */
-	private function NeedsRgpdConsent()
+	private function NeedsGdprConsent()
 	{
 		$sMode = $this->oWizard->GetParameter('install_mode');
 		$aModules = SetupUtils::AnalyzeInstallation($this->oWizard);
-		return $sMode == 'install' && SetupUtils::IsItopHubInstance($aModules);
+
+		return (($sMode === 'install') && SetupUtils::IsItopHubInstance($aModules));
 	}
 
     /**
@@ -752,7 +753,7 @@ EOF
 		$oPage->add('</fieldset>');
         $sChecked = ($this->oWizard->GetParameter('accept_license', 'no') == 'yes') ? ' checked ' : '';
         $oPage->p('<input type="checkbox" class="check_select" name="accept_license" id="accept" value="yes" '.$sChecked.'><label for="accept">&nbsp;I accept the terms of the licenses of the '.count($aLicenses).' components mentioned above.</label>');
-	    if ($this->NeedsRgpdConsent()) {
+	    if ($this->NeedsGdprConsent()) {
 		    $oPage->add('<div id="rgpd_message" class="message message-info">'.ITOP_APPLICATION.' software is compliant with the processing of personal data according to the European General Data Protection Regulation (GDPR).<p></p>
 By installing '.ITOP_APPLICATION.' you agree that some information will be collected by Combodo to help you manage your instances and for statistical purposes.
 This data remains anonymous until it is associated to a user account on iTop Hub.</p>


### PR DESCRIPTION
Up to now,  we define that RGPD consent is required if iTop is not an "iTop Product". This is, I think, too restrictive as other products based on iTop (TeemIp std alone today and ESM products tomorrow) may not require RGPD consent even if they are not "iTop Products". Since instance data are collected through iTop Hub only, I suggest to base the test of RGPD consent requirement on the fact that iTop Hub Connector extension is installed.