### PR TITLE
N°5797  - Email: Fix wrong config load

### DIFF
--- a/sources/Core/Email/EmailLaminas.php
+++ b/sources/Core/Email/EmailLaminas.php
@@ -315,7 +315,8 @@ class EMailLaminas extends Email
 		if ($bForceSynchronous) {
 			return $this->SendSynchronous($aIssues, $oLog);
 		} else {
-			$bConfigASYNC = MetaModel::GetConfig()->Get('email_asynchronous');
+			$oConfig = $this->LoadConfig();
+			$bConfigASYNC = $oConfig->Get('email_asynchronous');
 			if ($bConfigASYNC) {
 				return $this->SendAsynchronous($aIssues, $oLog);
 			} else {

--- a/sources/Core/Email/EmailSwiftMailer.php
+++ b/sources/Core/Email/EmailSwiftMailer.php
@@ -270,13 +270,11 @@ class EmailSwiftMailer extends EMail
 		}
 		else
 		{
-			$bConfigASYNC = MetaModel::GetConfig()->Get('email_asynchronous');
-			if ($bConfigASYNC)
-			{
+			$oConfig = $this->LoadConfig();
+			$bConfigASYNC = $oConfig->Get('email_asynchronous');
+			if ($bConfigASYNC) {
 				return $this->SendAsynchronous($aIssues, $oLog);
-			}
-			else
-			{
+			} else {
 				return $this->SendSynchronous($aIssues, $oLog);
 			}
 		}


### PR DESCRIPTION
Following #331 I see there are calls to \MetaModel::GetConfig in Send methods in Email children classes.
That means we can't use those methods without having loaded the datamodel !!

There is \EMail::LoadConfig though that don't have this pre-requisite and we should use it !