### PR TITLE
N°6077 - Attachment class: now creation_date and user_id are init by default

### DIFF
--- a/datamodels/2.x/itop-attachments/ajax.itop-attachment.php
+++ b/datamodels/2.x/itop-attachments/ajax.itop-attachment.php
@@ -98,7 +98,6 @@ try
 					$oAttachment->Set('expire', time() + MetaModel::GetConfig()->Get('draft_attachments_lifetime'));
 					$oAttachment->Set('temp_id', $sTempId);
 					$oAttachment->Set('item_class', $sClass);
-					$oAttachment->Set('creation_date', time());
 					$oAttachment->Set('user_id', UserRights::GetUserObject());
 					$oAttachment->SetDefaultOrgId();
 					$oAttachment->Set('contents', $oDoc);

--- a/datamodels/2.x/itop-attachments/ajax.itop-attachment.php
+++ b/datamodels/2.x/itop-attachments/ajax.itop-attachment.php
@@ -98,7 +98,6 @@ try
 					$oAttachment->Set('expire', time() + MetaModel::GetConfig()->Get('draft_attachments_lifetime'));
 					$oAttachment->Set('temp_id', $sTempId);
 					$oAttachment->Set('item_class', $sClass);
-					$oAttachment->Set('user_id', UserRights::GetUserObject());
 					$oAttachment->SetDefaultOrgId();
 					$oAttachment->Set('contents', $oDoc);
 					$iAttId = $oAttachment->DBInsert();

--- a/datamodels/2.x/itop-attachments/datamodel.itop-attachments.xml
+++ b/datamodels/2.x/itop-attachments/datamodel.itop-attachments.xml
@@ -110,6 +110,8 @@
     public function DBInsertNoReload()
     {
         $this->SetCurrentDateIfNull('creation_date');
+        $this->SetIfNull('user_id', CMDBChange::GetCurrentUserId());
+
         return parent::DBInsertNoReload();
     }
         ]]></code>

--- a/datamodels/2.x/itop-attachments/datamodel.itop-attachments.xml
+++ b/datamodels/2.x/itop-attachments/datamodel.itop-attachments.xml
@@ -102,6 +102,17 @@
         </field>
       </fields>
       <methods>
+        <method id="__construct">
+          <comment></comment>
+          <static>false</static>
+          <access>public</access>
+          <type>Overload-ExNihilo</type>
+          <code><![CDATA[	public function __construct()
+	{
+	  parent::__construct();
+		$this->Set('creation_date', new Date());
+	}]]></code>
+        </method>
         <method id="MapContextParam">
           <comment><![CDATA[/**
 	 * Maps the given context parameter name to the appropriate filter/search code for this class

--- a/datamodels/2.x/itop-attachments/datamodel.itop-attachments.xml
+++ b/datamodels/2.x/itop-attachments/datamodel.itop-attachments.xml
@@ -110,7 +110,7 @@
     public function DBInsertNoReload()
     {
         $this->SetIfNull('creation_date', time());
-        $iKey = parent::DBInsertNoReload();
+        return parent::DBInsertNoReload();
     }
         ]]></code>
         </method>

--- a/datamodels/2.x/itop-attachments/datamodel.itop-attachments.xml
+++ b/datamodels/2.x/itop-attachments/datamodel.itop-attachments.xml
@@ -109,7 +109,7 @@
           <code><![CDATA[
     public function DBInsertNoReload()
     {
-        $this->SetIfNull('creation_date', time());
+        $this->SetCurrentDateIfNull('creation_date');
         return parent::DBInsertNoReload();
     }
         ]]></code>

--- a/datamodels/2.x/itop-attachments/datamodel.itop-attachments.xml
+++ b/datamodels/2.x/itop-attachments/datamodel.itop-attachments.xml
@@ -102,16 +102,17 @@
         </field>
       </fields>
       <methods>
-        <method id="__construct">
-          <comment></comment>
+        <method id="DBInsertNoReload">
           <static>false</static>
           <access>public</access>
-          <type>Overload-ExNihilo</type>
-          <code><![CDATA[	public function __construct()
-	{
-	  parent::__construct();
-		$this->Set('creation_date', new Date());
-	}]]></code>
+          <type>Overload-DBObject</type>
+          <code><![CDATA[
+    public function DBInsertNoReload()
+    {
+        $this->SetIfNull('creation_date', time());
+        $iKey = parent::DBInsertNoReload();
+    }
+        ]]></code>
         </method>
         <method id="MapContextParam">
           <comment><![CDATA[/**

--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
@@ -1230,7 +1230,6 @@ class ObjectController extends BrickController
 						$oAttachment->Set('expire', time() + MetaModel::GetConfig()->Get('draft_attachments_lifetime')); // one hour...
 						$oAttachment->Set('temp_id', $sTempId);
 						$oAttachment->Set('item_class', $sObjectClass);
-						$oAttachment->Set('user_id', UserRights::GetUserObject());
 						$oAttachment->SetDefaultOrgId();
 						$oAttachment->Set('contents', $oDocument);
 						$iAttId = $oAttachment->DBInsert();

--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
@@ -1230,7 +1230,6 @@ class ObjectController extends BrickController
 						$oAttachment->Set('expire', time() + MetaModel::GetConfig()->Get('draft_attachments_lifetime')); // one hour...
 						$oAttachment->Set('temp_id', $sTempId);
 						$oAttachment->Set('item_class', $sObjectClass);
-						$oAttachment->Set('creation_date', time());
 						$oAttachment->Set('user_id', UserRights::GetUserObject());
 						$oAttachment->SetDefaultOrgId();
 						$oAttachment->Set('contents', $oDocument);


### PR DESCRIPTION
New fields were added to the class in 2.7.0 with N°330
The creation_date isn't initialized by default, that means every consumer needs to fill it. Currently Mail To Ticket extension doesn't...

This PR adds a `DBInsertNoReload` override in the class so that the field is set by default to the current date.
This would solve part of N°4081