### PR TITLE
Activity panel: Fix compose button opening log picker menu when only 1 log available

### DIFF
--- a/dictionaries/fr.dictionary.itop.ui.php
+++ b/dictionaries/fr.dictionary.itop.ui.php
@@ -496,7 +496,7 @@ Nous espérons que vous aimerez cette version autant que nous avons eu du plaisi
 	'UI:Menu:Actions' => 'Actions',
 	'UI:Menu:OtherActions' => 'Autres Actions',
 	'UI:Menu:Transitions' => 'Transitions~~',
-	'UI:Menu:OtherTransitions' => 'Other Transitions~~',
+	'UI:Menu:OtherTransitions' => 'Autres Transitions',
 	'UI:Menu:New' => 'Créer...',
 	'UI:Menu:Add' => 'Ajouter...',
 	'UI:Menu:Manage' => 'Gérer...',

--- a/js/layouts/activity-panel/activity-panel.js
+++ b/js/layouts/activity-panel/activity-panel.js
@@ -363,13 +363,22 @@ $(function()
 				const oActiveTabData = this._GetActiveTabData();
 				// If on a caselog tab, open its form if it has one
 				if ((this.enums.tab_types.caselog === oActiveTabData.type) && this._HasCaseLogEntryFormForTab(oActiveTabData.att_code)) {
-					// Note: Stop propogation to avoid the menu to be opened automatically by the popover handler, we will decide when it can opens below
+					// Note: Stop propagation to avoid the menu to be opened automatically by the popover handler
 					oEvent.stopImmediatePropagation();
 
 					this._ShowCaseLogTab(oActiveTabData.att_code);
 					this._ShowCaseLogsEntryForms();
 					this._SetFocusInCaseLogEntryForm(oActiveTabData.att_code);
 				}
+				// Else (activity tab) if only 1 clog tab, open it directly
+				else if (this._GetCaseLogEntryFormCount() === 1) {
+					// Note: Stop propagation to avoid the menu to be opened automatically by the popover handler
+					oEvent.stopImmediatePropagation();
+
+					// Simulate click on the only menu item
+					this.element.find(this.js_selectors.compose_menu_item+':first').trigger('click');
+				}
+
 				// Else, the compose menu will open automatically
 			},
 			/**
@@ -737,6 +746,14 @@ $(function()
 			},
 
 			// - Helpers on case logs entry forms
+			/**
+			 * @returns {integer} The number of caselog entry form
+			 * @private
+			 * @since 3.1.0
+			 */
+			_GetCaseLogEntryFormCount: function () {
+				return this.element.find(this.js_selectors.caselog_entry_form).length;
+			},
 			/**
 			 * @param sCaseLogAttCode {string}
 			 * @returns {boolean} Return true if there is a case log for entry for the sCaseLogAttCode tab


### PR DESCRIPTION
## Symptom

When on an object with only 1 log in the activity panel, if you click on the "Compose" button when being on the "Activity" tab, the log picker is displayed with only one item, forcing us to an avoidable extra click.

// TODO: Insert GIF of problem

## Proposition

When on an object with only 1 log in the activity panel, open the log directly when "Compose" button is pressed.

// TODO: Insert GIF of solution

## Arguments in favor

  * Better UX as it reduces the number of clicks to get to the log form

## Reproduction

Use the following XML delta which adds a log on the `Person` class.

```
<?xml version="1.0" encoding="UTF-8"?>
<itop_design xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0">
  <classes>
    <class id="Person">
      <fields>
        <field id="log" xsi:type="AttributeCaseLog" _delta="define">
          <sql>log</sql>
          <default_value/>
          <is_null_allowed>true</is_null_allowed>
        </field>
      </fields>
      <presentation>
        <details>
          <items>
            <item id="log" _delta="define">
              <rank>100</rank>
            </item>
          </items>
        </details>
      </presentation>
    </class>
  </classes>
</itop_design>
```