### PR TITLE
N°4798 - Align attribute "description" type for Service class

### DIFF
--- a/datamodels/2.x/itop-service-mgmt-provider/datamodel.itop-service-mgmt-provider.xml
+++ b/datamodels/2.x/itop-service-mgmt-provider/datamodel.itop-service-mgmt-provider.xml
@@ -1057,7 +1057,7 @@ public function PrefillSearchForm(&$aContextParam)
           <extkey_attcode>servicefamily_id</extkey_attcode>
           <target_attcode>name</target_attcode>
         </field>
-        <field id="description" xsi:type="AttributeString">
+        <field id="description" xsi:type="AttributeText">
           <sql>description</sql>
           <default_value/>
           <is_null_allowed>true</is_null_allowed>


### PR DESCRIPTION
## Objective

Align attribute "description" type for Service class in "Service provider" module (`AttributeString`) to the one in "Service" module (`AttributeText`)

## TODOs once PR is merged

  * ~[ ] Add migration audit check~ Check not needed as the XML structure and ID does not change.