### PR TITLE
N°2244 - Fix image attributes not being visible in PDF exports

### DIFF
--- a/core/pdfbulkexport.class.inc.php
+++ b/core/pdfbulkexport.class.inc.php
@@ -25,6 +25,19 @@
 
 class PDFBulkExport extends HTMLBulkExport
 {
+	/**
+	 * @var string For sample purposes
+	 * @internal
+	 * @since 2.7.8
+	 */
+	const ENUM_OUTPUT_TYPE_SAMPLE = 'sample';
+	/**
+	 * @var string For the real export
+	 * @internal
+	 * @since 2.7.8
+	 */
+	const ENUM_OUTPUT_TYPE_REAL = 'real';
+
 	public function DisplayUsage(Page $oP)
 	{
 		$oP->p(" * pdf format options:");
@@ -190,6 +203,25 @@ EOF
 		return $sPDF;
 	}
 
+	/**
+	 * @inheritDoc
+	 * @since 2.7.8
+	 */
+	protected function GetSampleData($oObj, $sAttCode)
+	{
+		if ($sAttCode !== 'id')
+		{
+			$oAttDef = MetaModel::GetAttributeDef(get_class($oObj), $sAttCode);
+
+			// As sample data will be displayed in the web browser, AttributeImage needs to be rendered with a regular HTML format, meaning its "src" looking like "data:image/png;base64,iVBORw0KGgoAAAANSUh..."
+			// Whereas for the PDF generation it needs to be rendered with a TCPPDF-compatible format, meaning its "src" looking like "@iVBORw0KGgoAAAANSUh..."
+			if ($oAttDef instanceof AttributeImage) {
+				return $this->GetAttributeImageValue($oAttDef, $oObj->Get($sAttCode), static::ENUM_OUTPUT_TYPE_SAMPLE);
+			}
+		}
+		return parent::GetSampleData($oObj, $sAttCode);
+	}
+
 	protected function GetValue($oObj, $sAttCode)
 	{
 		switch($sAttCode)
@@ -205,31 +237,7 @@ EOF
 					$oAttDef = MetaModel::GetAttributeDef(get_class($oObj), $sAttCode);
 					if ($oAttDef instanceof AttributeImage)
 					{
-						// To limit the image size in the PDF output, we have to enforce the size as height/width because max-width/max-height have no effect
-						//
-						$iDefaultMaxWidthPx = 48;
-						$iDefaultMaxHeightPx = 48;
-						if ($value->IsEmpty())
-						{
-							$iNewWidth = $iDefaultMaxWidthPx;
-							$iNewHeight = $iDefaultMaxHeightPx;
-
-							$sUrl = $oAttDef->Get('default_image');
-						}
-						else
-						{
-							list($iWidth, $iHeight) = utils::GetImageSize($value->GetData());
-							$iMaxWidthPx = min($iDefaultMaxWidthPx, $oAttDef->Get('display_max_width'));
-							$iMaxHeightPx = min($iDefaultMaxHeightPx, $oAttDef->Get('display_max_height'));
-
-							$fScale = min($iMaxWidthPx / $iWidth, $iMaxHeightPx / $iHeight);
-							$iNewWidth = $iWidth * $fScale;
-							$iNewHeight = $iHeight * $fScale;
-
-							$sUrl = 'data:'.$value->GetMimeType().';base64,'.base64_encode($value->GetData());
-						}
-						$sRet = ($sUrl !== null) ? '<img src="'.$sUrl.'" style="width: '.$iNewWidth.'px; height: '.$iNewHeight.'px">' : '';
-						$sRet = '<div class="view-image">'.$sRet.'</div>';
+						$sRet = $this->GetAttributeImageValue($oAttDef, $value, static::ENUM_OUTPUT_TYPE_REAL);
 					}
 					else
 					{
@@ -257,5 +265,54 @@ EOF
 	public function GetFileExtension()
 	{
 		return 'pdf';
+	}
+
+	/**
+	 * @param \AttributeImage $oAttDef Instance of image attribute
+	 * @param \ormDocument $oValue Value of image attribute
+	 * @param string $sOutputType {@see \PDFBulkExport::ENUM_OUTPUT_TYPE_SAMPLE}, {@see \PDFBulkExport::ENUM_OUTPUT_TYPE_REAL}
+	 *
+	 * @return string Rendered value of $oAttDef / $oValue according to the desired $sOutputType
+	 * @since 2.7.8
+	 */
+	protected function GetAttributeImageValue(AttributeImage $oAttDef, ormDocument $oValue, string $sOutputType)
+	{
+		// To limit the image size in the PDF output, we have to enforce the size as height/width because max-width/max-height have no effect
+		//
+		$iDefaultMaxWidthPx = 48;
+		$iDefaultMaxHeightPx = 48;
+		if ($oValue->IsEmpty()) {
+			$iNewWidth = $iDefaultMaxWidthPx;
+			$iNewHeight = $iDefaultMaxHeightPx;
+
+			$sUrl = $oAttDef->Get('default_image');
+		} else {
+			list($iWidth, $iHeight) = utils::GetImageSize($oValue->GetData());
+			$iMaxWidthPx = min($iDefaultMaxWidthPx, $oAttDef->Get('display_max_width'));
+			$iMaxHeightPx = min($iDefaultMaxHeightPx, $oAttDef->Get('display_max_height'));
+
+			$fScale = min($iMaxWidthPx / $iWidth, $iMaxHeightPx / $iHeight);
+			$iNewWidth = $iWidth * $fScale;
+			$iNewHeight = $iHeight * $fScale;
+
+			$sValueAsBase64 = base64_encode($oValue->GetData());
+			switch ($sOutputType) {
+				case static::ENUM_OUTPUT_TYPE_SAMPLE:
+					$sUrl = 'data:'.$oValue->GetMimeType().';base64,'.$sValueAsBase64;
+					break;
+
+				case static::ENUM_OUTPUT_TYPE_REAL:
+				default:
+					// TCPDF requires base64-encoded images to be rendered without the usual "data:<MIMETYPE>;base64" header but with an "@"
+					// @link https://tcpdf.org/examples/example_009/
+					$sUrl = '@'.$sValueAsBase64;
+					break;
+			}
+		}
+
+		$sRet = ($sUrl !== null) ? '<img src="'.$sUrl.'" style="width: '.$iNewWidth.'px; height: '.$iNewHeight.'px; vertical-align: middle; text-align:center;">' : '';
+		$sRet = '<div class="view-image">'.$sRet.'</div>';
+
+		return $sRet;
 	}
 }


### PR DESCRIPTION
## Symptom

Image attributes not visible in PDF exports when exporting a list of objects, for example `Person` and their `picture` attribute.

_Current behavior_
![image](https://user-images.githubusercontent.com/5130468/193418506-16548bac-db3c-49ad-9254-af1c5dc8d36c.png)

![image](https://user-images.githubusercontent.com/5130468/193418551-4c4eb58f-23a9-4992-a9a8-a90c17bf82f3.png)

_Expected_
![image](https://user-images.githubusercontent.com/5130468/193418566-d30973f1-075f-40aa-863a-013fa0fcf8a6.png)

## Reproduction

  * iTop 2.7.0 + sample data
  * Open a list of Person objects
  * Export the list in PDF with the `picture` attribute
  * Open the PDF and see the "Picture" column empty

## Cause

During the export, images are rendered in HTML as base64-encoded which is fine, but TCPDF requires a special formatting of the `src` attribute for it to work.