### PR TITLE
N°5588 - Improve PDF export robustness when AttributeImage dimensions cannot be determined

### DIFF
--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -549,6 +549,12 @@ class LogChannels
 
 	const DEADLOCK = 'DeadLock';
 
+	/**
+	 * @var string
+	 * @since 2.7.8
+	 */
+	const EXPORT = 'export';
+
 	const INLINE_IMAGE = 'InlineImage';
 
 	/**

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -551,7 +551,7 @@ class LogChannels
 
 	/**
 	 * @var string
-	 * @since 2.7.8
+	 * @since 2.7.9
 	 */
 	const EXPORT = 'export';
 

--- a/core/pdfbulkexport.class.inc.php
+++ b/core/pdfbulkexport.class.inc.php
@@ -296,7 +296,7 @@ EOF
 			$iMaxHeightPx = min($iDefaultMaxHeightPx, $oAttDef->Get('display_max_height'));
 
 			list($iWidth, $iHeight) = utils::GetImageSize($value->GetData());
-			if (($iWidth === 0) && ($iHeight === 0)) {
+			if (($iWidth === 0) || ($iHeight === 0)) {
 				// Avoid division by zero exception (SVGs, corrupted images, ...)
 				$iNewWidth = $iDefaultMaxWidthPx;
 				$iNewHeight = $iDefaultMaxHeightPx;

--- a/core/pdfbulkexport.class.inc.php
+++ b/core/pdfbulkexport.class.inc.php
@@ -300,7 +300,7 @@ EOF
 				// avoid division by zero exception :/
 				$iNewWidth = $iDefaultMaxWidthPx;
 				$iNewHeight = $iDefaultMaxHeightPx;
-				IssueLog::Warning('AttributeImage : cannot read image size', LogChannels::EXPORT, [
+				IssueLog::Warning('AttributeImage: Cannot read image size', LogChannels::EXPORT, [
 					'ObjClass'        => get_class($oObj),
 					'ObjKey'          => $oObj->GetKey(),
 					'ObjFriendlyName' => $oObj->GetName(),

--- a/core/pdfbulkexport.class.inc.php
+++ b/core/pdfbulkexport.class.inc.php
@@ -297,7 +297,7 @@ EOF
 
 			list($iWidth, $iHeight) = utils::GetImageSize($value->GetData());
 			if (($iWidth === 0) && ($iHeight === 0)) {
-				// avoid division by zero exception :/
+				// Avoid division by zero exception (SVGs, corrupted images, ...)
 				$iNewWidth = $iDefaultMaxWidthPx;
 				$iNewHeight = $iDefaultMaxHeightPx;
 				IssueLog::Warning('AttributeImage: Cannot read image size', LogChannels::EXPORT, [

--- a/core/pdfbulkexport.class.inc.php
+++ b/core/pdfbulkexport.class.inc.php
@@ -216,7 +216,7 @@ EOF
 			// As sample data will be displayed in the web browser, AttributeImage needs to be rendered with a regular HTML format, meaning its "src" looking like "data:image/png;base64,iVBORw0KGgoAAAANSUh..."
 			// Whereas for the PDF generation it needs to be rendered with a TCPPDF-compatible format, meaning its "src" looking like "@iVBORw0KGgoAAAANSUh..."
 			if ($oAttDef instanceof AttributeImage) {
-				return $this->GetAttributeImageValue($oObj, $oAttDef, $oObj->Get($sAttCode), static::ENUM_OUTPUT_TYPE_SAMPLE);
+				return $this->GetAttributeImageValue($oObj, $sAttCode, static::ENUM_OUTPUT_TYPE_SAMPLE);
 			}
 		}
 		return parent::GetSampleData($oObj, $sAttCode);
@@ -242,7 +242,7 @@ EOF
 					$oAttDef = MetaModel::GetAttributeDef(get_class($oObj), $sAttCode);
 					if ($oAttDef instanceof AttributeImage)
 					{
-						$sRet = $this->GetAttributeImageValue($oObj, $oAttDef, $value, static::ENUM_OUTPUT_TYPE_REAL);
+						$sRet = $this->GetAttributeImageValue($oObj, $sAttCode, static::ENUM_OUTPUT_TYPE_REAL);
 					}
 					else
 					{
@@ -273,15 +273,22 @@ EOF
 	}
 
 	/**
-	 * @param \AttributeImage $oAttDef Instance of image attribute
-	 * @param \ormDocument $oValue Value of image attribute
+	 * @param \DBObject $oObj
+	 * @param string $sAttCode
 	 * @param string $sOutputType {@see \PDFBulkExport::ENUM_OUTPUT_TYPE_SAMPLE}, {@see \PDFBulkExport::ENUM_OUTPUT_TYPE_REAL}
 	 *
 	 * @return string Rendered value of $oAttDef / $oValue according to the desired $sOutputType
-	 * @since 2.7.8
+	 * @throws \ArchivedObjectException
+	 * @throws \CoreException
+	 *
+	 * @since 2.7.8 N°2244 method creation
+	 * @since 2.7.9 N°5588 signature change to get the object so that we can log all the needed information
 	 */
-	protected function GetAttributeImageValue(DBObject $oObj, AttributeImage $oAttDef, ormDocument $oValue, string $sOutputType)
+	protected function GetAttributeImageValue(DBObject $oObj, string $sAttCode, string $sOutputType)
 	{
+		$oValue = $oObj->Get($sAttCode);
+		$oAttDef = MetaModel::GetAttributeDef(get_class($oObj), $sAttCode);
+
 		// To limit the image size in the PDF output, we have to enforce the size as height/width because max-width/max-height have no effect
 		//
 		$iDefaultMaxWidthPx = 48;


### PR DESCRIPTION
Avoid PDF export to crash when having some images GD can't read (in SVG format for example).
In such case we were getting this error log:

```
2022-10-07 01:27:33 | Error   | 1     | Uncaught DivisionByZeroError: Division by zero in /var/www/html/iTop/core/pdfbulkexport.class.inc.php:232
Stack trace:
#0 /var/www/html/iTop/core/htmlbulkexport.class.inc.php(68): PDFBulkExport->GetValue(Object(Person), 'picture')
#1 /var/www/html/iTop/core/tabularbulkexport.class.inc.php(297): HTMLBulkExport->GetSampleData(Object(Person), 'picture')
#2 /var/www/html/iTop/core/htmlbulkexport.class.inc.php(49): TabularBulkExport->GetInteractiveFieldsWidget(Object(AjaxPage), 'interactive_fie...')
#3 /var/www/html/iTop/core/pdfbulkexport.class.inc.php(117): HTMLBulkExport->GetFormPart(Object(AjaxPage), 'interactive_fie...')
#4 /var/www/html/iTop/webservices/export-v2.php(318): PDFBulkExport->GetFormPart(Object(AjaxPage), 'interactive_fie...')
#5 /var/www/html/iTop/webservices/export-v2.php(423): DisplayForm(Object(AjaxPage), 'http://webserve...', 'SELECT `Person`...', NULL, 'pdf')
#6 /var/www/html/iTop/webservices/export-v2.php(689): InteractiveShell('SELECT `Person`...', NULL, 'pdf', '', 'dialog')
#7 {main}
  thrown | IssueLog |||
array (
  'type' => 1,
  'file' => '/var/www/html/iTop/core/pdfbulkexport.class.inc.php',
  'line' => 232,
)
```

Now we won't crash anymore, but we will still get a warning in the log: 
```
2022-12-13 18:53:37 | Warning | 1     | AttributeImage: Cannot read image size | export
array (
  'ObjClass' => 'Person',
  'ObjKey' => '15',
  'ObjFriendlyName' => 'Agatha Christie',
  'AttCode' => 'picture',
)
```
