### PR TITLE
N°2013 - Setup: Cannot execute if existing config file contains an inaccessible MySQL server

### DIFF
--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -1348,6 +1348,18 @@ class WizStepModulesChoice extends WizardStep
 		if ($sConfigPath !== null)
 		{
 			$oConfig = new Config($sConfigPath);
+
+			$aParamValues = array(
+				'db_server' => $oWizard->GetParameter('db_server', ''),
+				'db_user' => $oWizard->GetParameter('db_user', ''),
+				'db_pwd' => $oWizard->GetParameter('db_pwd', ''),
+				'db_name' => $oWizard->GetParameter('db_name', ''),
+				'db_prefix' => $oWizard->GetParameter('db_prefix', ''),
+				'db_tls_enabled' => $oWizard->GetParameter('db_tls_enabled', false),
+				'db_tls_ca' => $oWizard->GetParameter('db_tls_ca', ''),
+			);
+			$oConfig->UpdateFromParams($aParamValues);
+
 			$this->bChoicesFromDatabase = $this->oExtensionsMap->LoadChoicesFromDatabase($oConfig);
 		}
 	}


### PR DESCRIPTION
When running setup to update iTop or install new extensions, but also want to change the DB settings at the same time an error occurs at the module selection wizard steps as it tries to connect to the old database (which might not exist) instead of the new one given a few steps before.

This seems to be like this since at least iTop 2.5.0