### PR TITLE
N°6100 ObjectFormManager::OnSubmit : better log for DBWrite exceptions

### DIFF
--- a/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
@@ -1164,7 +1164,7 @@ class ObjectFormManager extends FormManager
 				$aContext = [
 					'origin'    => __CLASS__.'::'.__METHOD__,
 					'obj_class' => get_class($this->oObject),
-					'obj_key' => $bIsNew ? 'NULL' : $this->oObject->GetKey(),
+					'obj_key' => $this->oObject->GetKey(),
 				];
 				ExceptionLog::LogException($e, $aContext);
 				$bExceptionLogged = true;

--- a/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
@@ -1164,8 +1164,8 @@ class ObjectFormManager extends FormManager
 				$aContext = [
 					'origin'    => __CLASS__.'::'.__METHOD__,
 					'obj_class' => get_class($this->oObject),
+					'obj_key' => $bIsNew ? 'NULL' : $this->oObject->GetKey(),
 				];
-				$aContext['obj_key'] = $bIsNew ? 'NULL' : $this->oObject->GetKey();
 				ExceptionLog::LogException($e, $aContext);
 				$bExceptionLogged = true;
 

--- a/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
@@ -1165,11 +1165,7 @@ class ObjectFormManager extends FormManager
 					'origin'    => __CLASS__.'::'.__METHOD__,
 					'obj_class' => get_class($this->oObject),
 				];
-				if ($bIsNew) {
-					$aContext['obj_key'] = 'NULL';
-				} else {
-					$aContext['obj_key'] = $this->oObject->GetKey();
-				}
+				$aContext['obj_key'] = $bIsNew ? 'NULL' : $this->oObject->GetKey();
 				ExceptionLog::LogException($e, $aContext);
 				$bExceptionLogged = true;
 


### PR DESCRIPTION
For now if an exception occurs during DBWrite in the portal form context, we only get a message containing a dict key (either Portal:Error:ObjectCannotBeCreated or Portal:Error:ObjectCannotBeUpdated) : 

```
2022-10-11 02:54:08 | Error   | 4     | Combodo\iTop\Portal\Form\ObjectFormManager::OnSubmit at line 1199 : Error: object cannot be created. Check associated objects and attachments before submitting again this form. | IssueLog |||
```

With this PR we are now using ExceptionLog (introduced in 3.0.0 with N°4261) to print a log with more info.