### PR TITLE
N°5622 - Do not verify ca in mysqldump if not configured

### DIFF
--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -1611,4 +1611,22 @@ class CMDBSource
 
 		return 'ALTER DATABASE'.CMDBSource::GetSqlStringColumnDefinition().';';
 	}
+
+	/**
+	 * Check which mysql client option (--ssl or --ssl-mode) to be used for encrypted connection
+	 *
+	 * @return bool true if --ssl-mode should be used, false otherwise
+	 * @throws \MySQLException
+	 *
+	 * @link https://dev.mysql.com/doc/refman/5.7/en/connection-options.html#encrypted-connection-options "Command Options for Encrypted Connections"
+	 */
+	public static function IsSslModeDBVersion()
+	{
+		if (static::GetDBVendor() === static::ENUM_DB_VENDOR_MYSQL)
+		{
+			//Mysql 5.7.0 and upper deprecated --ssl and uses --ssl-mode instead
+			return version_compare(static::GetDBVersion(), '5.7.11', '>=');
+		}
+		return false;
+	}
 }

--- a/test/setup/DBBackupTest.php
+++ b/test/setup/DBBackupTest.php
@@ -61,8 +61,16 @@ class DBBackupTest extends ItopTestCase
 		$oConfigToTest->Set('db_tls.enabled', true);
 		$sCliArgsMinCfg = DBBackup::GetMysqlCliTlsOptions($oConfigToTest);
 
-		// depending on the MySQL version, we would have `--ssl` or `--ssl-mode=VERIFY_CA`
-		$this->assertStringStartsWith(' --ssl', $sCliArgsMinCfg);
+		// depending on the MySQL vendor, we would have `--ssl` or `--ssl-mode=REQUIRED`
+		if (CMDBSource::IsSslModeDBVersion())
+		{
+			$this->assertStringStartsWith(' --ssl-mode=REQUIRED', $sCliArgsMinCfg);
+		}
+		else
+		{
+			$this->assertStringStartsWith(' --ssl', $sCliArgsMinCfg);
+			$this->assertStringNotContainsString('--ssl-mode', $sCliArgsMinCfg);
+		}
 	}
 
 	/**
@@ -81,7 +89,17 @@ class DBBackupTest extends ItopTestCase
 		$oConfigToTest->Set('db_tls.ca', $sTestCa);
 		$sCliArgsCapathCfg = DBBackup::GetMysqlCliTlsOptions($oConfigToTest);
 
-		$this->assertStringStartsWith(' --ssl', $sCliArgsCapathCfg);
+		// depending on the MySQL vendor, we would have `--ssl` or `--ssl-mode=VERIFY_CA`
+		if (CMDBSource::IsSslModeDBVersion())
+		{
+			$this->assertStringStartsWith(' --ssl-mode=VERIFY_CA', $sCliArgsCapathCfg);
+		}
+		else
+		{
+			$this->assertStringStartsWith(' --ssl', $sCliArgsCapathCfg);
+			$this->assertStringNotContainsString('--ssl-mode', $sCliArgsCapathCfg);
+
+		}
 		$this->assertStringEndsWith('--ssl-ca='.DBBackup::EscapeShellArg($sTestCa), $sCliArgsCapathCfg);
 	}
 }


### PR DESCRIPTION
### Symptom

Using mysql-client (not MariaDB) during the backup the CA is always verified even if no CA Path is configured.

_Current behavior_
<img width="718" alt="image" src="https://user-images.githubusercontent.com/24569763/195871316-4ec5abd1-a6b7-436d-ab7f-29d33ee2e61f.png">
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/24569763/195870977-9d2a9d40-7572-4b35-a38a-8ffec56caa54.png">

_Expected behavior_
Backup should be successful using mysql client and ssl without configured ca

### Reproduction

- Setup iTop (3.0 or 2.7) with separate web and database host
- Install mysql-client (not mariadb) on web server
- Add the config setting `'db_tls.enabled' => true`
- Do _not_ add `db_tls.ca` or leave it empty

### Cause

iTop adds the mysql option `--ssl-mode=VERIFY_CA` in case of mysql and tls enabled, but do not check whether ca is configured.
If no ca path is configured it should be `--ssl-mode=REQUIRED` instead of `VERIFY_CA`.
