### PR TITLE
N°6016 MissingDependencyException : better text message

### DIFF
--- a/setup/modulediscovery.class.inc.php
+++ b/setup/modulediscovery.class.inc.php
@@ -31,7 +31,7 @@ class MissingDependencyException extends CoreException
 
 	/**
 	 * @return string HTML to print to the user the modules impacted
-	 * @since 2.7.7 3.0.2 3.1.0 PR #280
+	 * @since 2.7.7 3.0.2 3.1.0 N°5090 PR #280
 	 */
 	public function getHtmlDesc($sHighlightHtmlBegin = null, $sHighlightHtmlEnd = null)
 	{
@@ -254,10 +254,10 @@ class ModuleDiscovery
 			foreach($aDependencies as $sId => $aDeps)
 			{
 				$aModule = $aModules[$sId];
-				$aModuleDeps[] = "{$aModule['label']} (id: $sId) depends on ".implode(' + ', $aDeps);
+				$aModuleDeps[] = "{$aModule['label']} (id: $sId) depends on: ".implode(' + ', $aDeps);
 				$aModulesInfo[$sId] = array('module' => $aModule, 'dependencies' => $aDeps);
 			}
-			$sMessage = "The following modules have unmet dependencies: ".implode(', ', $aModuleDeps);
+			$sMessage = "The following modules have unmet dependencies:\n".implode(",\n", $aModuleDeps);
 			$oException = new MissingDependencyException($sMessage);
 			$oException->aModulesInfo = $aModulesInfo;
 			throw $oException;


### PR DESCRIPTION
With #280 we improved the message displayed to the user in the setup screens when a module on disk hasn't got all of its dependencies present. The displayed message was based on the MissingDependencyException attributes.

This PR aims to improve the MissingDependencyException message as well : it will benefit to unattended install for example !

Before we were getting this in the log (direct MissingDependencyException message printing) : 
```
Error: The following modules have unmet dependencies: Database maintenance tools (id: combodo-db-tools/3.1.0) depends on itop-structure/3.0.0, Links between virtualization and storage (id: itop-bridge-virtualization-storage/3.1.0) depends on itop-storage-mgmt/2.2.0 + itop-virtualization-mgmt/2.2.0
```

After : 
```
Error: The following modules have unmet dependencies:
Database maintenance tools (id: combodo-db-tools/3.1.0) depends on itop-structure/3.0.0,
Links between virtualization and storage (id: itop-bridge-virtualization-storage/3.1.0) depends on itop-storage-mgmt/2.2.0 + itop-virtualization-mgmt/2.2.0
```