### PR TITLE
N°6014 Validation pattern for URL : now handles commas in params

### DIFF
--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -7673,7 +7673,7 @@ class AttributeURL extends AttributeString
 	 * @since 3.0.3 moved from Config to AttributeURL constant
 	 */
 	public const DEFAULT_VALIDATION_PATTERN = /** @lang RegExp */
-		'(https?|ftp)\://([a-zA-Z0-9+!*(),;?&=\$_.-]+(\:[a-zA-Z0-9+!*(),;?&=\$_.-]+)?@)?([a-zA-Z0-9-.]{3,})(\:[0-9]{2,5})?(/([a-zA-Z0-9:%+\$_-]\.?)+)*/?(\?[a-zA-Z+&\$_.-][a-zA-Z0-9;:[\]@&%=+/\$_.-]*)?(#[a-zA-Z0-9_.-][a-zA-Z0-9+\$_.-]*)?';
+		'(https?|ftp)\://([a-zA-Z0-9+!*(),;?&=\$_.-]+(\:[a-zA-Z0-9+!*(),;?&=\$_.-]+)?@)?([a-zA-Z0-9-.]{3,})(\:[0-9]{2,5})?(/([a-zA-Z0-9:%+\$_-]\.?)+)*/?(\?[a-zA-Z+&\$_.-][a-zA-Z0-9;:[\]@&%=+/\$_.,-]*)?(#[a-zA-Z0-9_.-][a-zA-Z0-9+\$_.-]*)?';
 
 	/**
 	 * Useless constructor, but if not present PHP 7.4.0/7.4.1 is crashing :( (N°2329)

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -7665,6 +7665,17 @@ class AttributeExternalField extends AttributeDefinition
 class AttributeURL extends AttributeString
 {
 	/**
+	 * @var string
+	 * SCHEME....... USER....................... PASSWORD.......................... HOST/IP........... PORT.......... PATH......................... GET............................................ ANCHOR..........................
+	 * Example: http://User:passWord@127.0.0.1:8888/patH/Page.php?arrayArgument[2]=something:blah20#myAnchor
+	 * @link http://www.php.net/manual/fr/function.preg-match.php#93824 regexp source
+	 * @since 3.0.1 N°4515 handle Alfresco and Sharepoint URLs
+	 * @since 3.0.3 moved from Config to AttributeURL constant
+	 */
+	public const DEFAULT_VALIDATION_PATTERN = /** @lang RegExp */
+		'(https?|ftp)\://([a-zA-Z0-9+!*(),;?&=\$_.-]+(\:[a-zA-Z0-9+!*(),;?&=\$_.-]+)?@)?([a-zA-Z0-9-.]{3,})(\:[0-9]{2,5})?(/([a-zA-Z0-9:%+\$_-]\.?)+)*/?(\?[a-zA-Z+&\$_.-][a-zA-Z0-9;:[\]@&%=+/\$_.-]*)?(#[a-zA-Z0-9_.-][a-zA-Z0-9+\$_.-]*)?';
+
+	/**
 	 * Useless constructor, but if not present PHP 7.4.0/7.4.1 is crashing :( (N°2329)
 	 *
 	 * @see https://www.php.net/manual/fr/language.oop5.decon.php states that child constructor can be ommited

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -899,16 +899,11 @@ class Config
 			'show_in_conf_sample' => false,
 		],
 		'url_validation_pattern' => [
-			'type' => 'string',
-			'description' => 'Regular expression to validate/detect the format of an URL (URL attributes and Wiki formatting for Text attributes)',
-			'default' => /** @lang RegExp */
-			'(https?|ftp)\://([a-zA-Z0-9+!*(),;?&=\$_.-]+(\:[a-zA-Z0-9+!*(),;?&=\$_.-]+)?@)?([a-zA-Z0-9-.]{3,})(\:[0-9]{2,5})?(/([a-zA-Z0-9:%+\$_-]\.?)+)*/?(\?[a-zA-Z+&\$_.-][a-zA-Z0-9;:[\]@&%=+/\$_.-]*)?(#[a-zA-Z0-9_.-][a-zA-Z0-9+\$_.-]*)?',
-			// SCHEME....... USER....................... PASSWORD.......................... HOST/IP........... PORT.......... PATH......................... GET............................................ ANCHOR..........................
-			// Example: http://User:passWord@127.0.0.1:8888/patH/Page.php?arrayArgument[2]=something:blah20#myAnchor
-			// RegExp source: http://www.php.net/manual/fr/function.preg-match.php#93824
-			// Update with N°4515
-			'value' => '',
-			'source_of_value' => '',
+			'type'                => 'string',
+			'description'         => 'Regular expression to validate/detect the format of an URL (URL attributes and Wiki formatting for Text attributes)',
+			'default'             => AttributeURL::DEFAULT_VALIDATION_PATTERN,
+			'value'               => '',
+			'source_of_value'     => '',
 			'show_in_conf_sample' => true,
 		],
 		'email_validation_pattern' => [

--- a/tests/php-unit-tests/unitary-tests/core/AttributeURLTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/AttributeURLTest.php
@@ -33,13 +33,14 @@ class AttributeURLTest extends ItopTestCase {
 	public function CheckFormatProvider(): array
 	{
 		return [
-			'Simple https URL' => ['https://www.combodo.com/itop', 1],
-			'Simple FTP URL' => ['ftp://user:password@myftp.mydomain.com', 1],
-			'Sharepoint URL 1' => ['https://mydomain1.sharepoint.com/:i:/r/sites/DSIMyDept/Shared%20Documents/Architecture%20Technique/02%20-%20R%C3%A9seau/Baie%2025C/Baie%201er/Baie-25C-1er.jpg?csf=1&web=1&e=Il3txR', 1],
-			'Sharepoint URL 2' => ['https://mydomain2.sharepoint.com/:u:/r/sites/DIS/ITSM/00_Admin_iTOP/iTop%20-%20Upgrade%20manuel/Procedure%20upgrade%20Combodo.url?csf=1&web=1&e=DAF0i3', 1],
-			'Alfresco URL 2' => ['http://alfresco.mydomain3.org/share/page/site/books/document-details?nodeRef=workspace://SpacesStore/6274f55f-a25b-4762-a863-77f7066f2034', 1],
-			'SF URL' => ['https://sourceforge.net/p/itop/discussion/customizing-itop/thread/707145b859/?limit=25#f53c', 1],
+			'Simple https URL'                  => ['https://www.combodo.com/itop', 1],
+			'Simple FTP URL'                    => ['ftp://user:password@myftp.mydomain.com', 1],
+			'Sharepoint URL 1'                  => ['https://mydomain1.sharepoint.com/:i:/r/sites/DSIMyDept/Shared%20Documents/Architecture%20Technique/02%20-%20R%C3%A9seau/Baie%2025C/Baie%201er/Baie-25C-1er.jpg?csf=1&web=1&e=Il3txR', 1],
+			'Sharepoint URL 2'                  => ['https://mydomain2.sharepoint.com/:u:/r/sites/DIS/ITSM/00_Admin_iTOP/iTop%20-%20Upgrade%20manuel/Procedure%20upgrade%20Combodo.url?csf=1&web=1&e=DAF0i3', 1],
+			'Alfresco URL 2'                    => ['http://alfresco.mydomain3.org/share/page/site/books/document-details?nodeRef=workspace://SpacesStore/6274f55f-a25b-4762-a863-77f7066f2034', 1],
+			'SF URL'                            => ['https://sourceforge.net/p/itop/discussion/customizing-itop/thread/707145b859/?limit=25#f53c', 1],
 			'SF URL anchor starting with digit' => ['https://sourceforge.net/p/itop/discussion/customizing-itop/thread/b0a2d474ba/?limit=25#2b35', 1],
+			'SF URL param containing commas'    => ['http://mydomain.ptrg.com/chart.png?type=graph&width=1500&height=700&hide=2,3,6,7,8,9,10,11,12,13,14&graphstyling=showLegend%3D%271%27+baseFontSize%3D%2715%27&graphid=0&id=34759&username=portaluser&passhash=2353031973', 1],
 		];
 	}
 }

--- a/tests/php-unit-tests/unitary-tests/core/AttributeURLTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/AttributeURLTest.php
@@ -40,7 +40,7 @@ class AttributeURLTest extends ItopTestCase {
 			'Alfresco URL 2'                    => ['http://alfresco.mydomain3.org/share/page/site/books/document-details?nodeRef=workspace://SpacesStore/6274f55f-a25b-4762-a863-77f7066f2034', 1],
 			'SF URL'                            => ['https://sourceforge.net/p/itop/discussion/customizing-itop/thread/707145b859/?limit=25#f53c', 1],
 			'SF URL anchor starting with digit' => ['https://sourceforge.net/p/itop/discussion/customizing-itop/thread/b0a2d474ba/?limit=25#2b35', 1],
-			'SF URL param containing commas'    => ['http://mydomain.ptrg.com/chart.png?type=graph&width=1500&height=700&hide=2,3,6,7,8,9,10,11,12,13,14&graphstyling=showLegend%3D%271%27+baseFontSize%3D%2715%27&graphid=0&id=34759&username=portaluser&passhash=2353031973', 1],
+			'URL param containing commas'    => ['http://mydomain.ptrg.com/chart.png?type=graph&width=1500&height=700&hide=2,3,6,7,8,9,10,11,12,13,14&graphstyling=showLegend%3D%271%27+baseFontSize%3D%2715%27&graphid=0&id=34759&username=portaluser&passhash=2353031973', 1],
 		];
 	}
 }

--- a/tests/php-unit-tests/unitary-tests/core/AttributeURLTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/AttributeURLTest.php
@@ -40,7 +40,7 @@ class AttributeURLTest extends ItopTestCase {
 			'Alfresco URL 2'                    => ['http://alfresco.mydomain3.org/share/page/site/books/document-details?nodeRef=workspace://SpacesStore/6274f55f-a25b-4762-a863-77f7066f2034', 1],
 			'SF URL'                            => ['https://sourceforge.net/p/itop/discussion/customizing-itop/thread/707145b859/?limit=25#f53c', 1],
 			'SF URL anchor starting with digit' => ['https://sourceforge.net/p/itop/discussion/customizing-itop/thread/b0a2d474ba/?limit=25#2b35', 1],
-			'URL param containing commas'    => ['http://mydomain.ptrg.com/chart.png?type=graph&width=1500&height=700&hide=2,3,6,7,8,9,10,11,12,13,14&graphstyling=showLegend%3D%271%27+baseFontSize%3D%2715%27&graphid=0&id=34759&username=portaluser&passhash=2353031973', 1],
+			'URL param containing commas'       => ['http://mydomain.prtg.com/chart.png?type=graph&width=1500&height=700&hide=2,3,6,7,8,9,10,11,12,13,14&graphstyling=showLegend%3D%271%27+baseFontSize%3D%2715%27&graphid=0&id=34759&username=portaluser&passhash=2353031973', 1],
 		];
 	}
 }


### PR DESCRIPTION
Some URLs like the one from PRTG contains commas and are refused by the current validation pattern.

Remember a validation pattern modification and a corresponding test was added in #249 - as this previous PR was fixed only in support/3.0, this one is targeting the same branch as well.