### PR TITLE
N°6101 Replace old Ctrl+Enter detection in run_query with the new one

### DIFF
--- a/js/jquery.hotkeys.js
+++ b/js/jquery.hotkeys.js
@@ -1,6 +1,12 @@
 /*jslint browser: true*/
 /*jslint jquery: true*/
 
+
+/**
+ * @deprecated 3.1.0 use JQuery event keys instead
+ * @link https://github.com/Combodo/iTop/pull/345 Ctrl+Enter shortcut added in iTop object forms
+ */
+
 /*
  * jQuery Hotkeys Plugin
  * Copyright 2010, John Resig

--- a/pages/run_query.php
+++ b/pages/run_query.php
@@ -177,13 +177,14 @@ try
 	$oQueryTextArea->AddCSSClasses(['ibo-input-text', 'ibo-query-oql', 'ibo-is-code']);
 	$oQueryForm->AddSubBlock($oQueryTextArea);
 
-	$oP->add_linked_script(utils::GetAbsoluteUrlAppRoot()."/js/jquery.hotkeys.js");
-	$oP->add_ready_script(<<<EOF
+	$oP->add_ready_script(<<<JS
 $("#expression").select();
-$("#expression").on("keydown", null, "ctrl+return", function() {
-	$(this).closest("form").submit();
+$("#expression").on('keyup', function (oEvent) {
+    if ((oEvent.ctrlKey || oEvent.metaKey) && oEvent.key === 'Enter') {
+        $(this).closest('form').trigger('submit');
+    }
 });
-EOF
+JS
 	);
 
 	if (count($aArgs) > 0) {

--- a/tests/php-unit-tests/legacy-tests/VerifyOQL.php
+++ b/tests/php-unit-tests/legacy-tests/VerifyOQL.php
@@ -158,13 +158,14 @@ try
 	$oP->add("<form method=\"post\">\n");
 	$oP->add(Dict::S('UI:RunQuery:ExpressionToEvaluate')."<br/>\n");
 	$oP->add("<textarea cols=\"120\" rows=\"8\" id=\"expression\" name=\"expression\">".utils::EscapeHtml($sExpression)."</textarea>\n");
-	$oP->add_linked_script(utils::GetAbsoluteUrlAppRoot()."/js/jquery.hotkeys.js");
-	$oP->add_ready_script(<<<EOF
+	$oP->add_ready_script(<<<JS
 $("#expression").select();
-$("#expression").on("keydown", null, "ctrl+return", function() {
-	$(this).closest("form").submit();
+$("#expression").on('keyup', function (oEvent) {
+    if ((oEvent.ctrlKey || oEvent.metaKey) && oEvent.key === 'Enter') {
+        $(this).closest('form').trigger('submit');
+    }
 });
-EOF
+JS
 	);
 
 	if (count($aArgs) > 0)


### PR DESCRIPTION
The Ctrl+Enter shortcut was added in the run query screen with [684e9e3](https://github.com/Combodo/iTop/commit/684e9e35375ec1709f51c0f8692ee1414ce21616) in iTop 2.5.0, introducing the JQuery Hotkeys plugin.

In #345 the Ctrl+Enter shortcut was added (for iTop 3.1.0) in multiline form fields using a more modern technique, without any plugin dependency.

This PR aims to use this new technique.

Note that : 
* I added a `@deprecated` comment in js/jquery.hotkeys.js, but we need to create corresponding tickets in Combodo BD
* test/VerifyOQL.php was using the same code as run_query.php. This is an old page (it is throwing warnings in iTop 3.x) but I modify it anyway as the fix is exactly the same

TODO : 
* [x] tech review
* [x] functional review
* [x] create ticket : JQuery Hotkeys depreciation => N°6102
* [x] create ticket : JQuery Hotkeys removal => N°6103
* [x] create ticket : run_query modification
