### PR TITLE
N°5619 - Hide newsroom menu when no provider

### DIFF
--- a/sources/application/UI/Base/Component/PopoverMenu/NewsroomMenu/NewsroomMenu.php
+++ b/sources/application/UI/Base/Component/PopoverMenu/NewsroomMenu/NewsroomMenu.php
@@ -21,6 +21,7 @@ namespace Combodo\iTop\Application\UI\Base\Component\PopoverMenu\NewsroomMenu;
 
 
 use Combodo\iTop\Application\UI\Base\Component\PopoverMenu\PopoverMenu;
+use MetaModel;
 
 /**
  * Class NewsroomMenu
@@ -64,5 +65,16 @@ class NewsroomMenu extends PopoverMenu
 	public function GetParamsAsJson(): string
 	{
 		return json_encode($this->aParams);
+	}
+	
+	/**
+	 * Check if there is any Newsroom provider configured
+	 * @since 3.1.0 N°5619
+	 * @return boolean
+	 */
+	public static function HasProviders(): bool
+	{
+		$aProviders = MetaModel::EnumPlugins('iNewsroomProvider');
+		return count($aProviders) > 0;
 	}
 }

--- a/sources/application/UI/Base/Component/PopoverMenu/NewsroomMenu/NewsroomMenu.php
+++ b/sources/application/UI/Base/Component/PopoverMenu/NewsroomMenu/NewsroomMenu.php
@@ -70,7 +70,7 @@ class NewsroomMenu extends PopoverMenu
 	/**
 	 * Check if there is any Newsroom provider configured
 	 * @since 3.1.0 N°5619
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function HasProviders(): bool
 	{

--- a/sources/application/UI/Base/Component/PopoverMenu/NewsroomMenu/NewsroomMenuFactory.php
+++ b/sources/application/UI/Base/Component/PopoverMenu/NewsroomMenu/NewsroomMenuFactory.php
@@ -50,6 +50,16 @@ class NewsroomMenuFactory
 	}
 
 	/**
+	 * Check if there is any Newsroom provider configured
+	 * @return boolean
+	 */	
+	public static function HasProviders()
+	{
+		$aProviders = MetaModel::EnumPlugins('iNewsroomProvider');
+		return count($aProviders) > 0;
+	}
+
+	/**
 	 * Prepare parameters for the newsroom JS widget
 	 *
 	 * @return array

--- a/sources/application/UI/Base/Component/PopoverMenu/NewsroomMenu/NewsroomMenuFactory.php
+++ b/sources/application/UI/Base/Component/PopoverMenu/NewsroomMenu/NewsroomMenuFactory.php
@@ -50,16 +50,6 @@ class NewsroomMenuFactory
 	}
 
 	/**
-	 * Check if there is any Newsroom provider configured
-	 * @return boolean
-	 */	
-	public static function HasProviders()
-	{
-		$aProviders = MetaModel::EnumPlugins('iNewsroomProvider');
-		return count($aProviders) > 0;
-	}
-
-	/**
 	 * Prepare parameters for the newsroom JS widget
 	 *
 	 * @return array

--- a/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
+++ b/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
@@ -35,6 +35,7 @@ use MetaModel;
 use UIExtKeyWidget;
 use UserRights;
 use utils;
+use Combodo\iTop\Application\UI\Base\Component\PopoverMenu\NewsroomMenu\NewsroomMenuFactory;
 
 /**
  * Class NavigationMenu
@@ -269,7 +270,7 @@ class NavigationMenu extends UIBlock implements iKeyboardShortcut
 	 */
 	public function IsNewsroomEnabled(): bool
 	{
-		return MetaModel::GetConfig()->Get('newsroom_enabled');
+		return (MetaModel::GetConfig()->Get('newsroom_enabled') && NewsroomMenuFactory::HasProviders());
 	}
 
 	/**

--- a/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
+++ b/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
@@ -35,7 +35,6 @@ use MetaModel;
 use UIExtKeyWidget;
 use UserRights;
 use utils;
-use Combodo\iTop\Application\UI\Base\Component\PopoverMenu\NewsroomMenu\NewsroomMenuFactory;
 
 /**
  * Class NavigationMenu
@@ -270,7 +269,7 @@ class NavigationMenu extends UIBlock implements iKeyboardShortcut
 	 */
 	public function IsNewsroomEnabled(): bool
 	{
-		return (MetaModel::GetConfig()->Get('newsroom_enabled') && NewsroomMenuFactory::HasProviders());
+		return (MetaModel::GetConfig()->Get('newsroom_enabled') && NewsroomMenu::HasProviders());
 	}
 
 	/**

--- a/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenuFactory.php
+++ b/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenuFactory.php
@@ -48,7 +48,7 @@ class NavigationMenuFactory
 	{
 		
 		$oNewsroomMenu = null;
-		if (MetaModel::GetConfig()->Get('newsroom_enabled'))
+		if (MetaModel::GetConfig()->Get('newsroom_enabled') && NewsroomMenuFactory::HasProviders())
 		{
 			$oNewsroomMenu = NewsroomMenuFactory::MakeNewsroomMenuForNavigationMenu();
 		}

--- a/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenuFactory.php
+++ b/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenuFactory.php
@@ -21,6 +21,7 @@ namespace Combodo\iTop\Application\UI\Base\Layout\NavigationMenu;
 
 
 use ApplicationContext;
+use Combodo\iTop\Application\UI\Base\Component\PopoverMenu\NewsroomMenu\NewsroomMenu;
 use Combodo\iTop\Application\UI\Base\Component\PopoverMenu\NewsroomMenu\NewsroomMenuFactory;
 use Combodo\iTop\Application\UI\Base\Component\PopoverMenu\PopoverMenuFactory;
 use MetaModel;
@@ -48,7 +49,7 @@ class NavigationMenuFactory
 	{
 		
 		$oNewsroomMenu = null;
-		if (MetaModel::GetConfig()->Get('newsroom_enabled') && NewsroomMenuFactory::HasProviders())
+		if (MetaModel::GetConfig()->Get('newsroom_enabled') && NewsroomMenu::HasProviders())
 		{
 			$oNewsroomMenu = NewsroomMenuFactory::MakeNewsroomMenuForNavigationMenu();
 		}


### PR DESCRIPTION
The newsroom menu can be hidden by configuration, but is not automatically hidden when there is no newsroom provider installed.
This pull request just hides the menu automatically in such a case.