### PR TITLE
N°5620 - Hide the organization filter with a conf parameter

### DIFF
--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -333,6 +333,14 @@ class Config
 			'source_of_value' => '',
 			'show_in_conf_sample' => false,
 		],
+		'allow_menu_organization_filter' => [
+			'type' => 'bool',
+			'description' => 'Display organization filter in menu',
+			'default' => true,
+			'value' => true,
+			'source_of_value' => '',
+			'show_in_conf_sample' => false,
+		],
 		'allow_target_creation' => [
 			'type' => 'bool',
 			'description' => 'Displays the + button on external keys to create target objects',
@@ -1861,7 +1869,7 @@ class Config
 		}
 		if (strlen($sNoise) > 0)
 		{
-			// Note: sNoise is an html output, but so far it was ok for me (e.g. showing the entire call stack) 
+			// Note: sNoise is an html output, but so far it was ok for me (e.g. showing the entire call stack)
 			throw new ConfigException('Syntax error in configuration file',
 				array('file' => $sConfigFile, 'error' => '<tt>'.htmlentities($sNoise, ENT_QUOTES, 'UTF-8').'</tt>'));
 		}
@@ -2671,7 +2679,7 @@ class ConfigPlaceholdersResolver
 		}
 
 		$sPattern = '/\%(env|server)\((\w+)\)(?:\?:(\w*))?\%/'; //3 capturing groups, ie `%env(HTTP_PORT)?:8080%` produce: `env` `HTTP_PORT` and `8080`.
-		
+
 		if (! preg_match_all($sPattern, $rawValue, $aMatchesCollection, PREG_SET_ORDER))
 		{
 			return $rawValue;

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -333,14 +333,6 @@ class Config
 			'source_of_value' => '',
 			'show_in_conf_sample' => false,
 		],
-		'allow_menu_organization_filter' => [
-			'type' => 'bool',
-			'description' => 'Display organization filter in menu',
-			'default' => true,
-			'value' => true,
-			'source_of_value' => '',
-			'show_in_conf_sample' => false,
-		],
 		'allow_target_creation' => [
 			'type' => 'bool',
 			'description' => 'Displays the + button on external keys to create target objects',
@@ -1241,6 +1233,14 @@ class Config
 		'navigation_menu.show_menus_count' => [
 			'type' => 'bool',
 			'description' => 'Display count badges for OQL menu entries',
+			'default' => true,
+			'value' => true,
+			'source_of_value' => '',
+			'show_in_conf_sample' => false,
+		],
+		'navigation_menu.show_organization_filter' => [
+			'type' => 'bool',
+			'description' => 'Display organization filter in menu',
 			'default' => true,
 			'value' => true,
 			'source_of_value' => '',

--- a/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
+++ b/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
@@ -196,7 +196,7 @@ class NavigationMenu extends UIBlock implements iKeyboardShortcut
 		}
 		return '';
 	}
-	
+
 	/**
 	 * @return array
 	 */
@@ -301,6 +301,11 @@ class NavigationMenu extends UIBlock implements iKeyboardShortcut
 		$this->bHasSiloSelected = false;
 		$this->sSiloLabel = null;
 
+		\IssueLog::Info("test allow_menu_organization_filter", null, ['allow_menu_organization_filter' => MetaModel::GetConfig()->Get('allow_menu_organization_filter')]);
+		if (! MetaModel::GetConfig()->Get('allow_menu_organization_filter')){
+			return;
+		}
+
 		//TODO 3.0 Use components if we have the time to build select/autocomplete components before release
 		// List of visible Organizations
 		$iCount = 0;
@@ -343,7 +348,7 @@ class NavigationMenu extends UIBlock implements iKeyboardShortcut
 				$this->aSiloSelection['html'] = '<form data-role="ibo-navigation-menu--silo-selection--form" action="'.utils::GetAbsoluteUrlAppRoot().'pages/UI.php">'; //<select class="org_combo" name="c[org_id]" title="Pick an organization" onChange="this.form.submit();">';
 
 				$oPage = new \CaptureWebPage();
-				
+
 				$oWidget = new UIExtKeyWidget('Organization', 'org_id', '', true /* search mode */);
 				$iMaxComboLength = MetaModel::GetConfig()->Get('max_combo_length');
 				$this->aSiloSelection['html'] .= $oWidget->DisplaySelect($oPage, $iMaxComboLength, false, Dict::S('UI:Layout:NavigationMenu:Silo:Label'), $oSet, $iCurrentOrganization, false, 'c[org_id]', '',
@@ -376,7 +381,7 @@ $sAddClearButton
 JS;
 		}
 	}
-	
+
 	/**
 	 * Compute if the menu is expanded or collapsed
 	 *

--- a/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
+++ b/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
@@ -289,6 +289,10 @@ class NavigationMenu extends UIBlock implements iKeyboardShortcut
 		}
 	}
 
+	/**
+	 * @return True if the silo selection is enabled, false otherwise
+	 * @since 3.1.0
+	 */
 	public function IsSiloSelectionEnabled() : bool {
 		return MetaModel::GetConfig()->Get('navigation_menu.show_organization_filter');
 	}

--- a/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
+++ b/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
@@ -301,7 +301,6 @@ class NavigationMenu extends UIBlock implements iKeyboardShortcut
 		$this->bHasSiloSelected = false;
 		$this->sSiloLabel = null;
 
-		\IssueLog::Info("test allow_menu_organization_filter", null, ['allow_menu_organization_filter' => MetaModel::GetConfig()->Get('allow_menu_organization_filter')]);
 		if (! MetaModel::GetConfig()->Get('allow_menu_organization_filter')){
 			return;
 		}

--- a/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
+++ b/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
@@ -19,7 +19,6 @@
 
 namespace Combodo\iTop\Application\UI\Base\Layout\NavigationMenu;
 
-
 use ApplicationContext;
 use ApplicationMenu;
 use appUserPreferences;
@@ -290,6 +289,10 @@ class NavigationMenu extends UIBlock implements iKeyboardShortcut
 		}
 	}
 
+	private function IsOrgMenuFilterAllowed() : bool {
+		return MetaModel::GetConfig()->Get('navigation_menu.show_organization_filter');
+	}
+
 	/**
 	 * @return void
 	 * @throws \CoreException
@@ -301,7 +304,7 @@ class NavigationMenu extends UIBlock implements iKeyboardShortcut
 		$this->bHasSiloSelected = false;
 		$this->sSiloLabel = null;
 
-		if (! MetaModel::GetConfig()->Get('allow_menu_organization_filter')){
+		if (! $this->IsOrgMenuFilterAllowed()){
 			return;
 		}
 

--- a/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
+++ b/sources/application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
@@ -289,7 +289,7 @@ class NavigationMenu extends UIBlock implements iKeyboardShortcut
 		}
 	}
 
-	private function IsOrgMenuFilterAllowed() : bool {
+	public function IsSiloSelectionEnabled() : bool {
 		return MetaModel::GetConfig()->Get('navigation_menu.show_organization_filter');
 	}
 
@@ -304,7 +304,7 @@ class NavigationMenu extends UIBlock implements iKeyboardShortcut
 		$this->bHasSiloSelected = false;
 		$this->sSiloLabel = null;
 
-		if (! $this->IsOrgMenuFilterAllowed()){
+		if (! $this->IsSiloSelectionEnabled()){
 			return;
 		}
 

--- a/test/ItopDataTestCase.php
+++ b/test/ItopDataTestCase.php
@@ -415,6 +415,20 @@ class ItopDataTestCase extends ItopTestCase
 	 */
 	protected function CreateUser($sLogin, $iProfileId, $sPassword=null, $iContactid=2)
 	{
+		$oUser = $this->CreateContactlessUser($sLogin, $iProfileId, $sPassword);
+		$oUser->Set('contactid', $iContactid);
+		return $oUser;
+	}
+
+	/**
+	 * @param string $sLogin
+	 * @param int $iProfileId
+	 *
+	 * @return \DBObject
+	 * @throws Exception
+	 */
+	protected function CreateContactlessUser($sLogin, $iProfileId, $sPassword=null)
+	{
 		if (empty($sPassword)){
 			$sPassword = $sLogin;
 		}
@@ -424,7 +438,6 @@ class ItopDataTestCase extends ItopTestCase
 		$oUserProfile->Set('reason', 'UNIT Tests');
 		$oSet = DBObjectSet::FromObject($oUserProfile);
 		$oUser = $this->createObject('UserLocal', array(
-			'contactid' => $iContactid,
 			'login' => $sLogin,
 			'password' => $sPassword,
 			'language' => 'EN US',

--- a/test/ItopDataTestCase.php
+++ b/test/ItopDataTestCase.php
@@ -410,13 +410,14 @@ class ItopDataTestCase extends ItopTestCase
 	 * @param string $sLogin
 	 * @param int $iProfileId
 	 *
-	 * @return \DBObject
+	 * @return \UserLocal
 	 * @throws Exception
 	 */
 	protected function CreateUser($sLogin, $iProfileId, $sPassword=null, $iContactid=2)
 	{
 		$oUser = $this->CreateContactlessUser($sLogin, $iProfileId, $sPassword);
 		$oUser->Set('contactid', $iContactid);
+		$oUser->DBWrite();
 		return $oUser;
 	}
 
@@ -424,7 +425,7 @@ class ItopDataTestCase extends ItopTestCase
 	 * @param string $sLogin
 	 * @param int $iProfileId
 	 *
-	 * @return \DBObject
+	 * @return \UserLocal
 	 * @throws Exception
 	 */
 	protected function CreateContactlessUser($sLogin, $iProfileId, $sPassword=null)
@@ -437,6 +438,7 @@ class ItopDataTestCase extends ItopTestCase
 		$oUserProfile->Set('profileid', $iProfileId);
 		$oUserProfile->Set('reason', 'UNIT Tests');
 		$oSet = DBObjectSet::FromObject($oUserProfile);
+		/** @var \UserLocal $oUser */
 		$oUser = $this->createObject('UserLocal', array(
 			'login' => $sLogin,
 			'password' => $sPassword,

--- a/test/application/UI/Base/Layout/NavigationMenuTest.php
+++ b/test/application/UI/Base/Layout/NavigationMenuTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace UI\Base\Layout;
+
+use ApplicationContext;
+use Combodo\iTop\Application\UI\Base\Component\PopoverMenu\PopoverMenu;
+use Combodo\iTop\Application\UI\Base\Layout\NavigationMenu\NavigationMenu;
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+
+class NavigationMenuTest extends ItopDataTestCase {
+	private $oConfigToRestore;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+		require_once(APPROOT.'application/themehandler.class.inc.php');
+		$this->oConfigToRestore = null;
+	}
+
+	public function tearDown(): void
+	{
+		if (! is_null($this->oConfigToRestore)){
+			$oReflexionClass = new \ReflectionClass(\MetaModel::class);
+			$oReflexionClass->setStaticPropertyValue('m_oConfig', $this->oConfigToRestore);
+		}
+	}
+
+	public function IsAllowedProvider(){
+		return [
+			'show menu' => [ true ],
+			'hide menu' => [ false ],
+		];
+	}
+
+	/**
+	 * @dataProvider IsAllowedProvider
+	 * test used to make sure backward compatibility is ensured
+	 */
+	public function testIsAllowed($bExpectedIsAllowed=true){
+		\MetaModel::GetConfig()->Set('navigation_menu.show_organization_filter', $bExpectedIsAllowed);
+		$oNavigationMenu = new NavigationMenu(
+			$this->createMock(ApplicationContext::class),
+			$this->createMock(PopoverMenu::class));
+
+		$isAllowed = $this->InvokeNonPublicMethod(NavigationMenu::class, "IsOrgMenuFilterAllowed", $oNavigationMenu, []);
+		$this->assertEquals($bExpectedIsAllowed, $isAllowed);
+	}
+
+	public function testIsAllowedWithNoConfVariable(){
+		\MetaModel::GetConfig()->Set('navigation_menu.show_organization_filter', false);
+
+		$sTmpFilePath = tempnam(sys_get_temp_dir(), 'test_');
+		$oInitConfig = \MetaModel::GetConfig();
+		$oInitConfig->WriteToFile($sTmpFilePath);
+
+		//remove variable for the test
+		$aLines = file($sTmpFilePath);
+
+		$aRows = array();
+
+		foreach ($aLines as $key => $sLine) {
+			if (!preg_match('/navigation_menu.show_organization_filter/', $sLine)) {
+				$aRows[] = $sLine;
+			}
+		}
+
+		file_put_contents($sTmpFilePath, implode("\n", $aRows));
+		$oTempConfig = new \Config($sTmpFilePath);
+
+		$this->oConfigToRestore = $oInitConfig;
+		$oReflexionClass = new \ReflectionClass(\MetaModel::class);
+		$oReflexionClass->setStaticPropertyValue('m_oConfig', $oTempConfig);
+
+		$oNavigationMenu = new NavigationMenu(
+			$this->createMock(ApplicationContext::class),
+			$this->createMock(PopoverMenu::class)
+		);
+
+		$isAllowed = $this->InvokeNonPublicMethod(NavigationMenu::class, "IsOrgMenuFilterAllowed", $oNavigationMenu, []);
+		$this->assertEquals(true, $isAllowed);
+	}
+}

--- a/test/application/UI/Base/Layout/NavigationMenuTest.php
+++ b/test/application/UI/Base/Layout/NavigationMenuTest.php
@@ -32,7 +32,7 @@ class NavigationMenuTest extends ItopDataTestCase {
 			$this->createMock(ApplicationContext::class),
 			$this->createMock(PopoverMenu::class));
 
-		$isAllowed = $this->InvokeNonPublicMethod(NavigationMenu::class, "IsOrgMenuFilterAllowed", $oNavigationMenu, []);
+		$isAllowed = $oNavigationMenu->IsSiloSelectionEnabled();
 		$this->assertEquals($bExpectedIsAllowed, $isAllowed);
 	}
 
@@ -65,7 +65,7 @@ class NavigationMenuTest extends ItopDataTestCase {
 			$this->createMock(PopoverMenu::class)
 		);
 
-		$isAllowed = $this->InvokeNonPublicMethod(NavigationMenu::class, "IsOrgMenuFilterAllowed", $oNavigationMenu, []);
+		$isAllowed = $oNavigationMenu->IsSiloSelectionEnabled();
 		$oReflexionClass->setStaticPropertyValue('m_oConfig', $oInitConfig);
 
 		$this->assertEquals(true, $isAllowed);

--- a/test/application/UI/Base/Layout/NavigationMenuTest.php
+++ b/test/application/UI/Base/Layout/NavigationMenuTest.php
@@ -8,21 +8,11 @@ use Combodo\iTop\Application\UI\Base\Layout\NavigationMenu\NavigationMenu;
 use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
 
 class NavigationMenuTest extends ItopDataTestCase {
-	private $oConfigToRestore;
 
 	public function setUp(): void
 	{
 		parent::setUp();
 		require_once(APPROOT.'application/themehandler.class.inc.php');
-		$this->oConfigToRestore = null;
-	}
-
-	public function tearDown(): void
-	{
-		if (! is_null($this->oConfigToRestore)){
-			$oReflexionClass = new \ReflectionClass(\MetaModel::class);
-			$oReflexionClass->setStaticPropertyValue('m_oConfig', $this->oConfigToRestore);
-		}
 	}
 
 	public function IsAllowedProvider(){
@@ -67,7 +57,6 @@ class NavigationMenuTest extends ItopDataTestCase {
 		file_put_contents($sTmpFilePath, implode("\n", $aRows));
 		$oTempConfig = new \Config($sTmpFilePath);
 
-		$this->oConfigToRestore = $oInitConfig;
 		$oReflexionClass = new \ReflectionClass(\MetaModel::class);
 		$oReflexionClass->setStaticPropertyValue('m_oConfig', $oTempConfig);
 
@@ -77,6 +66,8 @@ class NavigationMenuTest extends ItopDataTestCase {
 		);
 
 		$isAllowed = $this->InvokeNonPublicMethod(NavigationMenu::class, "IsOrgMenuFilterAllowed", $oNavigationMenu, []);
+		$oReflexionClass->setStaticPropertyValue('m_oConfig', $oInitConfig);
+
 		$this->assertEquals(true, $isAllowed);
 	}
 }

--- a/test/application/UI/Base/Layout/NavigationMenuTest.php
+++ b/test/application/UI/Base/Layout/NavigationMenuTest.php
@@ -7,14 +7,16 @@ use Combodo\iTop\Application\UI\Base\Component\PopoverMenu\PopoverMenu;
 use Combodo\iTop\Application\UI\Base\Layout\NavigationMenu\NavigationMenu;
 use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
 
+/**
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ * @backupGlobals disabled
+ * Class NavigationMenuTest
+ *
+ * @package UI\Base\Layout
+ */
 class NavigationMenuTest extends ItopDataTestCase {
-
-	public function setUp(): void
-	{
-		parent::setUp();
-		require_once(APPROOT.'application/themehandler.class.inc.php');
-	}
-
 	public function IsAllowedProvider(){
 		return [
 			'show menu' => [ true ],

--- a/test/application/UI/Base/Layout/NavigationMenuTest.php
+++ b/test/application/UI/Base/Layout/NavigationMenuTest.php
@@ -36,7 +36,7 @@ class NavigationMenuTest extends ItopDataTestCase {
 		$this->assertEquals($bExpectedIsAllowed, $isAllowed);
 	}
 
-	public function testIsAllowedWithNoConfVariable(){
+	public function testIsAllowed_BackwardCompatibility_NoVariableInConfFile(){
 		\MetaModel::GetConfig()->Set('navigation_menu.show_organization_filter', false);
 
 		$sTmpFilePath = tempnam(sys_get_temp_dir(), 'test_');
@@ -57,17 +57,9 @@ class NavigationMenuTest extends ItopDataTestCase {
 		file_put_contents($sTmpFilePath, implode("\n", $aRows));
 		$oTempConfig = new \Config($sTmpFilePath);
 
-		$oReflexionClass = new \ReflectionClass(\MetaModel::class);
-		$oReflexionClass->setStaticPropertyValue('m_oConfig', $oTempConfig);
-
-		$oNavigationMenu = new NavigationMenu(
-			$this->createMock(ApplicationContext::class),
-			$this->createMock(PopoverMenu::class)
-		);
-
-		$isAllowed = $oNavigationMenu->IsSiloSelectionEnabled();
-		$oReflexionClass->setStaticPropertyValue('m_oConfig', $oInitConfig);
+		$isAllowed = $oTempConfig->Get('navigation_menu.show_organization_filter');
 
 		$this->assertEquals(true, $isAllowed);
+		unlink($sTmpFilePath);
 	}
 }


### PR DESCRIPTION
This enhancement helps hiding menu organization filter via configuration variable.

By default this UI part is visible:
![image](https://user-images.githubusercontent.com/56586767/202207622-dc49e014-c3e7-4566-a020-91cf16bd5527.png)

for backward compatibility reason this is the default behaviour. ie if this new option is not set or set to true.

 To remove it set 'allow_menu_organization_filter' to false.
![image](https://user-images.githubusercontent.com/56586767/202207799-f039c944-8567-4822-8ac8-2a3142a51978.png)
