### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ local.properties
 
 # Windows
 Thumbs.db
+
+# vi
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -153,5 +153,3 @@ local.properties
 # Windows
 Thumbs.db
 
-# vi
-*~

--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,9 @@ local.properties
 .cache-main
 .scala_dependencies
 .worksheet
+
+# Mac
+.DS_Store
+
+# Windows
+Thumbs.db


### PR DESCRIPTION
It's a discussion started with @Hipska at PR #362 and I decided to open this PR to bother Hipska (LOL) and because I believe this change should be part of iTop project.
I know it can be added to the global ``.gitignore`` file, but newer contributes may not have these entries in their machine and commit unuseful codes to the iTop branch.
If these entries should be set in every global ``.gitignore`` files of every contributor around the world, following the same logic of Hipska, please remove the specific IDE entries because every developers that uses them must have it added to their global ``.gitignore`` file. Why don't we remove ``.gitignore`` file at all and follow the principle that everyone will have their global ``.gitignore`` file properly set?