### PR TITLE
N°5074 - Linkset datatable actions row improvements

### DIFF
--- a/dictionaries/en.dictionary.itop.ui.php
+++ b/dictionaries/en.dictionary.itop.ui.php
@@ -383,7 +383,7 @@ Dict::Add('EN US', 'English', 'English', array(
 <li>Manage the most important asset of your IT: Documentation.</li>
 </ul>
 </p>',
-	'UI:WelcomeMenu:Text'=> '<div>Congratulations, you landed on '.ITOP_APPLICATION.' '.ITOP_VERSION_NAME.'!</div>
+	'UI:WelcomeMenu:Text' => '<div>Congratulations, you landed on '.ITOP_APPLICATION.' '.ITOP_VERSION_NAME.'!</div>
 
 <div>This version features a brand new modern and accessible backoffice design.</div>
 
@@ -404,6 +404,7 @@ We hope you’ll enjoy this version as much as we enjoyed imagining and creating
 	'UI:Button:GlobalSearch' => 'Search',
 	'UI:Button:Search' => ' Search ',
 	'UI:Button:Clear' => ' Clear ',
+	'UI:Button:Confirm' => ' Confirm ',
 	'UI:Button:SearchInHierarchy' => 'Search in hierarchy',
 	'UI:Button:Query' => ' Query ',
 	'UI:Button:Ok' => 'Ok',

--- a/dictionaries/fr.dictionary.itop.ui.php
+++ b/dictionaries/fr.dictionary.itop.ui.php
@@ -367,7 +367,7 @@ Dict::Add('FR FR', 'French', 'Français', array(
 <li>Contrôlez l\'actif le plus important de votre SI&nbsp;: la documentation.</li>
 </ul>
 </p>',
-	'UI:WelcomeMenu:Text'=> '<div>Félicitations, vous avez atterri sur '.ITOP_APPLICATION.' '.ITOP_VERSION_NAME.' !</div>
+	'UI:WelcomeMenu:Text' => '<div>Félicitations, vous avez atterri sur '.ITOP_APPLICATION.' '.ITOP_VERSION_NAME.' !</div>
 
 <div>Cette version présente un tout nouveau design moderne et accessible pour la console de support.</div>
 
@@ -388,6 +388,7 @@ Nous espérons que vous aimerez cette version autant que nous avons eu du plaisi
 	'UI:Button:GlobalSearch' => 'Rechercher',
 	'UI:Button:Search' => 'Rechercher',
 	'UI:Button:Clear' => ' Clear ~~',
+	'UI:Button:Confirm' => 'Confirmer',
 	'UI:Button:SearchInHierarchy' => 'Rechercher dans la hiérarchie',
 	'UI:Button:Query' => ' Lancer la requête ',
 	'UI:Button:Ok' => 'Ok',

--- a/dictionaries/ui/application/links/en.dictionary.itop.links.php
+++ b/dictionaries/ui/application/links/en.dictionary.itop.links.php
@@ -19,10 +19,10 @@
 
 // Display DataTable
 Dict::Add('EN US', 'English', 'English', array(
-	'UI:Links:ActionRow:detach'              => 'Detach',
-	'UI:Links:ActionRow:detach+'             => 'Detach this object',
-	'UI:Links:ActionRow:detach:confirmation' => 'Do you really want to detach <b>{item}</b> from current object ?',
-	'UI:Links:ActionRow:delete'              => 'Delete',
-	'UI:Links:ActionRow:delete+'             => 'Delete this object',
-	'UI:Links:ActionRow:delete:confirmation' => 'Do you really want to delete <b>{item}</b> from current object ?',
+	'UI:Links:ActionRow:Detach'              => 'Detach',
+	'UI:Links:ActionRow:Detach+'             => 'Detach this object',
+	'UI:Links:ActionRow:Detach:Confirmation' => 'Do you really want to detach <b>{item}</b> from current object ?',
+	'UI:Links:ActionRow:Delete'              => 'Delete',
+	'UI:Links:ActionRow:Delete+'             => 'Delete this object',
+	'UI:Links:ActionRow:Delete:Confirmation' => 'Do you really want to delete <b>{item}</b> from current object ?',
 ));

--- a/dictionaries/ui/application/links/fr.dictionary.itop.links.php
+++ b/dictionaries/ui/application/links/fr.dictionary.itop.links.php
@@ -18,11 +18,11 @@
  */
 
 // Display DataTable
-Dict::Add('EN US', 'English', 'English', array(
-	'UI:Links:ActionRow:detach'              => 'Detach',
-	'UI:Links:ActionRow:detach+'             => 'Detach this object',
-	'UI:Links:ActionRow:detach:confirmation' => 'Do you really want to detach <b>{item}</b> from current object ?',
-	'UI:Links:ActionRow:delete'              => 'Delete',
-	'UI:Links:ActionRow:delete+'             => 'Delete this object',
-	'UI:Links:ActionRow:delete:confirmation' => 'Do you really want to delete <b>{item}</b> from current object ?',
+Dict::Add('FR FR', 'French', 'Français', array(
+	'UI:Links:ActionRow:detach'              => 'Détacher',
+	'UI:Links:ActionRow:detach+'             => 'Détacher cet objet',
+	'UI:Links:ActionRow:detach:confirmation' => 'Voulez-vous détacher <b>{item}</b> de l\'objet courant ?',
+	'UI:Links:ActionRow:delete'              => 'Supprimer',
+	'UI:Links:ActionRow:delete+'             => 'Supprimer cet objet',
+	'UI:Links:ActionRow:delete:confirmation' => 'Voulez-vous supprimer <b>{item}</b> de l\'objet courant ?',
 ));

--- a/dictionaries/ui/application/links/fr.dictionary.itop.links.php
+++ b/dictionaries/ui/application/links/fr.dictionary.itop.links.php
@@ -19,10 +19,10 @@
 
 // Display DataTable
 Dict::Add('FR FR', 'French', 'Français', array(
-	'UI:Links:ActionRow:detach'              => 'Détacher',
-	'UI:Links:ActionRow:detach+'             => 'Détacher cet objet',
-	'UI:Links:ActionRow:detach:confirmation' => 'Voulez-vous détacher <b>{item}</b> de l\'objet courant ?',
-	'UI:Links:ActionRow:delete'              => 'Supprimer',
-	'UI:Links:ActionRow:delete+'             => 'Supprimer cet objet',
-	'UI:Links:ActionRow:delete:confirmation' => 'Voulez-vous supprimer <b>{item}</b> de l\'objet courant ?',
+	'UI:Links:ActionRow:Detach'              => 'Détacher',
+	'UI:Links:ActionRow:Detach+'             => 'Détacher cet objet',
+	'UI:Links:ActionRow:Detach:Confirmation' => 'Voulez-vous détacher <b>{item}</b> de l\'objet courant ?',
+	'UI:Links:ActionRow:Delete'              => 'Supprimer',
+	'UI:Links:ActionRow:Delete+'             => 'Supprimer cet objet',
+	'UI:Links:ActionRow:Delete:Confirmation' => 'Voulez-vous supprimer <b>{item}</b> de l\'objet courant ?',
 ));

--- a/js/linksdirectwidget.js
+++ b/js/linksdirectwidget.js
@@ -652,6 +652,10 @@ $(function()
 				}
 			}
 			return aRes;
+		},
+		Remove: function(oCheckbox)  // for public access
+		{
+			this._removeRow(oCheckbox);
 		}
 	});	
 });

--- a/js/pages/backoffice/toolbox.js
+++ b/js/pages/backoffice/toolbox.js
@@ -370,6 +370,7 @@ CombodoModal.OpenConfirmationModal = function(oOptions, aData) {
 	oOptions = $.extend({
 		title: Dict.S('UI:Modal:DefaultConfirmationTitle'),
 		content: '',
+		confirm_button_text: null,
 		do_not_show_again_pref_key: null,
 		callback_on_confirm: null,
 		callback_on_cancel: null,
@@ -394,7 +395,7 @@ CombodoModal.OpenConfirmationModal = function(oOptions, aData) {
 				}
 			},
 			{
-				text: Dict.S('UI:Button:Ok'),
+				text: oOptions.confirm_button_text != null ? oOptions.confirm_button_text : Dict.S('UI:Button:Confirm'),
 				class: 'ibo-is-primary',
 				callback_on_click: function () {
 					// Call confirm handler and close dialog

--- a/js/pages/backoffice/toolbox.js
+++ b/js/pages/backoffice/toolbox.js
@@ -370,7 +370,7 @@ CombodoModal.OpenConfirmationModal = function(oOptions, aData) {
 	oOptions = $.extend({
 		title: Dict.S('UI:Modal:DefaultConfirmationTitle'),
 		content: '',
-		confirm_button_text: null,
+		confirm_button_label: null,
 		do_not_show_again_pref_key: null,
 		callback_on_confirm: null,
 		callback_on_cancel: null,
@@ -395,7 +395,7 @@ CombodoModal.OpenConfirmationModal = function(oOptions, aData) {
 				}
 			},
 			{
-				text: oOptions.confirm_button_text != null ? oOptions.confirm_button_text : Dict.S('UI:Button:Confirm'),
+				text: oOptions.confirm_button_label != null ? oOptions.confirm_button_label : Dict.S('UI:Button:Confirm'),
 				class: 'ibo-is-primary',
 				callback_on_click: function () {
 					// Call confirm handler and close dialog

--- a/js/pages/backoffice/toolbox.js
+++ b/js/pages/backoffice/toolbox.js
@@ -395,7 +395,7 @@ CombodoModal.OpenConfirmationModal = function(oOptions, aData) {
 				}
 			},
 			{
-				text: oOptions.confirm_button_label != null ? oOptions.confirm_button_label : Dict.S('UI:Button:Confirm'),
+				text: oOptions.confirm_button_label ?? Dict.S('UI:Button:Confirm'),
 				class: 'ibo-is-primary',
 				callback_on_click: function () {
 					// Call confirm handler and close dialog

--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -337,6 +337,7 @@ try
 					}
 				}
 				$oWidget = new UILinksWidgetDirect($sClass, $sAttCode, $iInputId);
+				$oFullSetFilter->SetShowObsoleteData(utils::ShowObsoleteData());
 				$oWidget->DoAddObjects($oPage, $oFullSetFilter);
 				break;
 

--- a/sources/Application/UI/Base/Component/DataTable/DataTableUIBlockFactory.php
+++ b/sources/Application/UI/Base/Component/DataTable/DataTableUIBlockFactory.php
@@ -214,7 +214,7 @@ class DataTableUIBlockFactory extends AbstractUIBlockFactory
 				array_key_exists('tooltip', $aAction) ? Dict::S($aAction['tooltip']) : '',
 				array_key_exists('name', $aAction) ? $aAction['name'] : 'undefined'
 			);
-			$oButton->SetDataAttributes(['action' => Dict::S($aAction['action']), 'action-id' => $iKey, 'table-id' => $oTable->GetId()]);
+			$oButton->SetDataAttributes(['label' => Dict::S($aAction['label']), 'action-id' => $iKey, 'table-id' => $oTable->GetId()]);
 			$oToolbar->AddSubBlock($oButton);
 		}
 

--- a/sources/Application/UI/Base/Component/DataTable/DataTableUIBlockFactory.php
+++ b/sources/Application/UI/Base/Component/DataTable/DataTableUIBlockFactory.php
@@ -214,7 +214,7 @@ class DataTableUIBlockFactory extends AbstractUIBlockFactory
 				array_key_exists('tooltip', $aAction) ? Dict::S($aAction['tooltip']) : '',
 				array_key_exists('name', $aAction) ? $aAction['name'] : 'undefined'
 			);
-			$oButton->SetDataAttributes(['action-id' => $iKey, 'table-id' => $oTable->GetId()]);
+			$oButton->SetDataAttributes(['action' => Dict::S($aAction['action']), 'action-id' => $iKey, 'table-id' => $oTable->GetId()]);
 			$oToolbar->AddSubBlock($oButton);
 		}
 

--- a/sources/Application/UI/Base/Component/DataTable/tTableRowActions.php
+++ b/sources/Application/UI/Base/Component/DataTable/tTableRowActions.php
@@ -25,6 +25,7 @@ trait tTableRowActions
 	/**
 	 * @var $aRowActions array array of row actions
 	 * action => {
+	 *      action: string,
 	 *      tooltip: string,
 	 *      icon_classes: string,
 	 *      js_row_action: string,

--- a/sources/Application/UI/Base/Component/DataTable/tTableRowActions.php
+++ b/sources/Application/UI/Base/Component/DataTable/tTableRowActions.php
@@ -25,7 +25,7 @@ trait tTableRowActions
 	/**
 	 * @var $aRowActions array array of row actions
 	 * action => {
-	 *      action: string,
+	 *      label: string,
 	 *      tooltip: string,
 	 *      icon_classes: string,
 	 *      js_row_action: string,

--- a/sources/Application/UI/Links/AbstractBlockLinksViewTable.php
+++ b/sources/Application/UI/Links/AbstractBlockLinksViewTable.php
@@ -135,6 +135,26 @@ abstract class AbstractBlockLinksViewTable extends UIContentBlock
 	}
 
 	/**
+	 * GetTableId.
+	 *
+	 * @return string table identifier
+	 */
+	protected function GetTableId()
+	{
+		return $this->sObjectClass.'_'.$this->sAttCode;
+	}
+
+	/**
+	 * GetDoNotShowAgainPreferenceKey.
+	 *
+	 * @return string do not show again preference key
+	 */
+	protected function GetDoNotShowAgainPreferenceKey()
+	{
+		return "{$this->GetTableId()}.remove_link.do_not_show_again";
+	}
+
+	/**
 	 * GetExtraParam.
 	 *
 	 * Provide parameters for display block as list.

--- a/sources/Application/UI/Links/AbstractBlockLinksViewTable.php
+++ b/sources/Application/UI/Links/AbstractBlockLinksViewTable.php
@@ -139,7 +139,7 @@ abstract class AbstractBlockLinksViewTable extends UIContentBlock
 	 *
 	 * @return string table identifier
 	 */
-	protected function GetTableId()
+	protected function GetTableId(): string
 	{
 		return $this->sObjectClass.'_'.$this->sAttCode;
 	}

--- a/sources/Application/UI/Links/AbstractBlockLinksViewTable.php
+++ b/sources/Application/UI/Links/AbstractBlockLinksViewTable.php
@@ -149,7 +149,7 @@ abstract class AbstractBlockLinksViewTable extends UIContentBlock
 	 *
 	 * @return string do not show again preference key
 	 */
-	protected function GetDoNotShowAgainPreferenceKey()
+	protected function GetDoNotShowAgainPreferenceKey(): string
 	{
 		return "{$this->GetTableId()}.remove_link.do_not_show_again";
 	}

--- a/sources/Application/UI/Links/Direct/BlockDirectLinksEditTable.php
+++ b/sources/Application/UI/Links/Direct/BlockDirectLinksEditTable.php
@@ -242,7 +242,7 @@ class BlockDirectLinksEditTable extends UIContentBlock
 
 				case LINKSET_RELATIONTYPE_LINK:
 					$aRowActions[] = array(
-						'action'        => 'UI:Links:ActionRow:detach',
+						'label'         => 'UI:Links:ActionRow:detach',
 						'tooltip'       => 'UI:Links:ActionRow:detach+',
 						'icon_classes'  => 'fas fa-minus',
 						'js_row_action' => "$('#{$this->oUILinksDirectWidget->GetInputId()}').directlinks('Remove', $(':checkbox', oTrElement));",
@@ -251,7 +251,7 @@ class BlockDirectLinksEditTable extends UIContentBlock
 
 				case LINKSET_RELATIONTYPE_PROPERTY:
 					$aRowActions[] = array(
-						'action'        => 'UI:Links:ActionRow:delete',
+						'label'         => 'UI:Links:ActionRow:delete',
 						'tooltip'       => 'UI:Links:ActionRow:delete+',
 						'icon_classes'  => 'fas fa-trash',
 						'js_row_action' => "$('#{$this->oUILinksDirectWidget->GetInputId()}').directlinks('Remove', $(':checkbox', oTrElement));",

--- a/sources/Application/UI/Links/Direct/BlockDirectLinksEditTable.php
+++ b/sources/Application/UI/Links/Direct/BlockDirectLinksEditTable.php
@@ -237,11 +237,27 @@ class BlockDirectLinksEditTable extends UIContentBlock
 		$aRowActions = array();
 
 		if (!$this->oAttributeLinkedSet->GetReadOnly()) {
-			$aRowActions[] = array(
-				'tooltip'       => 'remove link',
-				'icon_classes'  => 'fas fa-minus',
-				'js_row_action' => "$('#{$this->oUILinksDirectWidget->GetInputId()}').directlinks('instance')._deleteRow($(':checkbox', oTrElement));",
-			);
+
+			switch ($this->oAttributeLinkedSet->GetRelationType()) {
+
+				case LINKSET_RELATIONTYPE_LINK:
+					$aRowActions[] = array(
+						'action'        => 'UI:Links:ActionRow:detach',
+						'tooltip'       => 'UI:Links:ActionRow:detach+',
+						'icon_classes'  => 'fas fa-minus',
+						'js_row_action' => "$('#{$this->oUILinksDirectWidget->GetInputId()}').directlinks('instance')._removeRow($(':checkbox', oTrElement));",
+					);
+					break;
+
+				case LINKSET_RELATIONTYPE_PROPERTY:
+					$aRowActions[] = array(
+						'action'        => 'UI:Links:ActionRow:delete',
+						'tooltip'       => 'UI:Links:ActionRow:delete+',
+						'icon_classes'  => 'fas fa-trash',
+						'js_row_action' => "$('#{$this->oUILinksDirectWidget->GetInputId()}').directlinks('instance')._deleteRow($(':checkbox', oTrElement));",
+					);
+					break;
+			}
 		}
 
 		return $aRowActions;

--- a/sources/Application/UI/Links/Direct/BlockDirectLinksEditTable.php
+++ b/sources/Application/UI/Links/Direct/BlockDirectLinksEditTable.php
@@ -236,12 +236,28 @@ class BlockDirectLinksEditTable extends UIContentBlock
 	{
 		$aRowActions = array();
 
-		if (!$this->oAttributeLinkedSet->GetReadOnly()) {
-			$aRowActions[] = array(
-				'tooltip'       => 'remove link',
-				'icon_classes'  => 'fas fa-minus',
-				'js_row_action' => "$('#{$this->oUILinksDirectWidget->GetInputId()}').directlinks('instance')._deleteRow($(':checkbox', oTrElement));",
-			);
+		if (!$this->oAttDef->GetReadOnly()) {
+
+			switch ($this->oAttDef->GetRelationType()) {
+
+				case LINKSET_RELATIONTYPE_LINK:
+					$aRowActions[] = array(
+						'action'        => 'UI:Links:ActionRow:detach',
+						'tooltip'       => 'UI:Links:ActionRow:detach+',
+						'icon_classes'  => 'fas fa-minus',
+						'js_row_action' => "$('#{$this->oUILinksDirectWidget->GetInputId()}').directlinks('instance')._removeRow($(':checkbox', oTrElement));",
+					);
+					break;
+
+				case LINKSET_RELATIONTYPE_PROPERTY:
+					$aRowActions[] = array(
+						'action'        => 'UI:Links:ActionRow:delete',
+						'tooltip'       => 'UI:Links:ActionRow:delete+',
+						'icon_classes'  => 'fas fa-trash',
+						'js_row_action' => "$('#{$this->oUILinksDirectWidget->GetInputId()}').directlinks('instance')._deleteRow($(':checkbox', oTrElement));",
+					);
+					break;
+			}
 		}
 
 		return $aRowActions;

--- a/sources/Application/UI/Links/Direct/BlockDirectLinksEditTable.php
+++ b/sources/Application/UI/Links/Direct/BlockDirectLinksEditTable.php
@@ -245,7 +245,7 @@ class BlockDirectLinksEditTable extends UIContentBlock
 						'action'        => 'UI:Links:ActionRow:detach',
 						'tooltip'       => 'UI:Links:ActionRow:detach+',
 						'icon_classes'  => 'fas fa-minus',
-						'js_row_action' => "$('#{$this->oUILinksDirectWidget->GetInputId()}').directlinks('instance')._removeRow($(':checkbox', oTrElement));",
+						'js_row_action' => "$('#{$this->oUILinksDirectWidget->GetInputId()}').directlinks('Remove', $(':checkbox', oTrElement));",
 					);
 					break;
 
@@ -254,7 +254,7 @@ class BlockDirectLinksEditTable extends UIContentBlock
 						'action'        => 'UI:Links:ActionRow:delete',
 						'tooltip'       => 'UI:Links:ActionRow:delete+',
 						'icon_classes'  => 'fas fa-trash',
-						'js_row_action' => "$('#{$this->oUILinksDirectWidget->GetInputId()}').directlinks('instance')._deleteRow($(':checkbox', oTrElement));",
+						'js_row_action' => "$('#{$this->oUILinksDirectWidget->GetInputId()}').directlinks('Remove', $(':checkbox', oTrElement));",
 					);
 					break;
 			}

--- a/sources/Application/UI/Links/Direct/BlockDirectLinksEditTable.php
+++ b/sources/Application/UI/Links/Direct/BlockDirectLinksEditTable.php
@@ -242,8 +242,8 @@ class BlockDirectLinksEditTable extends UIContentBlock
 
 				case LINKSET_RELATIONTYPE_LINK:
 					$aRowActions[] = array(
-						'label'         => 'UI:Links:ActionRow:detach',
-						'tooltip'       => 'UI:Links:ActionRow:detach+',
+						'label'         => 'UI:Links:ActionRow:Detach',
+						'tooltip'       => 'UI:Links:ActionRow:Detach+',
 						'icon_classes'  => 'fas fa-minus',
 						'js_row_action' => "$('#{$this->oUILinksDirectWidget->GetInputId()}').directlinks('Remove', $(':checkbox', oTrElement));",
 					);
@@ -251,8 +251,8 @@ class BlockDirectLinksEditTable extends UIContentBlock
 
 				case LINKSET_RELATIONTYPE_PROPERTY:
 					$aRowActions[] = array(
-						'label'         => 'UI:Links:ActionRow:delete',
-						'tooltip'       => 'UI:Links:ActionRow:delete+',
+						'label'         => 'UI:Links:ActionRow:Delete',
+						'tooltip'       => 'UI:Links:ActionRow:Delete+',
 						'icon_classes'  => 'fas fa-trash',
 						'js_row_action' => "$('#{$this->oUILinksDirectWidget->GetInputId()}').directlinks('Remove', $(':checkbox', oTrElement));",
 					);

--- a/sources/Application/UI/Links/Direct/BlockDirectLinksViewTable.php
+++ b/sources/Application/UI/Links/Direct/BlockDirectLinksViewTable.php
@@ -35,7 +35,7 @@ class BlockDirectLinksViewTable extends AbstractBlockLinksViewTable
 			'object_id'   => $this->oDbObject->GetKey(),
 			'menu'        => MetaModel::GetConfig()->Get('allow_menu_on_linkset'),
 			'default'     => $this->GetDefault(),
-			'table_id'    => $this->sObjectClass.'_'.$this->sAttCode,
+			'table_id'    => $this->GetTableId(),
 			'row_actions' => $this->GetRowActions(),
 		);
 	}
@@ -58,7 +58,7 @@ class BlockDirectLinksViewTable extends AbstractBlockLinksViewTable
 						'confirmation'  => [
 							'message'                    => 'UI:Links:ActionRow:detach:confirmation',
 							'message_row_data'           => "{$this->sTargetClass}/hyperlink",
-							'do_not_show_again_pref_key' => 'LinkSetWorker.DetachLinkedObject',
+							'do_not_show_again_pref_key' => $this->GetDoNotShowAgainPreferenceKey(),
 						],
 					);
 					break;
@@ -72,7 +72,7 @@ class BlockDirectLinksViewTable extends AbstractBlockLinksViewTable
 						'confirmation'  => [
 							'message'                    => 'UI:Links:ActionRow:delete:confirmation',
 							'message_row_data'           => "{$this->sTargetClass}/hyperlink",
-							'do_not_show_again_pref_key' => 'LinkSetWorker.DeleteLinkedObject',
+							'do_not_show_again_pref_key' => $this->GetDoNotShowAgainPreferenceKey(),
 						],
 					);
 					break;

--- a/sources/Application/UI/Links/Direct/BlockDirectLinksViewTable.php
+++ b/sources/Application/UI/Links/Direct/BlockDirectLinksViewTable.php
@@ -51,7 +51,8 @@ class BlockDirectLinksViewTable extends AbstractBlockLinksViewTable
 
 				case LINKSET_RELATIONTYPE_LINK:
 					$aRowActions[] = array(
-						'tooltip'       => 'UI:Links:ActionRow:detach',
+						'action'        => 'UI:Links:ActionRow:detach',
+						'tooltip'       => 'UI:Links:ActionRow:detach+',
 						'icon_classes'  => 'fas fa-minus',
 						'js_row_action' => "LinkSetWorker.DetachLinkedObject('{$this->sTargetClass}', aRowData['{$this->sTargetClass}/_key_/raw'], '{$this->oAttDef->GetExtKeyToMe()}');",
 						'confirmation'  => [
@@ -64,7 +65,8 @@ class BlockDirectLinksViewTable extends AbstractBlockLinksViewTable
 
 				case LINKSET_RELATIONTYPE_PROPERTY:
 					$aRowActions[] = array(
-						'tooltip'       => 'UI:Links:ActionRow:delete',
+						'action'        => 'UI:Links:ActionRow:delete',
+						'tooltip'       => 'UI:Links:ActionRow:delete+',
 						'icon_classes'  => 'fas fa-trash',
 						'js_row_action' => "LinkSetWorker.DeleteLinkedObject('{$this->oAttDef->GetLinkedClass()}', aRowData['{$this->oAttDef->GetLinkedClass()}/_key_/raw']);",
 						'confirmation'  => [

--- a/sources/Application/UI/Links/Direct/BlockDirectLinksViewTable.php
+++ b/sources/Application/UI/Links/Direct/BlockDirectLinksViewTable.php
@@ -51,7 +51,7 @@ class BlockDirectLinksViewTable extends AbstractBlockLinksViewTable
 
 				case LINKSET_RELATIONTYPE_LINK:
 					$aRowActions[] = array(
-						'action'        => 'UI:Links:ActionRow:detach',
+						'label'         => 'UI:Links:ActionRow:detach',
 						'tooltip'       => 'UI:Links:ActionRow:detach+',
 						'icon_classes'  => 'fas fa-minus',
 						'js_row_action' => "LinkSetWorker.DetachLinkedObject('{$this->sTargetClass}', aRowData['{$this->sTargetClass}/_key_/raw'], '{$this->oAttDef->GetExtKeyToMe()}');",
@@ -65,7 +65,7 @@ class BlockDirectLinksViewTable extends AbstractBlockLinksViewTable
 
 				case LINKSET_RELATIONTYPE_PROPERTY:
 					$aRowActions[] = array(
-						'action'        => 'UI:Links:ActionRow:delete',
+						'label'         => 'UI:Links:ActionRow:delete',
 						'tooltip'       => 'UI:Links:ActionRow:delete+',
 						'icon_classes'  => 'fas fa-trash',
 						'js_row_action' => "LinkSetWorker.DeleteLinkedObject('{$this->oAttDef->GetLinkedClass()}', aRowData['{$this->oAttDef->GetLinkedClass()}/_key_/raw']);",

--- a/sources/Application/UI/Links/Direct/BlockDirectLinksViewTable.php
+++ b/sources/Application/UI/Links/Direct/BlockDirectLinksViewTable.php
@@ -51,12 +51,12 @@ class BlockDirectLinksViewTable extends AbstractBlockLinksViewTable
 
 				case LINKSET_RELATIONTYPE_LINK:
 					$aRowActions[] = array(
-						'label'         => 'UI:Links:ActionRow:detach',
-						'tooltip'       => 'UI:Links:ActionRow:detach+',
+						'label'         => 'UI:Links:ActionRow:Detach',
+						'tooltip'       => 'UI:Links:ActionRow:Detach+',
 						'icon_classes'  => 'fas fa-minus',
 						'js_row_action' => "LinkSetWorker.DetachLinkedObject('{$this->sTargetClass}', aRowData['{$this->sTargetClass}/_key_/raw'], '{$this->oAttDef->GetExtKeyToMe()}');",
 						'confirmation'  => [
-							'message'                    => 'UI:Links:ActionRow:detach:confirmation',
+							'message'                    => 'UI:Links:ActionRow:Detach:Confirmation',
 							'message_row_data'           => "{$this->sTargetClass}/hyperlink",
 							'do_not_show_again_pref_key' => $this->GetDoNotShowAgainPreferenceKey(),
 						],
@@ -65,12 +65,12 @@ class BlockDirectLinksViewTable extends AbstractBlockLinksViewTable
 
 				case LINKSET_RELATIONTYPE_PROPERTY:
 					$aRowActions[] = array(
-						'label'         => 'UI:Links:ActionRow:delete',
-						'tooltip'       => 'UI:Links:ActionRow:delete+',
+						'label'         => 'UI:Links:ActionRow:Delete',
+						'tooltip'       => 'UI:Links:ActionRow:Delete+',
 						'icon_classes'  => 'fas fa-trash',
 						'js_row_action' => "LinkSetWorker.DeleteLinkedObject('{$this->oAttDef->GetLinkedClass()}', aRowData['{$this->oAttDef->GetLinkedClass()}/_key_/raw']);",
 						'confirmation'  => [
-							'message'                    => 'UI:Links:ActionRow:delete:confirmation',
+							'message'                    => 'UI:Links:ActionRow:Delete:Confirmation',
 							'message_row_data'           => "{$this->sTargetClass}/hyperlink",
 							'do_not_show_again_pref_key' => $this->GetDoNotShowAgainPreferenceKey(),
 						],

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinksEditTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinksEditTable.php
@@ -430,7 +430,8 @@ JS
 
 		if (!$this->oAttributeLinkedSetIndirect->GetReadOnly()) {
 			$aRowActions[] = array(
-				'tooltip'       => 'remove link',
+				'action'        => 'UI:Links:ActionRow:detach',
+				'tooltip'       => 'UI:Links:ActionRow:detach+',
 				'icon_classes'  => 'fas fa-minus',
 				'js_row_action' => "oWidget{$this->oUILinksWidget->GetInputId()}.Remove(oTrElement);",
 			);

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinksEditTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinksEditTable.php
@@ -430,7 +430,7 @@ JS
 
 		if (!$this->oAttributeLinkedSetIndirect->GetReadOnly()) {
 			$aRowActions[] = array(
-				'action'        => 'UI:Links:ActionRow:detach',
+				'label'         => 'UI:Links:ActionRow:detach',
 				'tooltip'       => 'UI:Links:ActionRow:detach+',
 				'icon_classes'  => 'fas fa-minus',
 				'js_row_action' => "oWidget{$this->oUILinksWidget->GetInputId()}.Remove(oTrElement);",

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinksEditTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinksEditTable.php
@@ -430,8 +430,8 @@ JS
 
 		if (!$this->oAttributeLinkedSetIndirect->GetReadOnly()) {
 			$aRowActions[] = array(
-				'label'         => 'UI:Links:ActionRow:detach',
-				'tooltip'       => 'UI:Links:ActionRow:detach+',
+				'label'         => 'UI:Links:ActionRow:Detach',
+				'tooltip'       => 'UI:Links:ActionRow:Detach+',
 				'icon_classes'  => 'fas fa-minus',
 				'js_row_action' => "oWidget{$this->oUILinksWidget->GetInputId()}.Remove(oTrElement);",
 			);

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinksViewTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinksViewTable.php
@@ -59,7 +59,8 @@ class BlockIndirectLinksViewTable extends AbstractBlockLinksViewTable
 		if (!$this->oAttDef->GetReadOnly()) {
 
 			$aRowActions[] = array(
-				'tooltip'       => 'UI:Links:ActionRow:detach',
+				'action'        => 'UI:Links:ActionRow:detach',
+				'tooltip'       => 'UI:Links:ActionRow:detach+',
 				'icon_classes'  => 'fas fa-minus',
 				'js_row_action' => "LinkSetWorker.DeleteLinkedObject('{$this->oAttDef->GetLinkedClass()}', aRowData['Link/_key_/raw']);",
 				'confirmation'  => [

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinksViewTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinksViewTable.php
@@ -44,7 +44,7 @@ class BlockIndirectLinksViewTable extends AbstractBlockLinksViewTable
 			'view_link'     => false,
 			'menu'          => false,
 			'display_limit' => true,
-			'table_id'      => $this->sObjectClass.'_'.$this->sAttCode,
+			'table_id'      => $this->GetTableId(),
 			'zlist'         => false,
 			'extra_fields'  => $this->GetAttCodesToDisplay(),
 			'row_actions'   => $this->GetRowActions(),
@@ -66,7 +66,7 @@ class BlockIndirectLinksViewTable extends AbstractBlockLinksViewTable
 				'confirmation'  => [
 					'message'                    => 'UI:Links:ActionRow:detach:confirmation',
 					'message_row_data'           => "Remote/hyperlink",
-					'do_not_show_again_pref_key' => 'LinkSetWorker.DetachLinkedObject',
+					'do_not_show_again_pref_key' => $this->GetDoNotShowAgainPreferenceKey(),
 				],
 			);
 

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinksViewTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinksViewTable.php
@@ -59,7 +59,7 @@ class BlockIndirectLinksViewTable extends AbstractBlockLinksViewTable
 		if (!$this->oAttDef->GetReadOnly()) {
 
 			$aRowActions[] = array(
-				'action'        => 'UI:Links:ActionRow:detach',
+				'label'         => 'UI:Links:ActionRow:detach',
 				'tooltip'       => 'UI:Links:ActionRow:detach+',
 				'icon_classes'  => 'fas fa-minus',
 				'js_row_action' => "LinkSetWorker.DeleteLinkedObject('{$this->oAttDef->GetLinkedClass()}', aRowData['Link/_key_/raw']);",

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinksViewTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinksViewTable.php
@@ -64,7 +64,7 @@ class BlockIndirectLinksViewTable extends AbstractBlockLinksViewTable
 				'icon_classes'  => 'fas fa-minus',
 				'js_row_action' => "LinkSetWorker.DeleteLinkedObject('{$this->oAttDef->GetLinkedClass()}', aRowData['Link/_key_/raw']);",
 				'confirmation'  => [
-					'message'                    => 'UI:Links:ActionRow:detach:confirmation',
+					'message'                    => 'UI:Links:ActionRow:Detach:Confirmation',
 					'message_row_data'           => "Remote/hyperlink",
 					'do_not_show_again_pref_key' => $this->GetDoNotShowAgainPreferenceKey(),
 				],

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinksViewTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinksViewTable.php
@@ -59,8 +59,8 @@ class BlockIndirectLinksViewTable extends AbstractBlockLinksViewTable
 		if (!$this->oAttDef->GetReadOnly()) {
 
 			$aRowActions[] = array(
-				'label'         => 'UI:Links:ActionRow:detach',
-				'tooltip'       => 'UI:Links:ActionRow:detach+',
+				'label'         => 'UI:Links:ActionRow:Detach',
+				'tooltip'       => 'UI:Links:ActionRow:Detach+',
 				'icon_classes'  => 'fas fa-minus',
 				'js_row_action' => "LinkSetWorker.DeleteLinkedObject('{$this->oAttDef->GetLinkedClass()}', aRowData['Link/_key_/raw']);",
 				'confirmation'  => [

--- a/sources/Controller/AjaxRenderController.php
+++ b/sources/Controller/AjaxRenderController.php
@@ -747,6 +747,7 @@ class AjaxRenderController
 		} else {
 			$oFullSetFilter = new DBObjectSearch($sRemoteClass);
 		}
+		$oFullSetFilter->SetShowObsoleteData(utils::ShowObsoleteData());
 		$oWidget->DoAddIndirectLinks($oPage, $iMaxAddedId, $oFullSetFilter, $oObj);
 		$oKPI->ComputeAndReport('Data write');
 	}

--- a/templates/base/components/datatable/layout.live.js.twig
+++ b/templates/base/components/datatable/layout.live.js.twig
@@ -1,9 +1,9 @@
 {% if oUIBlock.GetOption("select_mode") is not empty %}
-    let oSelectedItems{{ oUIBlock.GetOption('sListId')|sanitize(constant('utils::ENUM_SANITIZATION_FILTER_VARIABLE_NAME')) }} = [];
+    var oSelectedItems{{ oUIBlock.GetOption('sListId')|sanitize(constant('utils::ENUM_SANITIZATION_FILTER_VARIABLE_NAME')) }} = [];
     {% if oUIBlock.GetOption("sSelectedRows") is not empty %}
         oSelectedItems{{ oUIBlock.GetOption('sListId')|sanitize(constant('utils::ENUM_SANITIZATION_FILTER_VARIABLE_NAME')) }} = {{ oUIBlock.GetOption('sSelectedRows')|raw }};
     {% endif %}
 {% endif %}
 
-let bSelectAllowed{{ oUIBlock.GetId()|sanitize(constant('utils::ENUM_SANITIZATION_FILTER_VARIABLE_NAME')) }} = false;
+var bSelectAllowed{{ oUIBlock.GetId()|sanitize(constant('utils::ENUM_SANITIZATION_FILTER_VARIABLE_NAME')) }} = false;
 

--- a/templates/base/components/datatable/row-actions/handler.js.twig
+++ b/templates/base/components/datatable/row-actions/handler.js.twig
@@ -10,21 +10,23 @@
         // variables accessible from action row js
         let oDatatable = $('#{{ oUIBlock.GetId() }}').DataTable();
         let oTrElement = $(this).closest('tr');
+        let sAction = $(this).data('action');
         let iActionId = $(this).data('action-id');
         let aRowData = oDatatable.row(oTrElement).data();
 
         {% if aAction.confirmation is defined %}
 
             // Prepare confirmation message
-            let sMessage = '{{ 'UI:Datatables:RowActions:ConfirmationMessage'|dict_s }}';
+            let sMessage = `{{ 'UI:Datatables:RowActions:ConfirmationMessage'|dict_s|raw  }}`;
             {% if aAction.confirmation.message is defined %}
-                sMessage = '{{ aAction.confirmation.message|dict_s|raw }}';
+                sMessage = `{{ aAction.confirmation.message|dict_s|raw }}`;
             {% endif %}
 
             // Handle action row with confirmation modal
             CombodoModal.OpenConfirmationModal({
                 title: '{{ 'UI:Datatables:RowActions:ConfirmationDialog'|dict_s }}',
                 content: sMessage.replaceAll('{item}', aRowData['{{ aAction.confirmation.message_row_data }}']),
+                confirm_button_text: sAction,
                 callback_on_confirm: ActionRowFunction{{ oUIBlock.GetId() }}{{ loop.index0 }},
                 {% if aAction.confirmation.do_not_show_again_pref_key is defined %}
                 do_not_show_again_pref_key: '{{ aAction.confirmation.do_not_show_again_pref_key }}',

--- a/templates/base/components/datatable/row-actions/handler.js.twig
+++ b/templates/base/components/datatable/row-actions/handler.js.twig
@@ -10,7 +10,7 @@
         // variables accessible from action row js
         let oDatatable = $('#{{ oUIBlock.GetId() }}').DataTable();
         let oTrElement = $(this).closest('tr');
-        let sAction = $(this).data('action');
+        let sLabel = $(this).data('label');
         let iActionId = $(this).data('action-id');
         let aRowData = oDatatable.row(oTrElement).data();
 
@@ -26,7 +26,7 @@
             CombodoModal.OpenConfirmationModal({
                 title: '{{ 'UI:Datatables:RowActions:ConfirmationDialog'|dict_s }}',
                 content: sMessage.replaceAll('{item}', aRowData['{{ aAction.confirmation.message_row_data }}']),
-                confirm_button_text: sAction,
+                confirm_button_label: sLabel,
                 callback_on_confirm: ActionRowFunction{{ oUIBlock.GetId() }}{{ loop.index0 }},
                 {% if aAction.confirmation.do_not_show_again_pref_key is defined %}
                 do_not_show_again_pref_key: '{{ aAction.confirmation.do_not_show_again_pref_key }}',


### PR DESCRIPTION
Linkset updates, feedbacks 09/12:
- Distinguish action label and tool tip message
- Change default action button label Ok => Confirm
- Use action label in place of default  confirm button label
- Attach do not show again preference key to table instance 