### PR TITLE
N°5784 - PHP 8.0: Fix mandatory attribute not visible in transition form due to bad emptiness test

### DIFF
--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -3374,13 +3374,14 @@ EOF
 			// Consider only the "expected" fields for the target state
 			if (array_key_exists($sAttCode, $aExpectedAttributes)) {
 				$iExpectCode = $aExpectedAttributes[$sAttCode];
+
 				// Prompt for an attribute if
 				// - the attribute must be changed or must be displayed to the user for confirmation
 				// - or the field is mandatory and currently empty
 				if (($iExpectCode & (OPT_ATT_MUSTCHANGE | OPT_ATT_MUSTPROMPT)) ||
-					(($iExpectCode & OPT_ATT_MANDATORY) && ($this->Get($sAttCode) == ''))) {
-					$oAttDef = MetaModel::GetAttributeDef($sClass, $sAttCode);
+					(($iExpectCode & OPT_ATT_MANDATORY) && (false === $this->HasAValue($sAttCode)))) {
 					$aArgs = array('this' => $this);
+					$oAttDef = MetaModel::GetAttributeDef($sClass, $sAttCode);
 					// If the field is mandatory, set it to the only possible value
 					if ((!$oAttDef->IsNullAllowed()) || ($iExpectCode & OPT_ATT_MANDATORY)) {
 						if ($oAttDef->IsExternalKey()) {

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -8218,7 +8218,7 @@ class AttributeBlob extends AttributeDefinition
 		}
 
 		// Empty file (no content, just a filename) are supported since PR {@link https://github.com/Combodo/combodo-email-synchro/pull/17}, so we check for both empty content and empty filename to determine that a document has no value
-		return utils::IsNullOrEmptyString($proposedValue->GetData()) && utils::IsNullOrEmptyString($proposedValue->GetFileName());
+		return utils::IsNotNullOrEmptyString($proposedValue->GetData()) && utils::IsNotNullOrEmptyString($proposedValue->GetFileName());
 	}
 
 

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -706,6 +706,17 @@ abstract class AttributeDefinition
 	}
 
 	/**
+	 * @param mixed $proposedValue
+	 *
+	 * @return bool True if $proposedValue is an actual value set in the attribute, false is the attribute remains "empty"
+	 * @since 3.0.3, 3.1.0 N°5784
+	 */
+	public function HasAValue(mixed $proposedValue): bool
+	{
+		return utils::IsNotNullOrEmptyString($proposedValue);
+	}
+
+	/**
 	 * force an allowed value (type conversion and possibly forces a value as mySQL would do upon writing!
 	 *
 	 * @param $proposedValue
@@ -2233,6 +2244,15 @@ class AttributeLinkedSet extends AttributeDefinition
 	{
 		return false;
 	}
+
+	/**
+	 * @inheritDoc
+	 * @param \ormLinkSet $proposedValue
+	 */
+	public function HasAValue($proposedValue): bool
+	{
+		return $proposedValue->Count() > 0;
+	}
 }
 
 /**
@@ -2711,6 +2731,14 @@ class AttributeObjectKey extends AttributeDBFieldVoid
 	public function IsNull($proposedValue)
 	{
 		return ($proposedValue == 0);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function HasAValue($proposedValue): bool
+	{
+		return ((int) $proposedValue) !== 0;
 	}
 
 	public function MakeRealValue($proposedValue, $oHostObj)
@@ -4477,6 +4505,22 @@ class AttributeCaseLog extends AttributeLongText
 
 		return ($proposedValue->GetText() == '');
 	}
+
+	/**
+	 * @inheritDoc
+	 * @param \ormCaseLog $proposedValue
+	 */
+	public function HasAValue($proposedValue): bool
+	{
+		// Protection against wrong value type
+		if (! ($proposedValue instanceof ormCaseLog)) {
+			return parent::HasAValue($proposedValue);
+		}
+
+		// TODO: What do we want to do? Check if there is a new entry or if the entire log is empty?
+		return utils::IsNotNullOrEmptyString($proposedValue->GetLatestEntry());
+	}
+
 
 	public function ScalarToSQL($value)
 	{
@@ -6798,6 +6842,14 @@ class AttributeExternalKey extends AttributeDBFieldVoid
 		return ($proposedValue == 0);
 	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function HasAValue($proposedValue): bool
+	{
+		return ((int) $proposedValue) !== 0;
+	}
+
 	public function MakeRealValue($proposedValue, $oHostObj)
 	{
 		if (is_null($proposedValue))
@@ -8105,6 +8157,21 @@ class AttributeBlob extends AttributeDefinition
 		return $oFormField;
 	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function HasAValue($proposedValue): bool
+	{
+		if (!($proposedValue instanceof ormDocument)) {
+			return parent::HasAValue($proposedValue);
+		}
+
+		/** @var \ormDocument $proposedValue */
+		// TODO: How do we implement this? Keep in mind the example of the "empty file" PR on combodo-email-synchro
+		return utils::IsNullOrEmptyString($proposedValue->GetData()) && utils::IsNullOrEmptyString($proposedValue->GetFileName());
+	}
+
+
 }
 
 /**
@@ -9131,6 +9198,17 @@ class AttributeStopWatch extends AttributeDefinition
 
 		return $sRet;
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function HasAValue($proposedValue): bool
+	{
+		// TODO: How to implement this?
+		return parent::HasAValue($proposedValue);
+	}
+
+
 }
 
 /**
@@ -9665,6 +9743,15 @@ class AttributeTable extends AttributeDBField
 		return (count($proposedValue) == 0);
 	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function HasAValue($proposedValue): bool
+	{
+		return count($proposedValue) > 0;
+	}
+
+
 	public function GetEditValue($sValue, $oHostObj = null)
 	{
 		return '';
@@ -10184,6 +10271,19 @@ abstract class AttributeSet extends AttributeDBFieldVoid
 
 		/** @var \ormSet $proposedValue */
 		return $proposedValue->Count() == 0;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function HasAValue($proposedValue): bool
+	{
+		if (!($proposedValue instanceof ormSet)) {
+			return parent::HasAValue($proposedValue);
+		}
+
+		/** @var \ormSet $proposedValue */
+		return $proposedValue->Count() > 0;
 	}
 
 	/**
@@ -12893,6 +12993,17 @@ class AttributeCustomFields extends AttributeDefinition
 
 		return $bEquals;
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function HasAValue($proposedValue): bool
+	{
+		// TODO: How to implement this?
+		return parent::HasAValue($proposedValue);
+	}
+
+
 }
 
 class AttributeArchiveFlag extends AttributeBoolean

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -3998,6 +3998,20 @@ abstract class DBObject implements iDisplay
 	}
 
 	/**
+	 * @param string $sAttCode
+	 *
+	 * @return bool True if $sAttCode has an actual value set, false is the attribute remains "empty"
+	 * @throws \ArchivedObjectException
+	 * @throws \CoreException
+	 * @since 3.0.3, 3.1.0 N°5784
+	 */
+	public function HasAValue(string $sAttCode): bool
+	{
+		$oAttDef = MetaModel::GetAttributeDef(get_class($this), $sAttCode);
+		return $oAttDef->HasAValue($this->Get($sAttCode));
+	}
+
+	/**
 	 * Helper to recover the default value (aka when an object is being created)
      * Suitable for use as a lifecycle action
      *

--- a/tests/php-unit-tests/unitary-tests/core/AttributeDefTest.inc.php
+++ b/tests/php-unit-tests/unitary-tests/core/AttributeDefTest.inc.php
@@ -29,4 +29,148 @@ class AttributeDefTest extends ItopDataTestCase {
 		$this->assertEquals(["status" => "ENUM('active','inactive') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"],
 			$aImportColumns);
 	}
+
+	/**
+	 * @dataProvider HasAValueProvider
+	 * @covers AttributeDefinition::HasAValue
+	 *
+	 * @param $sObjectClass
+	 * @param $sAttCode
+	 * @param $sUpdateCode
+	 * @param $bHasAValueInitially
+	 * @param $bHasAValueOnceSet
+	 *
+	 * @return void
+	 * @throws \ArchivedObjectException
+	 * @throws \CoreException
+	 */
+	public function testHasAValue($sObjectClass, $sAttCode, $sUpdateCode, $bHasAValueInitially, $bHasAValueOnceSet)
+	{
+		$oObject = MetaModel::NewObject($sObjectClass);
+
+		// Test attribute without a value yet
+		$this->assertEquals($bHasAValueInitially, $oObject->HasAValue($sAttCode));
+
+		eval($sUpdateCode);
+
+		// Test attribute once a value has been set
+		$this->assertEquals($bHasAValueOnceSet, $oObject->HasAValue($sAttCode));
+	}
+
+	public function HasAValueProvider(): array
+	{
+		// Note: This is test is not great as we are datamodel dependent and don't have a class with all the attribute types
+		return [
+			'AttributeDashboard' => [
+				'Organization',
+				'overview',
+				'',
+				false,
+				false,
+			],
+			'AttributeLinkedSet' => [
+				'UserRequest',
+				'workorders_list',
+				<<<PHP
+/** @var \ormLinkSet \$ormLinkset */
+\$ormLinkset = \$oObject->Get('workorders_list');
+\$ormLinkset->AddItem(MetaModel::NewObject('WorkOrder', []));
+\$oObject->Set('workorders_list', \$ormLinkset);
+PHP,
+				false,
+				true,
+			],
+			'AttributeLinkedSetIndirect' => [
+				'UserRequest',
+				'contacts_list',
+				<<<PHP
+/** @var \ormLinkSet \$ormLinkset */
+\$ormLinkset = \$oObject->Get('contacts_list');
+\$ormLinkset->AddItem(MetaModel::NewObject('Person', []));
+\$oObject->Set('contacts_list', \$ormLinkset);
+PHP,
+				false,
+				true,
+			],
+			'AttributeInteger' => [
+				'SLT',
+				'value',
+				<<<PHP
+\$oObject->Set('value', 100);
+PHP,
+				false,
+				true,
+			],
+			'AttributeDecimal' => [
+				'PhysicalInterface',
+				'speed',
+				<<<PHP
+\$oObject->Set('speed', 1024.5);
+PHP,
+				false,
+				true,
+			],
+			'AttributeString' => [
+				'UserRequest',
+				'title',
+				<<<PHP
+\$oObject->Set('title', 'Some title');
+PHP,
+				false,
+				true,
+			],
+			'AttributeObjectKey' => [
+				'Attachment',
+				'item_id',
+				<<<PHP
+\$oObject->Set('item_id', 12);
+PHP,
+				false,
+				true,
+			],
+			'AttributeExternalKey' => [
+				'UserRequest',
+				'org_id',
+				<<<PHP
+\$oObject->Set('org_id', 3);
+PHP,
+				false,
+				true,
+			],
+			'AttributeBlob' => [
+				'DocumentFile',
+				'file',
+				<<<PHP
+\$oObject->Set('file', new ormDocument('something', 'text/plain', 'something.txt'));
+PHP,
+				false,
+				true,
+			],
+			'AttributeStopWatch' => [
+				'UserRequest',
+				'tto',
+				'',
+				true,
+				true,
+			],
+			'AttributeSubItem' => [
+				'UserRequest',
+				'tto_escalation_deadline',
+				'',
+				true,
+				true,
+			],
+			'AttributeOneWayPassword' => [
+				'UserLocal',
+				'password',
+				<<<PHP
+$/** @var \ormPassword \$ormPassword */
+\$ormPassword = new ormPassword('somehash', 'somesalt');
+\$oObject->Set('password', \$ormPassword);
+PHP,
+				false,
+				true,
+			],
+		];
+	}
 }


### PR DESCRIPTION
**Issue description**
See ticket [#2136 on SF](https://sourceforge.net/p/itop/tickets/2136/)

**Cause**
In transition form, when an attribute is supposed to be mandatory we check if it already has a value.
The current test is not done correctly as it is testing if the value is an empty string `''`, when in the reported case it could be `0` as it was an external key. This weak test doesn't return true with PHP 8.0+ as you can [see there](https://3v4l.org/j7Oep).

![image](https://user-images.githubusercontent.com/5130468/207971034-2e4e229c-1b68-4486-a1f2-ec7023c3c8e4.png)

**Solution**
_Since the first version of this PR, internal discussion took place to prepare the best solution and introduce the new method in the maintenance version (3.0.3), this PR is a media for the discussion._
  * `AttributeDefinition::HasAValue(mixed $proposedValue): bool` has been introduced. **MIND that implementation for several attribute types are to be discussed**, this PR is here to find the best way to do it.
  * `DBObject::HasAValue(string $sAttCode): bool` is a shortcut to the above method to ease DX.

The main idea behind `HasAValue()` is to determine is a value has been set by the user in a form or by an automation. It is really different from `AttributeDefinition::IsNull()`, 2 examples:
  * On an attribute string `''` should be considered as NOT a set value, whereas it is not null.
  * On an attribute ext. key `0` should be considered as NOT a set value, whereas it is not null.

_PS: I'll add the unit tests once we decide how to do all the implementations_