### PR TITLE
N°2916 - Import of IPv6 addresses fails when reconciliation is done on the ip

### DIFF
--- a/core/bulkchange.class.inc.php
+++ b/core/bulkchange.class.inc.php
@@ -11,7 +11,7 @@ define('UTF8_BOM', chr(239).chr(187).chr(191)); // 0xEF, 0xBB, 0xBF
 
 /**
  * CellChangeSpec
- * A series of classes, keeping the information about a given cell: could it be changed or not (and why)?  
+ * A series of classes, keeping the information about a given cell: could it be changed or not (and why)?
  *
  * @package     iTopORM
  */
@@ -144,7 +144,7 @@ class CellStatus_Ambiguous extends CellStatus_Issue
 
 /**
  * RowStatus
- * A series of classes, keeping the information about a given row: could it be changed or not (and why)?  
+ * A series of classes, keeping the information about a given row: could it be changed or not (and why)?
  *
  * @package     iTopORM
  */
@@ -220,7 +220,7 @@ class RowStatus_Issue extends RowStatus
  */
 class BulkChange
 {
-	protected $m_sClass; 
+	protected $m_sClass;
 	protected $m_aData; // Note: hereafter, iCol maybe actually be any acceptable key (string)
 	// #@# todo: rename the variables to sColIndex
 	protected $m_aAttList; // attcode => iCol
@@ -261,7 +261,7 @@ class BulkChange
 		$this->m_sReportCsvSep = $sSeparator;
 		$this->m_sReportCsvDelimiter = $sDelimiter;
 	}
-   
+
 	protected function ResolveExternalKey($aRowData, $sAttCode, &$aResults)
 	{
 		$oExtKey = MetaModel::GetAttributeDef($this->m_sClass, $sAttCode);
@@ -318,7 +318,7 @@ class BulkChange
 	{
 		$aResults = array();
 		$aErrors = array();
-	
+
 		// External keys reconciliation
 		//
 		foreach($this->m_aExtKeys as $sAttCode => $aKeyConfig)
@@ -408,12 +408,12 @@ class BulkChange
 					$aErrors[$sAttCode] = Dict::S('UI:CSVReport-Value-Issue-NotFound');
 					$aResults[$sAttCode]= new CellStatus_SearchIssue();
 					break;
-					
+
 					case 1:
 					// Do change the external key attribute
 					$oTargetObj->Set($sAttCode, $iForeignKey);
 					break;
-					
+
 					default:
 					$aErrors[$sAttCode] = Dict::Format('UI:CSVReport-Value-Issue-FoundMany', $iCount);
 					$aResults[$sAttCode]= new CellStatus_Ambiguous($oTargetObj->Get($sAttCode), $iCount, $sOQL);
@@ -446,7 +446,7 @@ class BulkChange
 				}
 			}
 		}
-	
+
 		// Set the object attributes
 		//
 		foreach ($this->m_aAttList as $sAttCode => $iCol)
@@ -467,30 +467,21 @@ class BulkChange
 			$iFlags = ($oTargetObj->IsNew())
 				? $oTargetObj->GetInitialStateAttributeFlags($sAttCode, $aReasons)
 				: $oTargetObj->GetAttributeFlags($sAttCode, $aReasons);
-			if ( (($iFlags & OPT_ATT_READONLY) == OPT_ATT_READONLY) && ( $oTargetObj->Get($sAttCode) != $aRowData[$iCol]) ) {
+			if ((($iFlags & OPT_ATT_READONLY) == OPT_ATT_READONLY) && ($oTargetObj->Get($sAttCode) != $oAttDef->MakeValueFromString($aRowData[$iCol], $this->m_bLocalizedValues))) {
 				$aErrors[$sAttCode] = Dict::Format('UI:CSVReport-Value-Issue-Readonly', $sAttCode, $oTargetObj->Get($sAttCode), $aRowData[$iCol]);
-			}
-			else if ($oAttDef->IsLinkSet() && $oAttDef->IsIndirect())
-			{
-				try
-				{
+			} else if ($oAttDef->IsLinkSet() && $oAttDef->IsIndirect()) {
+				try {
 					$oSet = $oAttDef->MakeValueFromString($aRowData[$iCol], $this->m_bLocalizedValues);
 					$oTargetObj->Set($sAttCode, $oSet);
 				}
-				catch(CoreException $e)
-				{
+				catch (CoreException $e) {
 					$aErrors[$sAttCode] = Dict::Format('UI:CSVReport-Value-Issue-Format', $e->getMessage());
 				}
-			}
-			else
-			{
+			} else {
 				$value = $oAttDef->MakeValueFromString($aRowData[$iCol], $this->m_bLocalizedValues);
-				if (is_null($value) && (strlen($aRowData[$iCol]) > 0))
-				{
+				if (is_null($value) && (strlen($aRowData[$iCol]) > 0)) {
 					$aErrors[$sAttCode] = Dict::Format('UI:CSVReport-Value-Issue-NoMatch', $sAttCode);
-				}
-				else
-				{
+				} else {
 					$res = $oTargetObj->CheckValue($sAttCode, $value);
 					if ($res === true)
 					{
@@ -504,7 +495,7 @@ class BulkChange
 				}
 			}
 		}
-	
+
 		// Reporting on fields
 		//
 		$aChangedFields = $oTargetObj->ListChanges();
@@ -556,7 +547,7 @@ class BulkChange
 				}
 			}
 		}
-	
+
 		// Checks
 		//
 		$res = $oTargetObj->CheckConsistency();
@@ -567,12 +558,12 @@ class BulkChange
 		}
 		return $aResults;
 	}
-	
+
 	protected function PrepareMissingObject(&$oTargetObj, &$aErrors)
 	{
 		$aResults = array();
 		$aErrors = array();
-	
+
 		// External keys
 		//
 		foreach($this->m_aExtKeys as $sAttCode => $aKeyConfig)
@@ -585,7 +576,7 @@ class BulkChange
 				$aResults[$iCol] = new CellStatus_Void('?');
 			}
 		}
-	
+
 		// Update attributes
 		//
 		foreach($this->m_aOnDisappear as $sAttCode => $value)
@@ -596,7 +587,7 @@ class BulkChange
 			}
 			$oTargetObj->Set($sAttCode, $value);
 		}
-	
+
 		// Reporting on fields
 		//
 		$aChangedFields = $oTargetObj->ListChanges();
@@ -616,7 +607,7 @@ class BulkChange
 				$aResults[$iCol]= new CellStatus_Void($oTargetObj->Get($sAttCode));
 			}
 		}
-	
+
 		// Checks
 		//
 		$res = $oTargetObj->CheckConsistency();
@@ -674,14 +665,14 @@ class BulkChange
 		}
 
 		$aResult[$iRow] = $this->PrepareObject($oTargetObj, $aRowData, $aErrors);
-	
+
 		if (count($aErrors) > 0)
 		{
 			$sErrors = implode(', ', $aErrors);
 			$aResult[$iRow]["__STATUS__"] = new RowStatus_Issue(Dict::S('UI:CSVReport-Row-Issue-Attribute'));
 			return $oTargetObj;
 		}
-	
+
 		// Check that any external key will have a value proposed
 		$aMissingKeys = array();
 		foreach (MetaModel::GetExternalKeys($this->m_sClass) as $sExtKeyAttCode => $oExtKey)
@@ -689,7 +680,7 @@ class BulkChange
 			if (!$oExtKey->IsNullAllowed())
 			{
 				if (!array_key_exists($sExtKeyAttCode, $this->m_aExtKeys) && !array_key_exists($sExtKeyAttCode, $this->m_aAttList))
-				{ 
+				{
 					$aMissingKeys[] = $oExtKey->GetLabel();
 				}
 			}
@@ -747,12 +738,12 @@ class BulkChange
 			$aResult[$iRow]["__STATUS__"] = new RowStatus_Issue(Dict::S('UI:CSVReport-Row-Issue-Attribute'));
 			return;
 		}
-	
+
 		$aChangedFields = $oTargetObj->ListChanges();
 		if (count($aChangedFields) > 0)
 		{
 			$aResult[$iRow]["__STATUS__"] = new RowStatus_Modify(count($aChangedFields));
-	
+
 			// Optionaly record the results
 			//
 			if ($oChange)
@@ -796,7 +787,7 @@ class BulkChange
 			$aResult[$iRow]["__STATUS__"] = new RowStatus_Issue(Dict::S('UI:CSVReport-Row-Issue-Attribute'));
 			return;
 		}
-	
+
 		$aChangedFields = $oTargetObj->ListChanges();
 		if (count($aChangedFields) > 0)
 		{
@@ -821,7 +812,7 @@ class BulkChange
 			$aResult[$iRow]["__STATUS__"] = new RowStatus_Disappeared(0);
 		}
 	}
-	
+
 	public function Process(CMDBChange $oChange = null)
 	{
 		if ($oChange)
@@ -866,7 +857,7 @@ class BulkChange
 			foreach ($this->m_aAttList as $sAttCode => $iCol)
 			{
 				if ($sAttCode == 'id') continue;
-				
+
 				$oAttDef = MetaModel::GetAttributeDef($this->m_sClass, $sAttCode);
 				if ($oAttDef instanceof AttributeDateTime) // AttributeDate is derived from AttributeDateTime
 				{
@@ -953,22 +944,22 @@ class BulkChange
 						{
 							// The value has to be found or verified
 							list($sQuery, $aMatches) = $this->ResolveExternalKey($aRowData, $sAttCode, $aResult[$iRow]);
-		
+
 							if (count($aMatches) == 1)
 							{
 								$oRemoteObj = reset($aMatches); // first item
 								$valuecondition = $oRemoteObj->GetKey();
 								$aResult[$iRow][$sAttCode] = new CellStatus_Void($oRemoteObj->GetKey());
-							} 					
+							}
 							elseif (count($aMatches) == 0)
 							{
 								$aResult[$iRow][$sAttCode] = new CellStatus_SearchIssue();
-							} 					
+							}
 							else
 							{
 								$aResult[$iRow][$sAttCode] = new CellStatus_Ambiguous(null, count($aMatches), $sQuery);
 							}
-						} 					
+						}
 					}
 					else
 					{
@@ -990,7 +981,7 @@ class BulkChange
 					}
 					else
 					{
-						$oReconciliationFilter->AddCondition($sAttCode, $valuecondition, '=');
+						$oReconciliationFilter->AddCondition($sAttCode, $valuecondition, '=', true);
 					}
 				}
 				if ($bSkipQuery)
@@ -1110,7 +1101,7 @@ class BulkChange
 			}
 		}
 		$oBulkChanges->Seek(0);
-	
+
 		$aDetails = array();
 		while ($oChange = $oBulkChanges->Fetch())
 		{
@@ -1274,7 +1265,7 @@ EOF
 							$oOldTarget = MetaModel::GetObject($oAttDef->GetTargetClass(), $oOperation->Get('oldvalue'));
 							$sOldValue = $oOldTarget->GetHyperlink();
 						}
-						
+
 						$sNewValue = Dict::S('UI:UndefinedObject');
 						if ($oOperation->Get('newvalue') != 0)
 						{
@@ -1300,11 +1291,11 @@ EOF
 				}
 				else
 				{
-					$aAttributes[$sAttCode] = 1;				
+					$aAttributes[$sAttCode] = 1;
 				}
 			}
 		}
-		
+
 		$aDetails = array();
 		foreach($aObjects as $iUId => $aObjData)
 		{
@@ -1356,6 +1347,6 @@ EOF
 			$aConfig[$sAttCode] = array('label' => MetaModel::GetLabel($sClass, $sAttCode), 'description' => MetaModel::GetDescription($sClass, $sAttCode));
 		}
 		$oPage->table($aConfig, $aDetails);
-	}	
+	}
 }
 


### PR DESCRIPTION
Add an interface that should be implemented in order to handle  object type fields on import. It adds a function to transform the object (like ormIPv6) into a string.
This function is used twice during the CVS import:
- to find the corresponding objects in iTop if the field is a search criterion.
- when updating the object if the field is read-only.