### PR TITLE
Missing org_id in network interface class

### DIFF
--- a/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
+++ b/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
@@ -5385,6 +5385,8 @@
         <naming>
           <attributes>
             <attribute id="name"/>
+            <attribute id="org_id"/>
+						<attribute id="organization_name"/>
           </attributes>
         </naming>
         <style>
@@ -5403,6 +5405,16 @@
           <default_value/>
           <is_null_allowed>false</is_null_allowed>
         </field>
+        <field id="org_id" xsi:type="AttributeExternalKey" _delta="define">
+					<sql>org_id</sql>
+					<target_class>Organization</target_class>
+					<is_null_allowed>false</is_null_allowed>
+					<on_target_delete>DEL_MANUAL</on_target_delete>
+				</field>
+				<field id="organization_name" xsi:type="AttributeExternalField" _delta="define">
+					<extkey_attcode>org_id</extkey_attcode>
+					<target_attcode>name</target_attcode>
+				</field>
       </fields>
       <methods/>
       <presentation>
@@ -5410,6 +5422,9 @@
           <items>
             <item id="name">
               <rank>10</rank>
+            </item>
+            <item id="org_id">
+              <rank>15</rank>
             </item>
           </items>
         </details>


### PR DESCRIPTION
Added org_id to the network interface class so that network interfaces are not shown for every organization, This was especially an issue for TEEMIP extensions. The next step after this pull request is confirmed and tested is to add the org_id to all the relevant interfaces in the TEEMIP extensions. I personally already implemented this in my own itop production environment.