### PR TITLE
🐛 Fix: 'cancel' button redirects to console instead of portal

### DIFF
--- a/datamodels/2.x/itop-portal-base/portal/public/js/portal_form_handler.js
+++ b/datamodels/2.x/itop-portal-base/portal/public/js/portal_form_handler.js
@@ -435,10 +435,7 @@ $(function()
 					// In some browser (eg. Firefox 70), window won't close if it has NOT been open by JS. In that case, we try to redirect to homepage as a fallback.
 					var sHomepageUrl = (this.options.base_url !== null) ? this.options.base_url : $('#sidebar .menu .brick_menu_item:first a').attr('href')
 					window.location.href = sHomepageUrl;
-					
-				}
-				else {
-					
+				} else {
 					window.history.back(-1);
 				}
 				

--- a/datamodels/2.x/itop-portal-base/portal/public/js/portal_form_handler.js
+++ b/datamodels/2.x/itop-portal-base/portal/public/js/portal_form_handler.js
@@ -440,7 +440,6 @@ $(function()
 				else {
 					
 					window.history.back(-1);
-					
 				}
 				
 			}

--- a/datamodels/2.x/itop-portal-base/portal/public/js/portal_form_handler.js
+++ b/datamodels/2.x/itop-portal-base/portal/public/js/portal_form_handler.js
@@ -426,12 +426,24 @@ $(function()
 			}
 			else
 			{
-				// Try to close the window
-				window.close();
+				
+				if(window.history.length == 1) {
+					
+					// Not a modal, but there is no other history.
+					// Try to close the window.
+					window.close();
 
-				// In some browser (eg. Firefox 70), window won't close if it has NOT been open by JS. In that case, we try to redirect to homepage as a fallback.
-				var sHomepageUrl = (this.options.base_url !== null) ? this.options.base_url : $('#sidebar .menu .brick_menu_item:first a').attr('href')
-				window.location.href = sHomepageUrl;
+					// In some browser (eg. Firefox 70), window won't close if it has NOT been open by JS. In that case, we try to redirect to homepage as a fallback.
+					var sHomepageUrl = (this.options.base_url !== null) ? this.options.base_url : $('#sidebar .menu .brick_menu_item:first a').attr('href')
+					window.location.href = sHomepageUrl;
+					
+				}
+				else {
+					
+					window.history.back(-1);
+					
+				}
+				
 			}
 		},
 		submit: function(oEvent)

--- a/datamodels/2.x/itop-portal-base/portal/public/js/portal_form_handler.js
+++ b/datamodels/2.x/itop-portal-base/portal/public/js/portal_form_handler.js
@@ -427,8 +427,7 @@ $(function()
 			else
 			{
 				
-				if(window.history.length == 1) {
-					
+				if(window.history.length === 1) {
 					// Not a modal, but there is no other history.
 					// Try to close the window.
 					window.close();

--- a/datamodels/2.x/itop-portal-base/portal/templates/bricks/object/mode_create.html.twig
+++ b/datamodels/2.x/itop-portal-base/portal/templates/bricks/object/mode_create.html.twig
@@ -76,7 +76,7 @@
 			field_set: oFieldSet_{{ sFormIdSanitized }},
 			submit_btn_selector: $('#{{ sFormId }}').parent().find('.form_btn_submit, .form_btn_transition'),
 			cancel_btn_selector: $('#{{ sFormId }}').parent().find('.form_btn_cancel'),
-			base_url: "{{ app['combodo.absolute_url'] }}",
+			base_url: "{{ app['combodo.portal.base.absolute_url'] }}",
 			{% if form.submit_rule is not null %}submit_rule: {{ form.submit_rule|json_encode|raw }}{% endif %},
 			{% if form.cancel_rule is not null %}cancel_rule: {{ form.cancel_rule|json_encode|raw }}{% endif %},
 			endpoint: "{{ form.renderer.GetEndpoint()|raw }}",


### PR DESCRIPTION
Before:

1. Sign in to the portal, navigate to https://demo.combodo.com/simple/pages/exec.php/object/create/UserRequest?exec_module=itop-portal-base&exec_page=index.php&portal_id=itop-portal , press Cancel.
2. User with console permissions is redirected to the back end instead of staying in the portal.

After PR: user with console permissions should stay in the portal. Either a simple 'go back 1 page' is executed, or the user is redirected to the portal's home page.