### PR TITLE
N°2783 - Add support for custom zlists

### DIFF
--- a/setup/itopdesignformat.class.inc.php
+++ b/setup/itopdesignformat.class.inc.php
@@ -1131,6 +1131,10 @@ class iTopDesignFormat
 		// - remove display style
 		$this->RemoveNodeFromXPath("/itop_design/classes//class/fields/field[@xsi:type='AttributeLinkedSet']/display_style");
 		$this->RemoveNodeFromXPath("/itop_design/classes//class/fields/field[@xsi:type='AttributeLinkedSetIndirect']/display_style");
+
+		// N°2783 Custom zlists
+		$this->RemoveNodeFromXPath("/itop_design/classes//class/presentation/custom_presentations");
+		$this->RemoveNodeFromXPath("/itop_design/meta/presentation/custom_presentations");
 	}
 
 	/**

--- a/tests/php-unit-tests/unitary-tests/setup/iTopDesignFormat/Convert-samples/3.1_to_3.0.expected.xml
+++ b/tests/php-unit-tests/unitary-tests/setup/iTopDesignFormat/Convert-samples/3.1_to_3.0.expected.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <itop_design xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.0">
   <classes>
+    <class id="ClassWithCustomZlist">
+      <presentation/>
+    </class>
     <class id="ClassWithAttributeLinkedSetEditModeNone">
       <fields>
         <field id="status" xsi:type="AttributeLinkedSet">
@@ -75,4 +78,7 @@
       </methods>
     </class>
   </classes>
+  <meta>
+    <presentation/>
+  </meta>
 </itop_design>

--- a/tests/php-unit-tests/unitary-tests/setup/iTopDesignFormat/Convert-samples/3.1_to_3.0.input.xml
+++ b/tests/php-unit-tests/unitary-tests/setup/iTopDesignFormat/Convert-samples/3.1_to_3.0.input.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <itop_design xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3.1">
   <classes>
+    <class id="ClassWithCustomZlist">
+      <presentation>
+        <custom_presentations>
+          <custom_presentation id="my-custom-list" _delta="define">
+            <items>
+              <item id="foo">
+                <rank>10</rank>
+              </item>
+            </items>
+          </custom_presentation>
+        </custom_presentations>
+      </presentation>
+    </class>
     <class id="ClassWithAttributeLinkedSetEditModeNone">
       <fields>
         <field id="status" xsi:type="AttributeLinkedSet">
@@ -138,4 +151,13 @@
 ]]></code>
     </listener>
   </event_listeners>
+  <meta>
+    <presentation>
+      <custom_presentations>
+        <custom_presentation id="my-custom-list">
+          <description><![CDATA[Some description of the zlist]]></description>
+        </custom_presentation>
+      </custom_presentations>
+    </presentation>
+  </meta>
 </itop_design>


### PR DESCRIPTION
This is a reboot of #100 as we need to move forward and Thomas lacks time.

**Collection**
  * Custom zlists must be defined under the `/itop_design/classes/class/presentation/custom_presentations` which will contain zlists brought by customizations (extensions, Designer, ...)
  * ~This collection node must be added empty to all standard DM classes~ => Not anymore
  * ~This collection node must be added empty by the compiler on XML datamodel files during the version upgrade (see _iTopDesignFormat::From30To31()_)~ => Not anymore, it's an optional node

**Definition of the zlist**
  * Each custom zlist will be represented by a `<custom_presentation id="ZLIST_ID">[...]</custom>` node
  * The node must contain the same XML structure as other zlists (no particular test to do at compile time)
  * Custom zlist can (optional) expose a description of their purpose so it will be displayed in the Designer as they will be no specific UI display (nothing to there for you Thomas, just to explain why it's in the example below)

**Implementation**
  * Compiler should **append** custom zlist to the standard ones (= same PHP structure)
  * Compiler should throw an exception if a custom zlist has the same name (ID) as a standard one (need for explicit ID will be added in the documentation)
  * `MetaModel::GetZListItems()` will be used to retrieve both standard and custom zlists. If a custom zlist does not exist, it will return an empty array as it already does.

**Example**
```
<itop_design>
    <classes>
        <class id="UserRequest">
            <presentation>
                <details>[...]</details>
                <list>[...</list>
                [...]
                <custom_presentations>
                    <custom_presentation id="webhook-action-slack">
                        <items>
                            <item id="caller_id">
                                <rank>10</rank>
                            </item>
                            <item id="org_id">
                                <rank>20</rank>
                            </item>
                        </items>
                    </custom_presentation>
                </custom_presentations>
            </presentation>
        </class>
        <class id="Incident">
            <presentation>
                <custom_presentations>
                    <custom_presentation id="webhook-action-slack">
                        <items>
                            <item id="caller_id">
                                <rank>10</rank>
                            </item>
                        </items>
                    </custom_presentation>
                </custom_presentations>
            </presentation>
        </class>
    </classes>
    <meta>
        <presentation>
            <custom_presentations>
                <custom_presentation id="webhook-action-slack">
                    <description><![CDATA[Will be used by the "Slack notification" Action to display the corresponding attributes in the Slack message. Refer to the "Webhooks integration" extension documentation for more information.]]></description>
                </custom_presentation>
            </custom_presentations>
        </presentation>
    </meta>
</itop_design>
```

**Needs to be done**
  * [ ] Update XML Reference in the wiki
  * [X] Discuss what we want to do in XML conversion methods (iTopDesignFormat)
    We just need to clean nodes when downgrading. Don't automatically add nodes on upgrade as initially discussed.
  * [X] Add unit tests for XML conversion methods