### PR TITLE
N°5893 - Log triggers exception in CRUD stack

### DIFF
--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -2826,24 +2826,14 @@ abstract class DBObject implements iDisplay
 		$oSet = new DBObjectSet(DBObjectSearch::FromOQL("SELECT TriggerOnObjectCreate AS t WHERE t.target_class IN (:class_list)"), array(), $aParams);
 		while ($oTrigger = $oSet->Fetch())
 		{
-			/** @var \Trigger $oTrigger */
+			/** @var \TriggerOnObjectCreate $oTrigger */
 			try
 			{
 				$oTrigger->DoActivate($this->ToArgs('this'));
 			}
 			catch(Exception $e)
 			{
-				IssueLog::Error('A trigger did throw an exception', null, [
-					'exception.class'      => get_class($e),
-					'exception.message'    => $e->getMessage(),
-					'trigger.class'        => get_class($oTrigger),
-					'trigger.id'           => $oTrigger->GetKey(),
-					'trigger.friendlyname' => $oTrigger->GetRawName(),
-					'object.class'         => get_class($this),
-					'object.friendlyname'  => $this->GetRawName(),
-					'current_user'         => UserRights::GetUser(),
-					'exception.stack'      => $e->getTraceAsString(),
-				]);
+				$oTrigger->LogException($e, $this);
 				utils::EnrichRaisedException($oTrigger, $e);
 			}
 		}
@@ -3161,18 +3151,7 @@ abstract class DBObject implements iDisplay
 					$oTrigger->DoActivate($this->ToArgs('this'));
 				}
 				catch (Exception $e) {
-					IssueLog::Error('A trigger did throw an exception', null, [
-						'exception.class'      => get_class($e),
-						'exception.message'    => $e->getMessage(),
-						'trigger.class'        => get_class($oTrigger),
-						'trigger.id'           => $oTrigger->GetKey(),
-						'trigger.friendlyname' => $oTrigger->GetRawName(),
-						'object.class'         => get_class($this),
-						'object.id'            => $this->GetKey(),
-						'object.friendlyname'  => $this->GetRawName(),
-						'current_user'         => UserRights::GetUser(),
-						'exception.stack'      => $e->getTraceAsString(),
-					]);
+					$oTrigger->LogException($e, $this);
 					utils::EnrichRaisedException($oTrigger, $e);
 				}
 			}
@@ -3493,24 +3472,13 @@ abstract class DBObject implements iDisplay
 			$aParams);
 		while ($oTrigger = $oSet->Fetch())
 		{
-			/** @var \Trigger $oTrigger */
+			/** @var \TriggerOnObjectDelete $oTrigger */
 			try
 			{
 				$oTrigger->DoActivate($this->ToArgs('this'));
 			}
 			catch(Exception $e) {
-				IssueLog::Error('A trigger did throw an exception', null, [
-					'exception.class'      => get_class($e),
-					'exception.message'    => $e->getMessage(),
-					'trigger.class'        => get_class($oTrigger),
-					'trigger.id'           => $oTrigger->GetKey(),
-					'trigger.friendlyname' => $oTrigger->GetRawName(),
-					'object.class'         => get_class($this),
-					'object.id'            => $this->GetKey(),
-					'object.friendlyname'  => $this->GetRawName(),
-					'current_user'         => UserRights::GetUser(),
-					'exception.stack'      => $e->getTraceAsString(),
-				]);
+				$oTrigger->LogException($e, $this);
 				utils::EnrichRaisedException($oTrigger, $e);
 			}
 		}
@@ -3925,6 +3893,7 @@ abstract class DBObject implements iDisplay
 					$oTrigger->DoActivate($this->ToArgs('this'));
 				}
 				catch (Exception $e) {
+					$oTrigger->LogException($e, $this);
 					utils::EnrichRaisedException($oTrigger, $e);
 				}
 			}
@@ -3936,6 +3905,7 @@ abstract class DBObject implements iDisplay
 					$oTrigger->DoActivate($this->ToArgs('this'));
 				}
 				catch (Exception $e) {
+					$oTrigger->LogException($e, $this);
 					utils::EnrichRaisedException($oTrigger, $e);
 				}
 			}

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -3161,6 +3161,18 @@ abstract class DBObject implements iDisplay
 					$oTrigger->DoActivate($this->ToArgs('this'));
 				}
 				catch (Exception $e) {
+					IssueLog::Error('A trigger did throw an exception', null, [
+						'exception.class'      => get_class($e),
+						'exception.message'    => $e->getMessage(),
+						'trigger.class'        => get_class($oTrigger),
+						'trigger.id'           => $oTrigger->GetKey(),
+						'trigger.friendlyname' => $oTrigger->GetRawName(),
+						'object.class'         => get_class($this),
+						'object.id'            => $this->GetKey(),
+						'object.friendlyname'  => $this->GetRawName(),
+						'current_user'         => UserRights::GetUser(),
+						'exception.stack'      => $e->getTraceAsString(),
+					]);
 					utils::EnrichRaisedException($oTrigger, $e);
 				}
 			}

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -3498,8 +3498,19 @@ abstract class DBObject implements iDisplay
 			{
 				$oTrigger->DoActivate($this->ToArgs('this'));
 			}
-			catch(Exception $e)
-			{
+			catch(Exception $e) {
+				IssueLog::Error('A trigger did throw an exception', null, [
+					'exception.class'      => get_class($e),
+					'exception.message'    => $e->getMessage(),
+					'trigger.class'        => get_class($oTrigger),
+					'trigger.id'           => $oTrigger->GetKey(),
+					'trigger.friendlyname' => $oTrigger->GetRawName(),
+					'object.class'         => get_class($this),
+					'object.id'            => $this->GetKey(),
+					'object.friendlyname'  => $this->GetRawName(),
+					'current_user'         => UserRights::GetUser(),
+					'exception.stack'      => $e->getTraceAsString(),
+				]);
 				utils::EnrichRaisedException($oTrigger, $e);
 			}
 		}

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -2833,6 +2833,17 @@ abstract class DBObject implements iDisplay
 			}
 			catch(Exception $e)
 			{
+				IssueLog::Error('A trigger did throw an exception', null, [
+					'exception.class'      => get_class($e),
+					'exception.message'    => $e->getMessage(),
+					'trigger.class'        => get_class($oTrigger),
+					'trigger.id'           => $oTrigger->GetKey(),
+					'trigger.friendlyname' => $oTrigger->GetRawName(),
+					'object.class'         => get_class($this),
+					'object.friendlyname'  => $this->GetRawName(),
+					'current_user'         => UserRights::GetUser(),
+					'exception.stack'      => $e->getTraceAsString(),
+				]);
 				utils::EnrichRaisedException($oTrigger, $e);
 			}
 		}

--- a/core/trigger.class.inc.php
+++ b/core/trigger.class.inc.php
@@ -284,7 +284,7 @@ abstract class TriggerOnObject extends Trigger
 	 */
 	public function LogException($oException, $oObject)
 	{
-		$sObjectKey = ($oObject->IsNew()) ? 'N/A' : $oObject->GetKey();
+		$sObjectKey = $oObject->GetKey(); // if object wasn't persisted yet, then we'll have a negative value
 
 		$aContext = [
 			'exception.class'      => get_class($oException),

--- a/core/trigger.class.inc.php
+++ b/core/trigger.class.inc.php
@@ -259,20 +259,47 @@ abstract class TriggerOnObject extends Trigger
 	public function IsTargetObject($iObjectId, $aChanges = array())
 	{
 		$sFilter = trim($this->Get('filter'));
-		if (strlen($sFilter) > 0)
-		{
+		if (strlen($sFilter) > 0) {
 			$oSearch = DBObjectSearch::FromOQL($sFilter);
 			$oSearch->AddCondition('id', $iObjectId, '=');
 			$oSearch->AllowAllData();
 			$oSet = new DBObjectSet($oSearch);
 			$bRet = ($oSet->Count() > 0);
-		}
-		else
-		{
+		} else {
 			$bRet = true;
 		}
 
 		return $bRet;
+	}
+
+	/**
+	 * @param Exception $oException
+	 * @param \DBObject $oObject
+	 *
+	 * @return void
+	 *
+	 * @uses \IssueLog::Error()
+	 *
+	 * @since 2.7.9 3.0.3 3.1.0 N°5893
+	 */
+	public function LogException($oException, $oObject)
+	{
+		$sObjectKey = ($oObject->IsNew()) ? 'N/A' : $oObject->GetKey();
+
+		$aContext = [
+			'exception.class'      => get_class($oException),
+			'exception.message'    => $oException->getMessage(),
+			'trigger.class'        => get_class($this),
+			'trigger.id'           => $this->GetKey(),
+			'trigger.friendlyname' => $this->GetRawName(),
+			'object.class'         => get_class($oObject),
+			'object.id'            => $sObjectKey,
+			'object.friendlyname'  => $oObject->GetRawName(),
+			'current_user'         => UserRights::GetUser(),
+			'exception.stack'      => $oException->getTraceAsString(),
+		];
+
+		IssueLog::Error('A trigger did throw an exception', null, $aContext);
 	}
 }
 


### PR DESCRIPTION
When a trigger throws an exception, blocking the object operation, it's currently very hard to understand what's going on.
This PR adds a log on each trigger exception (insert, update, delete, apply stimulus) that will help to diagnose such error.

In an ideal world, all and every external code call (method override, extensibility interfaces) should be protected by a try/catch block... But it would cost a little bit much, and so another ticket exists to have a greater cover : N°3514.