### PR TITLE
N°6099 DeadLockLog : improve documentation

### DIFF
--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -757,14 +757,15 @@ class DeadLockLog extends LogAPI
 		parent::Enable($sTargetFile);
 	}
 
+	/** @noinspection PhpUnreachableStatementInspection */
 	private static function GetChannelFromMysqlErrorNo($iMysqlErrorNo)
 	{
 		switch ($iMysqlErrorNo)
 		{
-			case 1205:
+			case CMDBSource::MYSQL_ERRNO_WAIT_TIMEOUT:
 				return self::CHANNEL_WAIT_TIMEOUT;
 				break;
-			case 1213:
+			case CMDBSource::MYSQL_ERRNO_DEADLOCK:
 				return self::CHANNEL_DEADLOCK_FOUND;
 				break;
 			default:

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -735,7 +735,9 @@ class ToolsLog extends LogAPI
 
 /**
  * @see \CMDBSource::LogDeadLock()
- * @since 2.7.1
+ * @since 2.7.1 PR #139
+ *
+ * @link https://dev.mysql.com/doc/refman/5.7/en/innodb-deadlocks.html
  */
 class DeadLockLog extends LogAPI
 {

--- a/tests/php-unit-tests/unitary-tests/core/CMDBSource/DeadLockInjection.php
+++ b/tests/php-unit-tests/unitary-tests/core/CMDBSource/DeadLockInjection.php
@@ -56,7 +56,7 @@ class DeadLockInjection
 			if ($this->iRequestCount == $this->iFailAt) {
 				echo "Generating a FAKE DEADLOCK\n";
 				IssueLog::Trace("Generating a FAKE DEADLOCK", 'cmdbsource');
-				throw new MySQLException("FAKE DEADLOCK", [], new Exception("FAKE DEADLOCK", 1213));
+				throw new MySQLException("FAKE DEADLOCK", [], new Exception("FAKE DEADLOCK", CMDBSource::MYSQL_ERRNO_DEADLOCK));
 			}
 		}
 	}


### PR DESCRIPTION
Add phpdoc + use existing constants instead of literals

As a reference : DeadLockLog was added with #139 