### PR TITLE
N°5942 AttributeBlob now displays an image when applicable

### DIFF
--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -2163,14 +2163,14 @@ EOF
 			$this->CompileCommonProperty('mappings', $oField, $aParameters, $sModuleRelativeDir);
 		} elseif ($sAttType == 'AttributeBlob') {
 			$this->CompileCommonProperty('is_null_allowed', $oField, $aParameters, $sModuleRelativeDir, false);
+			$this->CompileCommonProperty('display_max_width', $oField, $aParameters, $sModuleRelativeDir, 128);
+			$this->CompileCommonProperty('display_max_height', $oField, $aParameters, $sModuleRelativeDir, 128);
+			$this->CompileCommonProperty('default_image', $oField, $aParameters, $sModuleRelativeDir);
 			$aParameters['depends_on'] = $sDependencies;
 		} elseif ($sAttType == 'AttributeImage') {
 			$this->CompileCommonProperty('is_null_allowed', $oField, $aParameters, $sModuleRelativeDir, false);
-			$this->CompileCommonProperty('display_max_width', $oField, $aParameters, $sModuleRelativeDir, 128);
-			$this->CompileCommonProperty('display_max_height', $oField, $aParameters, $sModuleRelativeDir, 128);
 			$this->CompileCommonProperty('storage_max_width', $oField, $aParameters, $sModuleRelativeDir, 256);
 			$this->CompileCommonProperty('storage_max_height', $oField, $aParameters, $sModuleRelativeDir, 256);
-			$this->CompileCommonProperty('default_image', $oField, $aParameters, $sModuleRelativeDir);
 			$aParameters['depends_on'] = $sDependencies;
 		} elseif ($sAttType == 'AttributeStopWatch') {
 			$this->CompileCommonProperty('states', $oField, $aParameters, $sModuleRelativeDir);


### PR DESCRIPTION
As pointed in [SF #2130](https://sourceforge.net/p/itop/tickets/2130/), when displaying a list of DocumentFile we don't have thumbnails when attached files are images.

This PR pulls up methods GetAsHtml an related methods from AttributeImage to AttributeBlob : now if an AttributeBlob contains an image it will do the same as AttributeImage. See this DocumentFile list after update : 

![image](https://user-images.githubusercontent.com/8947448/216950774-6b1cae01-1da3-42e4-9b79-4fa76a2badd0.png)

The mime type detection is in the new method \AttributeBlob::IsWebImage

Note that the old \AttributeImage::GetAsHTML is using multiple attribute parameters that are defined in the compiler : 

* display_max_width
* display_max_height
* default_image

I made the bold move of moving those init from AttributeImage to AttributeBlob... But a better way might be to only keep default values ? To be discussed during review.