### PR TITLE
N°5906 Launch Ticket impact analysis after lnk modification

### DIFF
--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -4559,6 +4559,8 @@ HTML;
 				static::FireEventDbLinksChangedForAllObjects();
 			}
 		}
+
+		return $oDeletionPlan;
 	}
 
 		protected function DBDeleteTracked_Internal(&$oDeletionPlan = null)
@@ -5798,7 +5800,7 @@ JS
 	final protected function FireEventCreateDone(): void
 	{
 		self::NotifyAttachedObjectsOnLinkClassModification($this);
-		$this->FireEventDbLinksChangedForCurrentObject();
+		//$this->FireEventDbLinksChangedForCurrentObject();
 		$this->FireEvent(EVENT_DB_CREATE_DONE);
 	}
 
@@ -5817,7 +5819,7 @@ JS
 	final protected function FireEventUpdateDone(array $aChanges): void
 	{
 		self::NotifyAttachedObjectsOnLinkClassModification($this);
-		$this->FireEventDbLinksChangedForCurrentObject();
+		//$this->FireEventDbLinksChangedForCurrentObject();
 
 		$this->FireEvent(EVENT_DB_UPDATE_DONE, ['changes' => $aChanges]);
 	}
@@ -5961,7 +5963,6 @@ JS
 
 		return $bFlagRemoved;
 	}
-
 	/**
 	 * @return void
 	 * @throws \ArchivedObjectException

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -5901,11 +5901,11 @@ JS
 	 * Register one object for later EVENT_DB_LINKS_CHANGED event.
 	 *
 	 * @param string $sClass
-	 * @param string $sId
+	 * @param string|int|null $sId
 	 *
 	 * @since 3.1.0 N°5906
 	 */
-	private static function RegisterObjectAwaitingEventDbLinksChanged(string $sClass, string $sId): void
+	private static function RegisterObjectAwaitingEventDbLinksChanged(string $sClass, $sId): void
 	{
 		if (isset(self::$aObjectsAwaitingEventDbLinksChanged[$sClass][$sId])) {
 			self::$aObjectsAwaitingEventDbLinksChanged[$sClass][$sId]++;
@@ -5938,13 +5938,13 @@ JS
 	 * Fire the EVENT_DB_LINKS_CHANGED event if given object is registered, and unregister it
 	 *
 	 * @param string $sClass
-	 * @param string $sId
+	 * @param string|int|null $sId
 	 *
 	 * @return void
 	 * @throws \ArchivedObjectException
 	 * @throws \CoreException
 	 */
-	private static function FireEventDbLinksChangedForClassId(string $sClass, string $sId): void
+	private static function FireEventDbLinksChangedForClassId(string $sClass, $sId): void
 	{
 		if (true === static::IsEventDBLinksChangedBlocked()) {
 			return;
@@ -5966,12 +5966,12 @@ JS
 	 * Remove the registration of an object concerning the EVENT_DB_LINKS_CHANGED event
 	 *
 	 * @param string $sClass
-	 * @param string $sId
+	 * @param string|int|null $sId
 	 *
 	 * @return bool true if the object [class, id] was present in the list
 	 * @throws \CoreException
 	 */
-	final protected static function RemoveObjectAwaitingEventDbLinksChanged(string $sClass, string $sId): bool
+	final protected static function RemoveObjectAwaitingEventDbLinksChanged(string $sClass, $sId): bool
 	{
 		$bFlagRemoved = false;
 		$aClassesHierarchy = MetaModel::EnumParentClasses($sClass, ENUM_PARENT_CLASSES_ALL, false);

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -5849,13 +5849,27 @@ JS
 			return;
 		}
 
-		$aClassesHierarchy = MetaModel::EnumParentClasses($sClass, ENUM_PARENT_CLASSES_ALL, false);
-		foreach ($aClassesHierarchy as $sClassInHierarchy) {
-			unset(self::$aLinkModificationsStack[$sClassInHierarchy][$sId]);
+		$bIsClassInStack = self::RemoveClassIdFromStack($sClass, $sId);
+		if (false === $bIsClassInStack) {
+			return;
 		}
 
 		$oObject = MetaModel::GetObject($sClass, $sId);
 		$oObject->FireEvent(EVENT_DB_LINKS_CHANGED);
+	}
+
+	final private static function RemoveClassIdFromStack(string $sClass, string $sId): bool
+	{
+		$aClassesHierarchy = MetaModel::EnumParentClasses($sClass, ENUM_PARENT_CLASSES_ALL, false);
+		foreach ($aClassesHierarchy as $sClassInHierarchy) {
+			if (isset(self::$aLinkModificationsStack[$sClassInHierarchy][$sId])) {
+				unset(self::$aLinkModificationsStack[$sClassInHierarchy][$sId]);
+
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	final public static function ProcessAllDeferedUpdates()

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -4456,6 +4456,8 @@ HTML;
 			}
 		} finally {
 			if (static::IsCrudStackEmpty()) {
+				// Avoid signaling the current object that links were modified
+				static::RemoveObjectAwaitingEventDbLinksChanged(get_class($this), $this->GetKey());
 				static::FireEventDbLinksChangedForAllObjects();
 			}
 		}
@@ -4531,6 +4533,8 @@ HTML;
 			}
 		} finally {
 			if (static::IsCrudStackEmpty()) {
+				// Avoid signaling the current object that links were modified
+				static::RemoveObjectAwaitingEventDbLinksChanged(get_class($this), $this->GetKey());
 				static::FireEventDbLinksChangedForAllObjects();
 			}
 		}
@@ -4561,6 +4565,8 @@ HTML;
 			parent::DBDelete($oDeletionPlan);
 		}  finally {
 			if (static::IsCrudStackEmpty()) {
+				// Avoid signaling the current object that links were modified
+				static::RemoveObjectAwaitingEventDbLinksChanged(get_class($this), $this->GetKey());
 				static::FireEventDbLinksChangedForAllObjects();
 			}
 		}
@@ -5965,7 +5971,7 @@ JS
 	 * @return bool true if the object [class, id] was present in the list
 	 * @throws \CoreException
 	 */
-	private static function RemoveObjectAwaitingEventDbLinksChanged(string $sClass, string $sId): bool
+	final protected static function RemoveObjectAwaitingEventDbLinksChanged(string $sClass, string $sId): bool
 	{
 		$bFlagRemoved = false;
 		$aClassesHierarchy = MetaModel::EnumParentClasses($sClass, ENUM_PARENT_CLASSES_ALL, false);

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -5805,7 +5805,6 @@ JS
 	final protected function FireEventCreateDone(): void
 	{
 		$this->NotifyAttachedObjectsOnLinkClassModification();
-		//$this->FireEventDbLinksChangedForCurrentObject();
 		$this->FireEvent(EVENT_DB_CREATE_DONE);
 	}
 
@@ -5824,8 +5823,6 @@ JS
 	final protected function FireEventUpdateDone(array $aChanges): void
 	{
 		$this->NotifyAttachedObjectsOnLinkClassModification();
-		//$this->FireEventDbLinksChangedForCurrentObject();
-
 		$this->FireEvent(EVENT_DB_UPDATE_DONE, ['changes' => $aChanges]);
 	}
 
@@ -5859,7 +5856,7 @@ JS
 
 	/**
 	 * If the passed object is an instance of a link class, then will register each remote object for modification using {@see static::RegisterObjectAwaitingEventDbLinksChanged()}
-	 * If an external key was modified, register also the previous object that the link was modified.
+	 * If an external key was modified, register also the previous object that was linked previously.
 	 *
 	 * @throws \ArchivedObjectException
 	 * @throws \CoreException
@@ -5902,7 +5899,7 @@ JS
 	 *
 	 * @since 3.1.0 N°5906
 	 */
-	final protected static function RegisterObjectAwaitingEventDbLinksChanged(string $sClass, string $sId): void
+	private static function RegisterObjectAwaitingEventDbLinksChanged(string $sClass, string $sId): void
 	{
 		if (isset(self::$aObjectsAwaitingEventDbLinksChanged[$sClass][$sId])) {
 			self::$aObjectsAwaitingEventDbLinksChanged[$sClass][$sId]++;
@@ -5920,7 +5917,7 @@ JS
 	 *
 	 * @since 3.1.0 N°5906
 	 */
-	final public function FireEventDbLinksChangedForCurrentObject(): void
+	final protected function FireEventDbLinksChangedForCurrentObject(): void
 	{
 		if (true === static::IsEventDBLinksChangedBlocked()) {
 			return;
@@ -6009,17 +6006,17 @@ JS
 	 *
 	 * @return bool
 	 */
-	public static function IsEventDBLinksChangedBlocked(): bool
+	final public static function IsEventDBLinksChangedBlocked(): bool
 	{
 		return self::$bBlockEventDBLinksChanged;
 	}
 
 	/**
-	 * Block/unblock the event EVENT_DB_LINKS_CHANGED (the registration of objects on links modifications continue to work)
+	 * Block/unblock the event EVENT_DB_LINKS_CHANGED (the registration of objects on links modifications continues to work)
 	 *
 	 * @param bool $bBlockEventDBLinksChanged
 	 */
-	public static function SetEventDBLinksChangedBlocked(bool $bBlockEventDBLinksChanged): void
+	final public static function SetEventDBLinksChangedBlocked(bool $bBlockEventDBLinksChanged): void
 	{
 		self::$bBlockEventDBLinksChanged = $bBlockEventDBLinksChanged;
 	}

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -5848,11 +5848,6 @@ JS
 		if ($sClass === self::class) {
 			return;
 		}
-		if (false === isset(self::$aLinkModificationsStack[$sClass][$sId])) {
-			self::ProcessClassIdDeferedUpdate(MetaModel::GetParentClass($sClass), $sId);
-
-			return;
-		}
 
 		unset(self::$aLinkModificationsStack[$sClass][$sId]);
 		$oObject = MetaModel::GetObject($sClass, $sId);

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -5829,8 +5829,11 @@ JS
 	 */
 	final protected static function RegisterLinkModification($sClass, $sId): void
 	{
-		// the @ get rid of undefined index warnings
-		@self::$aLinkModificationsStack[$sClass][$sId]++;
+		if (isset(self::$aLinkModificationsStack[$sClass][$sId])) {
+			self::$aLinkModificationsStack[$sClass][$sId]++;
+		} else {
+			self::$aLinkModificationsStack[$sClass][$sId] = 1;
+		}
 	}
 
 	final public function ProcessObjectDeferedUpdates()

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -5820,7 +5820,7 @@ JS
 
 			$oExternalKeyAttDef = MetaModel::GetAttributeDef($sClass, $sExternalKeyAttCode);
 			$sRemoteClassName = $oExternalKeyAttDef->GetTargetClass();
-			static::RegisterLinkModification($sRemoteClassName, $sRemoteObjectId);
+			self::RegisterLinkModification($sRemoteClassName, $sRemoteObjectId);
 		}
 	}
 
@@ -5849,7 +5849,7 @@ JS
 			return;
 		}
 
-		unset(self::$aLinkModificationsStack[$sClass][$sId]);
+		unset(self::$aLinkModificationsStack[$sClass][$sId]); // FIXME cannot do that, we are on a leaf class
 		$oObject = MetaModel::GetObject($sClass, $sId);
 		$oObject->FireEvent(EVENT_DB_LINKS_CHANGED);
 	}

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -5755,6 +5755,7 @@ JS
 	final protected function FireEventCreateDone(): void
 	{
 		self::CheckLinkModifications($this);
+		$this->ProcessObjectDeferedUpdates();
 		$this->FireEvent(EVENT_DB_CREATE_DONE);
 	}
 

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -5881,7 +5881,7 @@ JS
 	 * @throws \ArchivedObjectException
 	 * @throws \CoreException
 	 */
-	final private static function FireEventDbLinksChangedForClassId(string $sClass, string $sId): void
+	private static function FireEventDbLinksChangedForClassId(string $sClass, string $sId): void
 	{
 		if ($sClass === self::class) {
 			return;
@@ -5906,7 +5906,7 @@ JS
 	 * @return bool true if the object [class, id] was present in the list
 	 * @throws \CoreException
 	 */
-	final private static function RemoveObjectAwaitingEventDbLinksChanged(string $sClass, string $sId): bool
+	private static function RemoveObjectAwaitingEventDbLinksChanged(string $sClass, string $sId): bool
 	{
 		$bFlagRemoved = false;
 		$aClassesHierarchy = MetaModel::EnumParentClasses($sClass, ENUM_PARENT_CLASSES_ALL, false);

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -5849,7 +5849,11 @@ JS
 			return;
 		}
 
-		unset(self::$aLinkModificationsStack[$sClass][$sId]); // FIXME cannot do that, we are on a leaf class
+		$aClassesHierarchy = MetaModel::EnumParentClasses($sClass, ENUM_PARENT_CLASSES_ALL, false);
+		foreach ($aClassesHierarchy as $sClassInHierarchy) {
+			unset(self::$aLinkModificationsStack[$sClassInHierarchy][$sId]);
+		}
+
 		$oObject = MetaModel::GetObject($sClass, $sId);
 		$oObject->FireEvent(EVENT_DB_LINKS_CHANGED);
 	}

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -5856,6 +5856,9 @@ JS
 
 		$oObject = MetaModel::GetObject($sClass, $sId);
 		$oObject->FireEvent(EVENT_DB_LINKS_CHANGED);
+
+		// The event listeners might have generated new lnk instances pointing to thi object, so removing object from stack to avoid reentrance
+		self::RemoveClassIdFromStack($sClass, $sId);
 	}
 
 	final private static function RemoveClassIdFromStack(string $sClass, string $sId): bool

--- a/application/datamodel.application.xml
+++ b/application/datamodel.application.xml
@@ -371,6 +371,22 @@
         </event_datum>
       </event_data>
     </event>
+    <event id="EVENT_DB_LINKS_CHANGED" _delta="define">
+      <description>At least one link class was changed</description>
+      <sources>
+        <source id="cmdbAbstractObject">cmdbAbstractObject</source>
+      </sources>
+      <event_data>
+        <event_datum id="object">
+          <description>The object re-loaded</description>
+          <type>DBObject</type>
+        </event_datum>
+        <event_datum id="debug_info">
+          <description>Debug string</description>
+          <type>string</type>
+        </event_datum>
+      </event_data>
+    </event>
     <event id="EVENT_DB_OBJECT_RELOAD" _delta="define">
       <description>An object has been re-loaded from the database</description>
       <sources>

--- a/core/bulkchange.class.inc.php
+++ b/core/bulkchange.class.inc.php
@@ -1162,7 +1162,7 @@ class BulkChange
 		$iLoopTimeLimit = MetaModel::GetConfig()->Get('max_execution_time_per_loop');
 
 		// Avoid too many events
-		cmdbAbstractObject::SetEventDBLinksChangedAllowed(false);
+		cmdbAbstractObject::SetEventDBLinksChangedBlocked(true);
 		try {
 			foreach ($this->m_aData as $iRow => $aRowData) {
 				set_time_limit(intval($iLoopTimeLimit));
@@ -1262,7 +1262,7 @@ class BulkChange
 			}
 		} finally {
 			// Send all the retained events for further computations
-			cmdbAbstractObject::SetEventDBLinksChangedAllowed(true);
+			cmdbAbstractObject::SetEventDBLinksChangedBlocked(false);
 			cmdbAbstractObject::FireEventDbLinksChangedForAllObjects();
 		}
 

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -157,6 +157,12 @@ abstract class DBObject implements iDisplay
 	protected $m_oLinkHostObject = null;
 
 	/**
+	 * @var array List all the CRUD stack in progress
+	 * @since 3.1.0 N°5906
+	 */
+	protected static array $m_aCrudStack = [];
+
+	/**
      * DBObject constructor.
      *
      * You should preferably use MetaModel::NewObject() instead of this constructor.
@@ -2952,148 +2958,161 @@ abstract class DBObject implements iDisplay
 	public function DBInsertNoReload()
 	{
 		$sClass = get_class($this);
-        if (MetaModel::DBIsReadOnly())
-        {
-            $sErrorMessage = "Cannot Insert object of class '$sClass' because of an ongoing maintenance: the database is in ReadOnly mode";
 
-            IssueLog::Error("$sErrorMessage\n".MyHelpers::get_callstack_text(1));
-            throw new CoreException("$sErrorMessage (see the log for more information)");
-        }
-
-		if ($this->m_bIsInDB) {
-			throw new CoreException('The object already exists into the Database, you may want to use the clone function');
-		}
-
-		$sClass = get_class($this);
-		$sRootClass = MetaModel::GetRootClass($sClass);
-
-		// Ensure the update of the values (we are accessing the data directly)
-		$this->DoComputeValues();
-		$this->OnInsert();
-
-		// If not automatically computed, then check that the key is given by the caller
-		if (!MetaModel::IsAutoIncrementKey($sRootClass)) {
-			if (empty($this->m_iKey)) {
-				throw new CoreWarning('Missing key for the object to write - This class is supposed to have a user defined key, not an autonumber', array('class' => $sRootClass));
-			}
-		}
-
-		list($bRes, $aIssues) = $this->CheckToWrite(false);
-		if (!$bRes) {
-			throw new CoreCannotSaveObjectException(array('issues' => $aIssues, 'class' => get_class($this), 'id' => $this->GetKey()));
-		}
-
-		if ($this->m_iKey < 0) {
-			// This was a temporary "memory" key: discard it so that DBInsertSingleTable will not try to use it!
-			$this->m_iKey = null;
-		}
-
-		$this->ComputeStopWatchesDeadline(true);
-
-		$iTransactionRetry = 1;
-		$bIsTransactionEnabled = MetaModel::GetConfig()->Get('db_core_transactions_enabled');
-		if ($bIsTransactionEnabled) {
-			// TODO Deep clone this object before the transaction (to use it in case of rollback)
-			// $iTransactionRetryCount = MetaModel::GetConfig()->Get('db_core_transactions_retry_count');
-			$iTransactionRetryCount = 1;
-			$iTransactionRetryDelay = MetaModel::GetConfig()->Get('db_core_transactions_retry_delay_ms');
-			$iTransactionRetry = $iTransactionRetryCount;
-		}
-		while ($iTransactionRetry > 0) {
-			try {
-				$iTransactionRetry--;
-				if ($bIsTransactionEnabled) {
-					CMDBSource::Query('START TRANSACTION');
-				}
-
-				// First query built upon on the root class, because the ID must be created first
-				$this->m_iKey = $this->DBInsertSingleTable($sRootClass);
-
-				// Then do the leaf class, if different from the root class
-				if ($sClass != $sRootClass) {
-					$this->DBInsertSingleTable($sClass);
-				}
-
-				// Then do the other classes
-				foreach (MetaModel::EnumParentClasses($sClass) as $sParentClass) {
-					if ($sParentClass == $sRootClass) {
-						continue;
-					}
-					$this->DBInsertSingleTable($sParentClass);
-				}
-
-				$this->OnObjectKeyReady();
-
-				$this->DBWriteLinks();
-				$this->WriteExternalAttributes();
-
-				// Write object creation history within the transaction
-				$this->RecordObjCreation();
-
-				if ($bIsTransactionEnabled) {
-					CMDBSource::Query('COMMIT');
-				}
-				break;
-			}
-			catch (Exception $e) {
-				IssueLog::Error($e->getMessage());
-				if ($bIsTransactionEnabled) {
-					CMDBSource::Query('ROLLBACK');
-					if (!CMDBSource::IsInsideTransaction() && CMDBSource::IsDeadlockException($e)) {
-						// Deadlock found when trying to get lock; try restarting transaction (only in main transaction)
-						if ($iTransactionRetry > 0) {
-							// wait and retry
-							IssueLog::Error('Insert TRANSACTION Retrying...');
-							usleep(random_int(1, 5) * 1000 * $iTransactionRetryDelay * ($iTransactionRetryCount - $iTransactionRetry));
-							continue;
-						} else {
-							IssueLog::Error('Insert Deadlock TRANSACTION prevention failed.');
-						}
-					}
-				}
-				throw $e;
-			}
-		}
-
-		$this->m_bIsInDB = true;
-		$this->m_bDirty = false;
-		foreach ($this->m_aCurrValues as $sAttCode => $value) {
-			if (is_object($value)) {
-				$value = clone $value;
-			}
-			$this->m_aOrigValues[$sAttCode] = $value;
-		}
-
-		// Prevent DBUpdate at this point (reentrance protection)
-		MetaModel::StartReentranceProtection($this);
+		$this->AddCurrentObjectInCrudStack('INSERT');
 
 		try {
-			$this->FireEventCreateDone();
-			$this->AfterInsert();
+	        if (MetaModel::DBIsReadOnly())
+	        {
+	            $sErrorMessage = "Cannot Insert object of class '$sClass' because of an ongoing maintenance: the database is in ReadOnly mode";
 
-			// Activate any existing trigger
+	            IssueLog::Error("$sErrorMessage\n".MyHelpers::get_callstack_text(1));
+	            throw new CoreException("$sErrorMessage (see the log for more information)");
+	        }
+
+			if ($this->m_bIsInDB) {
+				throw new CoreException('The object already exists into the Database, you may want to use the clone function');
+			}
+
 			$sClass = get_class($this);
-			$aParams = array('class_list' => MetaModel::EnumParentClasses($sClass, ENUM_PARENT_CLASSES_ALL));
-			$oSet = new DBObjectSet(DBObjectSearch::FromOQL('SELECT TriggerOnObjectCreate AS t WHERE t.target_class IN (:class_list)'), array(), $aParams);
-			while ($oTrigger = $oSet->Fetch()) {
-				/** @var \Trigger $oTrigger */
-				try {
-					$oTrigger->DoActivate($this->ToArgs('this'));
-				}
-				catch (Exception $e) {
-					utils::EnrichRaisedException($oTrigger, $e);
+			$sRootClass = MetaModel::GetRootClass($sClass);
+
+			// Ensure the update of the values (we are accessing the data directly)
+			$this->DoComputeValues();
+			$this->OnInsert();
+			if ($this->m_iKey < 0) {
+				// This was a temporary "memory" key: discard it so that DBInsertSingleTable will not try to use it!
+				$this->m_iKey = null;
+				$this->UpdateCurrentObjectInCrudStack();
+			}
+			// If not automatically computed, then check that the key is given by the caller
+			if (!MetaModel::IsAutoIncrementKey($sRootClass)) {
+				if (empty($this->m_iKey)) {
+					throw new CoreWarning('Missing key for the object to write - This class is supposed to have a user defined key, not an autonumber', array('class' => $sRootClass));
 				}
 			}
 
-			// - TriggerOnObjectMention
-			$this->ActivateOnMentionTriggers(true);
+			list($bRes, $aIssues) = $this->CheckToWrite(false);
+			if (!$bRes) {
+				throw new CoreCannotSaveObjectException(array('issues' => $aIssues, 'class' => get_class($this), 'id' => $this->GetKey()));
+			}
+
+			if ($this->m_iKey < 0) {
+				// This was a temporary "memory" key: discard it so that DBInsertSingleTable will not try to use it!
+				$this->m_iKey = null;
+			}
+
+			$this->ComputeStopWatchesDeadline(true);
+
+			$iTransactionRetry = 1;
+			$bIsTransactionEnabled = MetaModel::GetConfig()->Get('db_core_transactions_enabled');
+			if ($bIsTransactionEnabled) {
+				// TODO Deep clone this object before the transaction (to use it in case of rollback)
+				// $iTransactionRetryCount = MetaModel::GetConfig()->Get('db_core_transactions_retry_count');
+				$iTransactionRetryCount = 1;
+				$iTransactionRetryDelay = MetaModel::GetConfig()->Get('db_core_transactions_retry_delay_ms');
+				$iTransactionRetry = $iTransactionRetryCount;
+			}
+			while ($iTransactionRetry > 0) {
+				try {
+					$iTransactionRetry--;
+					if ($bIsTransactionEnabled) {
+						CMDBSource::Query('START TRANSACTION');
+					}
+
+					// First query built upon on the root class, because the ID must be created first
+					$this->m_iKey = $this->DBInsertSingleTable($sRootClass);
+
+					// Then do the leaf class, if different from the root class
+					if ($sClass != $sRootClass) {
+						$this->DBInsertSingleTable($sClass);
+					}
+
+					// Then do the other classes
+					foreach (MetaModel::EnumParentClasses($sClass) as $sParentClass) {
+						if ($sParentClass == $sRootClass) {
+							continue;
+						}
+						$this->DBInsertSingleTable($sParentClass);
+					}
+
+					$this->OnObjectKeyReady();
+					$this->UpdateCurrentObjectInCrudStack();
+
+					$this->DBWriteLinks();
+					$this->WriteExternalAttributes();
+
+					// Write object creation history within the transaction
+					$this->RecordObjCreation();
+
+					if ($bIsTransactionEnabled) {
+						CMDBSource::Query('COMMIT');
+					}
+					break;
+				}
+				catch (Exception $e) {
+					IssueLog::Error($e->getMessage());
+					if ($bIsTransactionEnabled) {
+						CMDBSource::Query('ROLLBACK');
+						if (!CMDBSource::IsInsideTransaction() && CMDBSource::IsDeadlockException($e)) {
+							// Deadlock found when trying to get lock; try restarting transaction (only in main transaction)
+							if ($iTransactionRetry > 0) {
+								// wait and retry
+								IssueLog::Error('Insert TRANSACTION Retrying...');
+								usleep(random_int(1, 5) * 1000 * $iTransactionRetryDelay * ($iTransactionRetryCount - $iTransactionRetry));
+								continue;
+							} else {
+								IssueLog::Error('Insert Deadlock TRANSACTION prevention failed.');
+							}
+						}
+					}
+					throw $e;
+				}
+			}
+
+			$this->m_bIsInDB = true;
+			$this->m_bDirty = false;
+			foreach ($this->m_aCurrValues as $sAttCode => $value) {
+				if (is_object($value)) {
+					$value = clone $value;
+				}
+				$this->m_aOrigValues[$sAttCode] = $value;
+			}
+
+			// Prevent DBUpdate at this point (reentrance protection)
+			MetaModel::StartReentranceProtection($this);
+
+			try {
+				$this->FireEventCreateDone();
+				$this->AfterInsert();
+
+				// Activate any existing trigger
+				$sClass = get_class($this);
+				$aParams = array('class_list' => MetaModel::EnumParentClasses($sClass, ENUM_PARENT_CLASSES_ALL));
+				$oSet = new DBObjectSet(DBObjectSearch::FromOQL('SELECT TriggerOnObjectCreate AS t WHERE t.target_class IN (:class_list)'), array(), $aParams);
+				while ($oTrigger = $oSet->Fetch()) {
+					/** @var \Trigger $oTrigger */
+					try {
+						$oTrigger->DoActivate($this->ToArgs('this'));
+					}
+					catch (Exception $e) {
+						utils::EnrichRaisedException($oTrigger, $e);
+					}
+				}
+
+				// - TriggerOnObjectMention
+				$this->ActivateOnMentionTriggers(true);
+			}
+			finally {
+				MetaModel::StopReentranceProtection($this);
+			}
+
+			if ($this->IsModified()) {
+				$this->DBUpdate();
+			}
 		}
 		finally {
-			MetaModel::StopReentranceProtection($this);
-		}
-
-		if ($this->IsModified()) {
-			$this->DBUpdate();
+			$this->RemoveCurrentObjectInCrudStack();
 		}
 
 		return $this->m_iKey;
@@ -3167,8 +3186,9 @@ abstract class DBObject implements iDisplay
 			return false;
 		}
 
-		try
-		{
+		$this->AddCurrentObjectInCrudStack('UPDATE');
+
+		try {
 			$this->DoComputeValues();
 			$this->ComputeStopWatchesDeadline(false);
 			$this->OnUpdate();
@@ -3391,6 +3411,7 @@ abstract class DBObject implements iDisplay
 		finally
 		{
 			MetaModel::StopReentranceProtection($this);
+			$this->RemoveCurrentObjectInCrudStack();
 		}
 
 		if ($this->IsModified() || $bModifiedByUpdateDone) {
@@ -3781,7 +3802,14 @@ abstract class DBObject implements iDisplay
 				if ($oToDelete->m_bIsInDB)
 				{
 					set_time_limit(intval($iLoopTimeLimit));
-					$oToDelete->DBDeleteSingleObject();
+
+					$oToDelete->AddCurrentObjectInCrudStack('DELETE');
+					try {
+						$oToDelete->DBDeleteSingleObject();
+					}
+					finally {
+						$oToDelete->RemoveCurrentObjectInCrudStack();
+					}
 				}
 			}
 		}
@@ -5965,6 +5993,63 @@ abstract class DBObject implements iDisplay
 	 */
 	protected function FireEventUnArchive(): void
 	{
+	}
+
+	//////////////
+	/// CRUD stack in progress
+	///
+	/**
+	 * @since 3.1.0 N°5609
+	 */
+	public static function IsObjectCurrentlyInCrud(string $sClass, ?string $sId): bool
+	{
+		// during insert key is reset from -1 to null
+		// so we need to handle null values (will give empty string after conversion)
+		$sConvertedId = (string)$sId;
+
+		foreach (self::$m_aCrudStack as $aCrudStackEntry) {
+			if (($sClass === $aCrudStackEntry['class'])
+				&& ($sConvertedId === $aCrudStackEntry['id'])) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @since 3.1.0 N°5609
+	 */
+	public static function IsClassCurrentlyInCrud(string $sClass): bool
+	{
+		foreach (self::$m_aCrudStack as $aCrudStackEntry) {
+			if ($sClass === $aCrudStackEntry['class']) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	protected function AddCurrentObjectInCrudStack(string $sCrudType): void
+	{
+		self::$m_aCrudStack[] = [
+			'type'  => $sCrudType,
+			'class' => get_class($this),
+			'id'    => (string)$this->GetKey(), // GetKey() doesn't have type hinting, so forcing type to avoid getting an int
+		];
+	}
+
+	protected function UpdateCurrentObjectInCrudStack(): void
+	{
+		$aCurrentCrudStack = array_pop(self::$m_aCrudStack);
+		$aCurrentCrudStack['id'] = (string)$this->GetKey();
+		self::$m_aCrudStack[] = $aCurrentCrudStack;
+	}
+
+	protected function RemoveCurrentObjectInCrudStack(): void
+	{
+		array_pop(self::$m_aCrudStack);
 	}
 }
 

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -6051,5 +6051,10 @@ abstract class DBObject implements iDisplay
 	{
 		array_pop(self::$m_aCrudStack);
 	}
+
+	protected function IsCrudStackEmpty(): bool
+	{
+		return count(self::$m_aCrudStack) === 0;
+	}
 }
 

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -158,6 +158,12 @@ abstract class DBObject implements iDisplay
 
 	/**
 	 * @var array List all the CRUD stack in progress
+	 *
+	 * The array contains instances of
+	 * ['type' => 'type of CRUD operation (INSERT, UPDATE, DELETE)',
+	 *  'class' => 'class of the object in the CRUD process',
+	 *  'id' => 'id of the object in the CRUD process']
+	 *
 	 * @since 3.1.0 N°5906
 	 */
 	protected static array $m_aCrudStack = [];
@@ -5998,10 +6004,17 @@ abstract class DBObject implements iDisplay
 	//////////////
 	/// CRUD stack in progress
 	///
+
 	/**
+	 * Check if an object is currently involved in CRUD operation
+	 *
+	 * @param string $sClass
+	 * @param string|null $sId
+	 *
+	 * @return bool
 	 * @since 3.1.0 N°5609
 	 */
-	public static function IsObjectCurrentlyInCrud(string $sClass, ?string $sId): bool
+	final public static function IsObjectCurrentlyInCrud(string $sClass, ?string $sId): bool
 	{
 		// during insert key is reset from -1 to null
 		// so we need to handle null values (will give empty string after conversion)
@@ -6018,9 +6031,14 @@ abstract class DBObject implements iDisplay
 	}
 
 	/**
+	 * Check if an object of the given class  is currently involved in CRUD operation
+	 *
+	 * @param string $sClass
+	 *
+	 * @return bool
 	 * @since 3.1.0 N°5609
 	 */
-	public static function IsClassCurrentlyInCrud(string $sClass): bool
+	final public static function IsClassCurrentlyInCrud(string $sClass): bool
 	{
 		foreach (self::$m_aCrudStack as $aCrudStackEntry) {
 			if ($sClass === $aCrudStackEntry['class']) {
@@ -6031,7 +6049,15 @@ abstract class DBObject implements iDisplay
 		return false;
 	}
 
-	protected function AddCurrentObjectInCrudStack(string $sCrudType): void
+	/**
+	 * Add the current object to the CRUD stack
+	 *
+	 * @param string $sCrudType
+	 *
+	 * @return void
+	 * @since 3.1.0 N°5609
+	 */
+	private function AddCurrentObjectInCrudStack(string $sCrudType): void
 	{
 		self::$m_aCrudStack[] = [
 			'type'  => $sCrudType,
@@ -6040,19 +6066,38 @@ abstract class DBObject implements iDisplay
 		];
 	}
 
-	protected function UpdateCurrentObjectInCrudStack(): void
+	/**
+	 * Update the last entry of the CRUD stack with the information of the current object
+	 * This is calls during DBInsert since the object id changes
+	 *
+	 * @return void
+	 * @since 3.1.0 N°5609
+	 */
+	private function UpdateCurrentObjectInCrudStack(): void
 	{
 		$aCurrentCrudStack = array_pop(self::$m_aCrudStack);
 		$aCurrentCrudStack['id'] = (string)$this->GetKey();
 		self::$m_aCrudStack[] = $aCurrentCrudStack;
 	}
 
-	protected function RemoveCurrentObjectInCrudStack(): void
+	/**
+	 * Remove the last entry of the CRUD stack
+	 *
+	 * @return void
+	 * @since 3.1.0 N°5609
+	 */
+	private function RemoveCurrentObjectInCrudStack(): void
 	{
 		array_pop(self::$m_aCrudStack);
 	}
 
-	protected function IsCrudStackEmpty(): bool
+	/**
+	 * Check if there are objects in the CRUD stack
+	 *
+	 * @return bool
+	 * @since 3.1.0 N°5609
+	 */
+	final protected function IsCrudStackEmpty(): bool
 	{
 		return count(self::$m_aCrudStack) === 0;
 	}

--- a/datamodels/2.x/itop-change-mgmt-itil/datamodel.itop-change-mgmt-itil.xml
+++ b/datamodels/2.x/itop-change-mgmt-itil/datamodel.itop-change-mgmt-itil.xml
@@ -1022,8 +1022,7 @@
           <code><![CDATA[
     protected function OnInsert()
 	{
-        parent::OnInsert();
-        $this->UpdateImpactedItems();
+    parent::OnInsert();
 		$this->SetIfNull('creation_date', time());
 		$this->SetIfNull('last_update', time());
 	}]]></code>
@@ -1036,11 +1035,6 @@
     protected function OnUpdate()
   	{
         parent::OnUpdate();
-        $aChanges = $this->ListChanges();
-        if (array_key_exists('functionalcis_list', $aChanges))
-        {
-            $this->UpdateImpactedItems();
-        }
   	    $this->Set('last_update', time());
   	}]]></code>
         </method>

--- a/datamodels/2.x/itop-change-mgmt-itil/datamodel.itop-change-mgmt-itil.xml
+++ b/datamodels/2.x/itop-change-mgmt-itil/datamodel.itop-change-mgmt-itil.xml
@@ -1023,6 +1023,7 @@
     protected function OnInsert()
 	{
     parent::OnInsert();
+    $this->UpdateImpactedItems();
 		$this->SetIfNull('creation_date', time());
 		$this->SetIfNull('last_update', time());
 	}]]></code>
@@ -1035,6 +1036,11 @@
     protected function OnUpdate()
   	{
         parent::OnUpdate();
+        $aChanges = $this->ListChanges();
+        if (array_key_exists('functionalcis_list', $aChanges))
+        {
+            $this->UpdateImpactedItems();
+        }
   	    $this->Set('last_update', time());
   	}]]></code>
         </method>

--- a/datamodels/2.x/itop-change-mgmt/datamodel.itop-change-mgmt.xml
+++ b/datamodels/2.x/itop-change-mgmt/datamodel.itop-change-mgmt.xml
@@ -582,8 +582,9 @@
     protected function OnInsert()
 	{
         parent::OnInsert();
-		$this->SetIfNull('creation_date', time());
-		$this->SetIfNull('last_update', time());
+        $this->UpdateImpactedItems();
+        $this->SetIfNull('creation_date', time());
+        $this->SetIfNull('last_update', time());
 	}]]></code>
         </method>
         <method id="OnUpdate">
@@ -594,6 +595,11 @@
     protected function OnUpdate()
 	{
     parent::OnUpdate();
+    $aChanges = $this->ListChanges();
+    if (array_key_exists('functionalcis_list', $aChanges))
+    {
+        $this->UpdateImpactedItems();
+    }
 		$this->Set('last_update', time());
 	}]]></code>
         </method>

--- a/datamodels/2.x/itop-change-mgmt/datamodel.itop-change-mgmt.xml
+++ b/datamodels/2.x/itop-change-mgmt/datamodel.itop-change-mgmt.xml
@@ -582,7 +582,6 @@
     protected function OnInsert()
 	{
         parent::OnInsert();
-        $this->UpdateImpactedItems();
 		$this->SetIfNull('creation_date', time());
 		$this->SetIfNull('last_update', time());
 	}]]></code>
@@ -594,12 +593,7 @@
           <code><![CDATA[
     protected function OnUpdate()
 	{
-        parent::OnUpdate();
-        $aChanges = $this->ListChanges();
-        if (array_key_exists('functionalcis_list', $aChanges))
-        {
-            $this->UpdateImpactedItems();
-        }
+    parent::OnUpdate();
 		$this->Set('last_update', time());
 	}]]></code>
         </method>

--- a/datamodels/2.x/itop-incident-mgmt-itil/datamodel.itop-incident-mgmt-itil.xml
+++ b/datamodels/2.x/itop-incident-mgmt-itil/datamodel.itop-incident-mgmt-itil.xml
@@ -1497,6 +1497,11 @@
           <code><![CDATA[	protected function OnUpdate()
 	{
     parent::OnUpdate();
+    $aChanges = $this->ListChanges();
+    if (array_key_exists('functionalcis_list', $aChanges))
+    {
+        $this->UpdateImpactedItems();
+    }
 		$this->Set('last_update', time());
 		$this->UpdateChildRequestLog();
 		$this->UpdateChildIncidentLog();

--- a/datamodels/2.x/itop-incident-mgmt-itil/datamodel.itop-incident-mgmt-itil.xml
+++ b/datamodels/2.x/itop-incident-mgmt-itil/datamodel.itop-incident-mgmt-itil.xml
@@ -1496,12 +1496,7 @@
           <type>Overload-DBObject</type>
           <code><![CDATA[	protected function OnUpdate()
 	{
-        parent::OnUpdate();
-        $aChanges = $this->ListChanges();
-        if (array_key_exists('functionalcis_list', $aChanges))
-        {
-            $this->UpdateImpactedItems();
-        }
+    parent::OnUpdate();
 		$this->Set('last_update', time());
 		$this->UpdateChildRequestLog();
 		$this->UpdateChildIncidentLog();

--- a/datamodels/2.x/itop-request-mgmt-itil/datamodel.itop-request-mgmt-itil.xml
+++ b/datamodels/2.x/itop-request-mgmt-itil/datamodel.itop-request-mgmt-itil.xml
@@ -1566,12 +1566,7 @@
           <code><![CDATA[
     protected function OnUpdate()
 	{
-        parent::OnUpdate();
-        $aChanges = $this->ListChanges();
-        if (array_key_exists('functionalcis_list', $aChanges))
-        {
-            $this->UpdateImpactedItems();
-        }
+    parent::OnUpdate();
 		$this->Set('last_update', time());
 		$this->UpdateChildRequestLog();
 	}]]></code>

--- a/datamodels/2.x/itop-request-mgmt-itil/datamodel.itop-request-mgmt-itil.xml
+++ b/datamodels/2.x/itop-request-mgmt-itil/datamodel.itop-request-mgmt-itil.xml
@@ -1567,6 +1567,11 @@
     protected function OnUpdate()
 	{
     parent::OnUpdate();
+    $aChanges = $this->ListChanges();
+    if (array_key_exists('functionalcis_list', $aChanges))
+    {
+        $this->UpdateImpactedItems();
+    }
 		$this->Set('last_update', time());
 		$this->UpdateChildRequestLog();
 	}]]></code>

--- a/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
+++ b/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
@@ -1236,6 +1236,13 @@
           </state>
         </states>
       </lifecycle>
+      <event_listeners>
+        <listener id="UpdateImpactAnalysis">
+          <event>EVENT_DB_LINKS_CHANGED</event>
+          <callback>UpdateImpactedItems</callback>
+          <rank>0</rank>
+        </listener>
+      </event_listeners>
       <methods>
         <method id="GetTicketRefFormat">
           <static>true</static>
@@ -1596,8 +1603,7 @@
           <code><![CDATA[
     protected function OnInsert()
 	{
-        parent::OnInsert();
-		$this->ComputeImpactedItems();
+    parent::OnInsert();
 
 		$this->SetIfNull('last_update', time());
 		$this->SetIfNull('start_date', time());
@@ -1610,12 +1616,8 @@
           <code><![CDATA[
    	protected function OnUpdate()
 	{
-        parent::OnUpdate();
-        $aChanges = $this->ListChanges();
-        if (array_key_exists('functionalcis_list', $aChanges))
-        {
-            $this->UpdateImpactedItems();
-        }
+    parent::OnUpdate();
+
 		$this->Set('last_update', time());
 		$this->UpdateChildRequestLog();
 	}]]></code>

--- a/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
+++ b/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
@@ -1239,7 +1239,7 @@
       <event_listeners>
         <listener id="UpdateImpactAnalysis">
           <event>EVENT_DB_LINKS_CHANGED</event>
-          <callback>UpdateImpactedItems</callback>
+          <callback>UpdateTicketImpactedItems</callback>
           <rank>0</rank>
         </listener>
       </event_listeners>
@@ -1621,6 +1621,18 @@
 		$this->Set('last_update', time());
 		$this->UpdateChildRequestLog();
 	}]]></code>
+        </method>
+        <method id="UpdateTicketImpactedItems">
+          <comment></comment>
+          <static>false</static>
+          <access>public</access>
+          <type>EventListener</type>
+          <code><![CDATA[
+public function UpdateTicketImpactedItems(Combodo\iTop\Service\Events\EventData $oEventData) {
+    $this->UpdateImpactedItems();
+    $this->DBWrite();
+}
+            ]]></code>
         </method>
       </methods>
       <presentation>

--- a/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
+++ b/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
@@ -1597,7 +1597,7 @@
     protected function OnInsert()
 	{
     parent::OnInsert();
-
+    $this->UpdateImpactedItems();
 		$this->SetIfNull('last_update', time());
 		$this->SetIfNull('start_date', time());
 	}]]></code>
@@ -1610,7 +1610,11 @@
    	protected function OnUpdate()
 	{
     parent::OnUpdate();
-
+    $aChanges = $this->ListChanges();
+    if (array_key_exists('functionalcis_list', $aChanges))
+    {
+        $this->UpdateImpactedItems();
+    }
 		$this->Set('last_update', time());
 		$this->UpdateChildRequestLog();
 	}]]></code>

--- a/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
+++ b/datamodels/2.x/itop-request-mgmt/datamodel.itop-request-mgmt.xml
@@ -1236,13 +1236,6 @@
           </state>
         </states>
       </lifecycle>
-      <event_listeners>
-        <listener id="UpdateImpactAnalysis">
-          <event>EVENT_DB_LINKS_CHANGED</event>
-          <callback>UpdateTicketImpactedItems</callback>
-          <rank>0</rank>
-        </listener>
-      </event_listeners>
       <methods>
         <method id="GetTicketRefFormat">
           <static>true</static>
@@ -1621,18 +1614,6 @@
 		$this->Set('last_update', time());
 		$this->UpdateChildRequestLog();
 	}]]></code>
-        </method>
-        <method id="UpdateTicketImpactedItems">
-          <comment></comment>
-          <static>false</static>
-          <access>public</access>
-          <type>EventListener</type>
-          <code><![CDATA[
-public function UpdateTicketImpactedItems(Combodo\iTop\Service\Events\EventData $oEventData) {
-    $this->UpdateImpactedItems();
-    $this->DBWrite();
-}
-            ]]></code>
         </method>
       </methods>
       <presentation>

--- a/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
+++ b/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
@@ -220,6 +220,13 @@
           <read_only>false</read_only>
         </field>
       </fields>
+      <event_listeners>
+        <listener id="UpdateImpactAnalysis">
+          <event>EVENT_DB_LINKS_CHANGED</event>
+          <callback>UpdateImpactedItems</callback>
+          <rank>0</rank>
+        </listener>
+      </event_listeners>
       <methods>
         <method id="DBInsertNoReload">
           <static>false</static>

--- a/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
+++ b/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
@@ -223,11 +223,23 @@
       <event_listeners>
         <listener id="UpdateImpactAnalysis">
           <event>EVENT_DB_LINKS_CHANGED</event>
-          <callback>UpdateImpactedItems</callback>
+          <callback>UpdateTicketImpactedItems</callback>
           <rank>0</rank>
         </listener>
       </event_listeners>
       <methods>
+        <method id="UpdateTicketImpactedItems">
+        <comment/>
+        <static>false</static>
+        <access>public</access>
+        <type>EventListener</type>
+        <code><![CDATA[
+public function UpdateTicketImpactedItems(Combodo\iTop\Service\Events\EventData $oEventData) {
+    $this->UpdateImpactedItems();
+    $this->DBUpdate();
+}
+            ]]></code>
+        </method>
         <method id="DBInsertNoReload">
           <static>false</static>
           <access>public</access>

--- a/datamodels/2.x/itop-tickets/main.itop-tickets.php
+++ b/datamodels/2.x/itop-tickets/main.itop-tickets.php
@@ -266,7 +266,6 @@ class _Ticket extends cmdbAbstractObject
 		}
 		$this->Set('contacts_list', $oContactsSet);
 
-		//FIXME the modified lnk will trigger this method again... What can we do ?? Set a flag to disable event from firing on this object ?
 		// if called withing the object CRUD stack reentrance will be protected by iTop
 		$this->DBUpdate();
 	}

--- a/datamodels/2.x/itop-tickets/main.itop-tickets.php
+++ b/datamodels/2.x/itop-tickets/main.itop-tickets.php
@@ -258,14 +258,17 @@ class _Ticket extends cmdbAbstractObject
                         $oContactsSet->AddItem($oNewLink);
                     }
                 }
-				break;
+					break;
 			}
 		}
-		if (MetaModel::IsValidClass('FunctionalCI'))
-		{
+		if (MetaModel::IsValidClass('FunctionalCI')) {
 			$this->Set('functionalcis_list', $oCIsSet);
 		}
 		$this->Set('contacts_list', $oContactsSet);
+
+		//FIXME the modified lnk will trigger this method again... What can we do ?? Set a flag to disable event from firing on this object ?
+		// if called withing the object CRUD stack reentrance will be protected by iTop
+		$this->DBUpdate();
 	}
 
 	private function StoreComputedObject(&$aGraphObjects, $oObj)

--- a/datamodels/2.x/itop-tickets/main.itop-tickets.php
+++ b/datamodels/2.x/itop-tickets/main.itop-tickets.php
@@ -265,9 +265,6 @@ class _Ticket extends cmdbAbstractObject
 			$this->Set('functionalcis_list', $oCIsSet);
 		}
 		$this->Set('contacts_list', $oContactsSet);
-
-		// if called withing the object CRUD stack reentrance will be protected by iTop
-		$this->DBUpdate();
 	}
 
 	private function StoreComputedObject(&$aGraphObjects, $oObj)

--- a/js/links/links_view_table_widget.js
+++ b/js/links/links_view_table_widget.js
@@ -36,7 +36,7 @@ $(function()
 			// link object deletion
 			CombodoLinkSetWorker.DeleteLinkedObject(this.options.link_class, sLinkedObjectKey, function (data) {
 				if (data.data.success === true) {
-					oTrElement.remove();
+					me.$tableSettingsDialog.DataTableSettings('DoRefresh');
 				} else {
 					CombodoModal.OpenInformativeModal(data.data.error_message, 'error');
 				}
@@ -57,7 +57,7 @@ $(function()
 			// link object unlink
 			CombodoLinkSetWorker.DetachLinkedObject(this.options.link_class, sLinkedObjectKey, this.options.external_key_to_me,  function (data) {
 				if (data.data.success === true) {
-					oTrElement.remove();
+					me.$tableSettingsDialog.DataTableSettings('DoRefresh');
 				} else {
 					CombodoModal.OpenInformativeModal(data.data.error_message, 'error');
 				}

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -1570,8 +1570,6 @@ try
 		}
 	}
 
-	cmdbAbstractObject::FireEventDbLinksChangedForAllObjects();
-
 	DisplayWelcomePopup($oP);
 	$oKPI->ComputeAndReport('Compute page');
 	$oP->output();

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -1570,7 +1570,7 @@ try
 		}
 	}
 
-	cmdbAbstractObject::ProcessAllDeferedUpdates();
+	cmdbAbstractObject::FireEventDbLinksChangedForAllObjects();
 
 	DisplayWelcomePopup($oP);
 	$oKPI->ComputeAndReport('Compute page');

--- a/pages/UI.php
+++ b/pages/UI.php
@@ -1561,15 +1561,16 @@ try
 			default: // Menu node rendering (templates)
 			ApplicationMenu::LoadAdditionalMenus();
 			$oMenuNode = ApplicationMenu::GetMenuNode(ApplicationMenu::GetMenuIndexById(ApplicationMenu::GetActiveNodeId()));
-			if (is_object($oMenuNode))
-			{
-				$oMenuNode->RenderContent($oP, $oAppContext->GetAsHash());
-				$oP->set_title($oMenuNode->GetLabel());
-			}
+				if (is_object($oMenuNode)) {
+					$oMenuNode->RenderContent($oP, $oAppContext->GetAsHash());
+					$oP->set_title($oMenuNode->GetLabel());
+				}
 
 			///////////////////////////////////////////////////////////////////////////////////////////
 		}
 	}
+
+	cmdbAbstractObject::ProcessAllDeferedUpdates();
 
 	DisplayWelcomePopup($oP);
 	$oKPI->ComputeAndReport('Compute page');

--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -2556,6 +2556,9 @@ EOF
 				$oPage->p("Invalid query.");
 		}
 	}
+
+	cmdbAbstractObject::ProcessAllDeferedUpdates();
+
 	$oKPI->ComputeAndReport('Data fetch and format');
 	$oPage->output();
 } catch (Exception $e) {

--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -2557,7 +2557,7 @@ EOF
 		}
 	}
 
-	cmdbAbstractObject::ProcessAllDeferedUpdates();
+	cmdbAbstractObject::FireEventDbLinksChangedForAllObjects();
 
 	$oKPI->ComputeAndReport('Data fetch and format');
 	$oPage->output();

--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -2557,8 +2557,6 @@ EOF
 		}
 	}
 
-	cmdbAbstractObject::FireEventDbLinksChangedForAllObjects();
-
 	$oKPI->ComputeAndReport('Data fetch and format');
 	$oPage->output();
 } catch (Exception $e) {

--- a/sources/Application/Service/Events/EventService.php
+++ b/sources/Application/Service/Events/EventService.php
@@ -175,7 +175,7 @@ final class EventService
 	 *
 	 * @return array
 	 */
-	public static function GetListeners(string $sEvent, $eventSource): array
+	public static function GetListeners(string $sEvent, $eventSource = null): array
 	{
 		$aListeners = [];
 		if (isset(self::$aEventListeners[$sEvent])) {

--- a/sources/Application/Service/Events/EventServiceLog.php
+++ b/sources/Application/Service/Events/EventServiceLog.php
@@ -8,38 +8,8 @@ namespace Combodo\iTop\Service\Events;
 
 use IssueLog;
 use LogChannels;
-use utils;
 
 class EventServiceLog extends IssueLog
 {
 	const CHANNEL_DEFAULT = LogChannels::EVENT_SERVICE;
-
-	/**
-	 * @param $sMessage
-	 * @param $sEvent
-	 * @param $sources
-	 *
-	 * @return void
-	 * @throws \ConfigException
-	 * @throws \CoreException
-	 */
-	public static function DebugEvent($sMessage, $sEvent, $sources)
-	{
-		$oConfig = utils::GetConfig();
-		$aLogEvents = $oConfig->Get('event_service.debug.filter_events');
-		$aLogSources = $oConfig->Get('event_service.debug.filter_sources');
-
-		if (is_array($aLogEvents)) {
-			if (!in_array($sEvent, $aLogEvents)) {
-				return;
-			}
-		}
-		if (is_array($aLogSources)) {
-			if (!EventHelper::MatchEventSource($aLogSources, $sources)) {
-				return;
-			}
-		}
-		static::Debug($sMessage);
-	}
-
 }

--- a/synchro/synchrodatasource.class.inc.php
+++ b/synchro/synchrodatasource.class.inc.php
@@ -3536,7 +3536,7 @@ class SynchroExecution
 		}
 
 		// Avoid too many events
-		cmdbAbstractObject::SetEventDBLinksChangedAllowed(false);
+		cmdbAbstractObject::SetEventDBLinksChangedBlocked(true);
 		try {
 			$iLastReplicaProcessed = -1;
 			/** @var \SynchroReplica $oReplica */
@@ -3551,7 +3551,7 @@ class SynchroExecution
 			}
 		} finally {
 			// Send all the retained events for further computations
-			cmdbAbstractObject::SetEventDBLinksChangedAllowed(true);
+			cmdbAbstractObject::SetEventDBLinksChangedBlocked(false);
 			cmdbAbstractObject::FireEventDbLinksChangedForAllObjects();
 		}
 

--- a/tests/php-unit-tests/ItopTestCase.php
+++ b/tests/php-unit-tests/ItopTestCase.php
@@ -155,7 +155,7 @@ class ItopTestCase extends TestCase
 	/**
 	 * @param string $sObjectClass for example DBObject::class
 	 * @param string $sMethodName
-	 * @param object $oObject
+	 * @param ?object $oObject
 	 * @param array $aArgs
 	 *
 	 * @return mixed method result

--- a/tests/php-unit-tests/ItopTestCase.php
+++ b/tests/php-unit-tests/ItopTestCase.php
@@ -175,22 +175,38 @@ class ItopTestCase extends TestCase
 
 
 	/**
+	 * @since 3.1.0
+	 */
+	public function GetNonPublicStaticProperty(string $sClass, string $sProperty)
+	{
+		return $this->GetProperty($sClass, null, $sProperty);
+	}
+
+	/**
 	 * @param object $oObject
 	 * @param string $sProperty
 	 *
 	 * @return mixed property
 	 *
-	 * @throws \ReflectionException
 	 * @since 2.7.8 3.0.3 3.1.0
 	 */
 	public function GetNonPublicProperty(object $oObject, string $sProperty)
 	{
-		$class = new \ReflectionClass(get_class($oObject));
+		return $this->GetProperty(get_class($oObject), $oObject, $sProperty);
+	}
+
+	/**
+	 * @since 3.1.0
+	 */
+	private function GetProperty(string $sClass, ?object $oObject, string $sProperty)
+	{
+		$class = new \ReflectionClass($sClass);
 		$property = $class->getProperty($sProperty);
 		$property->setAccessible(true);
 
 		return $property->getValue($oObject);
 	}
+
 
 	/**
 	 * @param object $oObject

--- a/tests/php-unit-tests/ItopTestCase.php
+++ b/tests/php-unit-tests/ItopTestCase.php
@@ -179,7 +179,10 @@ class ItopTestCase extends TestCase
 	 */
 	public function GetNonPublicStaticProperty(string $sClass, string $sProperty)
 	{
-		return $this->GetProperty($sClass, null, $sProperty);
+		/** @noinspection OneTimeUseVariablesInspection */
+		$oProperty = $this->GetProperty($sClass, $sProperty);
+
+		return $oProperty->getValue();
 	}
 
 	/**
@@ -192,19 +195,22 @@ class ItopTestCase extends TestCase
 	 */
 	public function GetNonPublicProperty(object $oObject, string $sProperty)
 	{
-		return $this->GetProperty(get_class($oObject), $oObject, $sProperty);
+		/** @noinspection OneTimeUseVariablesInspection */
+		$oProperty = $this->GetProperty(get_class($oObject), $sProperty);
+
+		return $oProperty->getValue($oObject);
 	}
 
 	/**
 	 * @since 3.1.0
 	 */
-	private function GetProperty(string $sClass, ?object $oObject, string $sProperty)
+	private function GetProperty(string $sClass, string $sProperty): \ReflectionProperty
 	{
 		$class = new \ReflectionClass($sClass);
 		$property = $class->getProperty($sProperty);
 		$property->setAccessible(true);
 
-		return $property->getValue($oObject);
+		return $property;
 	}
 
 
@@ -213,27 +219,34 @@ class ItopTestCase extends TestCase
 	 * @param string $sProperty
 	 * @param $value
 	 *
-	 * @throws \ReflectionException
 	 * @since 2.7.8 3.0.3 3.1.0
 	 */
 	public function SetNonPublicProperty(object $oObject, string $sProperty, $value)
 	{
-		$class = new \ReflectionClass(get_class($oObject));
-		$property = $class->getProperty($sProperty);
-		$property->setAccessible(true);
-
-		$property->setValue($oObject, $value);
+		$oProperty = $this->GetProperty(get_class($oObject), $sProperty);
+		$oProperty->setValue($oObject, $value);
 	}
 
-	public function RecurseRmdir($dir) {
+	/**
+	 * @since 3.1.0
+	 */
+	public function SetNonPublicStaticProperty(string $sClass, string $sProperty, $value)
+	{
+		$oProperty = $this->GetProperty($sClass, $sProperty);
+		$oProperty->setValue($value);
+	}
+
+	public function RecurseRmdir($dir)
+	{
 		if (is_dir($dir)) {
 			$objects = scandir($dir);
 			foreach ($objects as $object) {
 				if ($object != "." && $object != "..") {
-					if (is_dir($dir.DIRECTORY_SEPARATOR.$object))
+					if (is_dir($dir.DIRECTORY_SEPARATOR.$object)) {
 						$this->RecurseRmdir($dir.DIRECTORY_SEPARATOR.$object);
-					else
+					} else {
 						unlink($dir.DIRECTORY_SEPARATOR.$object);
+					}
 				}
 			}
 			rmdir($dir);

--- a/tests/php-unit-tests/unitary-tests/application/cmdbAbstractObjectTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/cmdbAbstractObjectTest.php
@@ -7,6 +7,7 @@ class cmdbAbstractObjectTest extends ItopDataTestCase {
 		$aLinkModificationsStack = $this->GetNonPublicStaticProperty(cmdbAbstractObject::class, 'aLinkModificationsStack');
 		$this->assertSame([], $aLinkModificationsStack);
 
+		// lnkPersonToTeam:1 is sample data with : team_id=39 ; person_id=9 ; role_id=3
 		$oLinkPersonToTeam1 = MetaModel::GetObject(lnkPersonToTeam::class, 1);
 		$oLinkPersonToTeam1->Set('role_id', 1);
 		$oLinkPersonToTeam1->DBWrite();

--- a/tests/php-unit-tests/unitary-tests/application/cmdbAbstractObjectTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/cmdbAbstractObjectTest.php
@@ -16,7 +16,7 @@ class cmdbAbstractObjectTest extends ItopDataTestCase {
 		$this->assertSame([], $aLinkModificationsStack);
 
 		// retain events
-		cmdbAbstractObject::SetEventDBLinksChangedAllowed(false);
+		cmdbAbstractObject::SetEventDBLinksChangedBlocked(true);
 
 		// Create the person
 		$oPerson = $this->CreatePerson(1);

--- a/tests/php-unit-tests/unitary-tests/application/cmdbAbstractObjectTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/cmdbAbstractObjectTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+
+class cmdbAbstractObjectTest extends ItopDataTestCase {
+	public function testCheckLinkModifications() {
+		$aLinkModificationsStack = $this->GetNonPublicStaticProperty(cmdbAbstractObject::class, 'aLinkModificationsStack');
+		$this->assertSame([], $aLinkModificationsStack);
+
+		$oLinkPersonToTeam1 = MetaModel::GetObject(lnkPersonToTeam::class, 1);
+		$oLinkPersonToTeam1->Set('role_id', 1);
+		$oLinkPersonToTeam1->DBWrite();
+		$aLinkModificationsStack = $this->GetNonPublicStaticProperty(cmdbAbstractObject::class, 'aLinkModificationsStack');
+		self::assertCount(3, $aLinkModificationsStack);
+		$aExpectedLinkStack = [
+			'Team'        => ['39' => 1],
+			'Person'      => ['9' => 1],
+			'ContactType' => ['1' => 1],
+		];
+		self::assertSame($aExpectedLinkStack, $aLinkModificationsStack);
+
+		$oLinkPersonToTeam1->Set('role_id', 2);
+		$oLinkPersonToTeam1->DBWrite();
+		$aLinkModificationsStack = $this->GetNonPublicStaticProperty(cmdbAbstractObject::class, 'aLinkModificationsStack');
+		self::assertCount(3, $aLinkModificationsStack);
+		$aExpectedLinkStack = [
+			'Team'        => ['39' => 2],
+			'Person'      => ['9' => 2],
+			'ContactType' => [
+				'1' => 1,
+				'2' => 1,
+			],
+		];
+		self::assertSame($aExpectedLinkStack, $aLinkModificationsStack);
+	}
+}


### PR DESCRIPTION
For now analysis impact update is only launched after creating / modifying each Ticket children object (OnInsert / OnUpdate callbacks).
But in 3.1 lnk can be edited directly in the GUI !

This moves analysis impact update in a listener on the EVENT_DB_LINKS_CHANGED event.
On each lnk modification cmdbAbstractObject will record remote objects (\cmdbAbstractObject::$aLinkModificationsStack attribute).
Those records will be used : 
* just before firing \EVENT_DB_UPDATE_DONE, if the current object was recorded, fires EVENT_DB_LINKS_CHANGED 
* at the end of the session (UI.php and ajax.render.php) send one EVENT_DB_LINKS_CHANGED  for each remaining recorded object