### PR TITLE
N°6023 Fix cannot load SVG files in AttributeImage since 3.0.0

### DIFF
--- a/core/htmlsanitizer.class.inc.php
+++ b/core/htmlsanitizer.class.inc.php
@@ -34,32 +34,36 @@ abstract class HTMLSanitizer
 
 	/**
 	 * Sanitize an HTML string with the configured sanitizer, falling back to HTMLDOMSanitizer in case of Exception or invalid configuration
+	 *
 	 * @param string $sHTML
+	 * @param string $sConfigKey
+	 *
 	 * @return string
 	 */
-	public static function Sanitize($sHTML)
+	public static function Sanitize($sHTML, $sConfigKey = 'html_sanitizer')
 	{
-		$sSanitizerClass = MetaModel::GetConfig()->Get('html_sanitizer');
-		if(!class_exists($sSanitizerClass))
-		{
+		$sSanitizerClass = utils::GetConfig()->Get($sConfigKey);
+		if (!class_exists($sSanitizerClass)) {
 			IssueLog::Warning('The configured "html_sanitizer" class "'.$sSanitizerClass.'" is not a valid class. Will use HTMLDOMSanitizer as the default sanitizer.');
 			$sSanitizerClass = 'HTMLDOMSanitizer';
-		}
-		else if(!is_subclass_of($sSanitizerClass, 'HTMLSanitizer'))
-		{
-			IssueLog::Warning('The configured "html_sanitizer" class "'.$sSanitizerClass.'" is not a subclass of HTMLSanitizer. Will use HTMLDOMSanitizer as the default sanitizer.');
-			$sSanitizerClass = 'HTMLDOMSanitizer';
+		} else if (!is_subclass_of($sSanitizerClass, 'HTMLSanitizer')) {
+			if ($sConfigKey === 'html_sanitizer') {
+				IssueLog::Warning('The configured "'.$sConfigKey.'" class "'.$sSanitizerClass.'" is not a subclass of HTMLSanitizer. Will use HTMLDOMSanitizer as the default sanitizer.');
+				$sSanitizerClass = 'HTMLDOMSanitizer';
+			}
+			if ($sConfigKey === 'svg_sanitizer') {
+				IssueLog::Error('The configured "'.$sConfigKey.'" class "'.$sSanitizerClass.'" is not a subclass of '.HTMLSanitizer::class.' ! Won\'t sanitize string.');
+
+				return $sHTML;
+			}
 		}
 
-		try
-		{
+		try {
 			$oSanitizer = new $sSanitizerClass();
 			$sCleanHTML = $oSanitizer->DoSanitize($sHTML);
 		}
-		catch(Exception $e)
-		{
-			if($sSanitizerClass != 'HTMLDOMSanitizer')
-			{
+		catch (Exception $e) {
+			if ($sSanitizerClass != 'HTMLDOMSanitizer') {
 				IssueLog::Warning('Failed to sanitize an HTML string with "'.$sSanitizerClass.'". The following exception occured: '.$e->getMessage());
 				IssueLog::Warning('Will try to sanitize with HTMLDOMSanitizer.');
 				// try again with the HTMLDOMSanitizer

--- a/core/htmlsanitizer.class.inc.php
+++ b/core/htmlsanitizer.class.inc.php
@@ -36,7 +36,7 @@ abstract class HTMLSanitizer
 	 * Sanitize an HTML string with the configured sanitizer, falling back to HTMLDOMSanitizer in case of Exception or invalid configuration
 	 *
 	 * @param string $sHTML
-	 * @param string $sConfigKey
+	 * @param string $sConfigKey eg. 'html_sanitizer', 'svg_sanitizer'
 	 *
 	 * @return string
 	 */

--- a/tests/php-unit-tests/unitary-tests/core/sanitizer/SvgDOMSanitizerTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/sanitizer/SvgDOMSanitizerTest.php
@@ -2,6 +2,7 @@
 
 namespace Combodo\iTop\Test\UnitTest\Core\Sanitizer;
 
+use HTMLSanitizer;
 use SVGDOMSanitizer;
 
 
@@ -22,7 +23,7 @@ class SVGDOMSanitizerTest extends AbstractDOMSanitizerTest
 		$sOutputHtml = $this->RemoveNewLines($sOutputHtml);
 
 		$oSanitizer = new SVGDOMSanitizer();
-		$sRes = $oSanitizer->DoSanitize($sInputHtml);
+		$sResFromSvgSanitizer = $oSanitizer->DoSanitize($sInputHtml);
 
 		// Removing newlines as the parser gives different results depending on the PHP version
 		// Didn't manage to get it right :
@@ -30,19 +31,22 @@ class SVGDOMSanitizerTest extends AbstractDOMSanitizerTest
 		// - playing with the parser preserveWhitespace/formatOutput parser options didn't help
 		// So we're removing new lines on both sides :/
 		$sOutputHtml = $this->RemoveNewLines($sOutputHtml);
-		$sRes = $this->RemoveNewLines($sRes);
+		$sResFromSvgSanitizer = $this->RemoveNewLines($sResFromSvgSanitizer);
 
-		$this->debug($sRes);
-		$this->assertEquals($sOutputHtml, $sRes);
+		$this->debug($sResFromSvgSanitizer);
+		$this->assertEquals($sOutputHtml, $sResFromSvgSanitizer);
+
+		// N°6023 checking call through the factory is working as well
+		$sResFromSanitizerFactory = HTMLSanitizer::Sanitize($sInputHtml, 'svg_sanitizer');
+		$sResFromSanitizerFactory = $this->RemoveNewLines($sResFromSanitizerFactory);
+		$this->assertEquals($sOutputHtml, $sResFromSanitizerFactory);
 	}
 
 	public function DoSanitizeProvider()
 	{
-		return array(
-			array(
-				'scripts.svg',
-			),
-		);
+		return [
+			['scripts.svg'],
+		];
 	}
 }
 


### PR DESCRIPTION
A merge error in ddd6bf2 (support/3.0 as target branch) causes the SVG sanitization to always return an empty string.
In consequence trying to load a SVG file in a AttributeImage will result in an empty content loaded everytime.