### PR TITLE
N°541 - Dashlets: Improve readability when to much labels (pie chart) or too long labels (bar chart)

### DIFF
--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -1119,8 +1119,8 @@ EOF
 				}
 				$oPage->add_ready_script(
 <<<EOF
-var iSizeOfChar = (200 + 20 * $iNbLineToAddForName);
-$('#my_chart_$sId').height(iSizeOfChar + 'px');
+var iChartHeight = (200 + 20 * $iNbLinesToAddForName);
+$('#my_chart_$sId').height(iChartHeight + 'px');
 var chart = c3.generate({
     bindto: d3.select('#my_chart_$sId'),
     data: {

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -1124,9 +1124,10 @@ EOF
 				}
 				$oPage->add_ready_script(
 <<<EOF
+// Calculate height of graph : 200px (minimum height for the chart) + 20*iNbLinesToAddForName for the legend
 var iChartDefaultHeight = 200,
       iChartLegendHeight = 20 * $iNbLinesToAddForName,
-      iChartTotalHeight = (200 + iChartLegendHeight);
+      iChartTotalHeight = (iChartDefaultHeight + iChartLegendHeight);
 $('#my_chart_$sId').height(iChartTotalHeight + 'px');
 var chart = c3.generate({
     bindto: d3.select('#my_chart_$sId'),

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -1017,8 +1017,8 @@ EOF
 					$aGroupBy[(int)$iRow] = (int) $aRow[$sFctVar];
 					$iTotalCount += $aRow['_itop_count_'];
 					$aValues[] = array('label' => html_entity_decode(strip_tags($sHtmlValue), ENT_QUOTES, 'UTF-8'), 'label_html' => $sHtmlValue, 'value' => (int) $aRow[$sFctVar]);
-					if ($iMaxNbCharInLabel < strlen($sValue)) {
-						$iMaxNbCharInLabel = strlen($sValue);
+					if ($iMaxNbCharsInLabel < strlen($sValue)) {
+						$iMaxNbCharsInLabel = strlen($sValue);
 					}
 
 					// Build the search for this subset

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -1009,6 +1009,7 @@ EOF
 				$iTotalCount = 0;
 				$aValues = array();
 				$aURLs = array();
+				$iMaxNbCharInLabel = 0;
 				foreach ($aRes as $iRow => $aRow)
 				{
 					$sValue = $aRow['grouped_by_1'];
@@ -1016,7 +1017,10 @@ EOF
 					$aGroupBy[(int)$iRow] = (int) $aRow[$sFctVar];
 					$iTotalCount += $aRow['_itop_count_'];
 					$aValues[] = array('label' => html_entity_decode(strip_tags($sHtmlValue), ENT_QUOTES, 'UTF-8'), 'label_html' => $sHtmlValue, 'value' => (int) $aRow[$sFctVar]);
-					
+					if ($iMaxNbCharInLabel < strlen($sValue)) {
+						$iMaxNbCharInLabel = strlen($sValue);
+					}
+
 					// Build the search for this subset
 					$oSubsetSearch = $this->m_oFilter->DeepClone();
 					$oCondition = new BinaryExpression($oGroupByExp, '=', new ScalarExpression($sValue));
@@ -1039,7 +1043,8 @@ EOF
 				$sJson = json_encode($aValues);
 				$oPage->add_ready_script(
 <<<EOF
-
+var iSizeOfChar = (200 + 6 * $iMaxNbCharInLabel);
+$('#my_chart_$sId').height(iSizeOfChar + 'px');
 var chart = c3.generate({
     bindto: d3.select('#my_chart_$sId'),
     data: {
@@ -1107,8 +1112,15 @@ EOF
 				}
 				$sJSColumns = json_encode($aColumns);
 				$sJSNames = json_encode($aNames);
+				$iNbLineToAddForName = 0;
+				if( count($aNames)>50) {
+					//increase size of the graph in order to have a maximum of 5 columns of legend
+					$iNbLineToAddForName = ceil ( count($aNames) / 5) - 10;
+				}
 				$oPage->add_ready_script(
 <<<EOF
+var iSizeOfChar = (200 + 20 * $iNbLineToAddForName);
+$('#my_chart_$sId').height(iSizeOfChar + 'px');
 var chart = c3.generate({
     bindto: d3.select('#my_chart_$sId'),
     data: {

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -1009,7 +1009,7 @@ EOF
 				$iTotalCount = 0;
 				$aValues = array();
 				$aURLs = array();
-				$iMaxNbCharInLabel = 0;
+				$iMaxNbCharsInLabel = 0;
 				foreach ($aRes as $iRow => $aRow)
 				{
 					$sValue = $aRow['grouped_by_1'];

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -1010,6 +1010,7 @@ EOF
 				$aValues = array();
 				$aURLs = array();
 				$iMaxNbCharsInLabel = 0;
+				
 				foreach ($aRes as $iRow => $aRow)
 				{
 					$sValue = $aRow['grouped_by_1'];
@@ -1017,6 +1018,7 @@ EOF
 					$aGroupBy[(int)$iRow] = (int) $aRow[$sFctVar];
 					$iTotalCount += $aRow['_itop_count_'];
 					$aValues[] = array('label' => html_entity_decode(strip_tags($sHtmlValue), ENT_QUOTES, 'UTF-8'), 'label_html' => $sHtmlValue, 'value' => (int) $aRow[$sFctVar]);
+
 					if ($iMaxNbCharsInLabel < mb_strlen($sValue)) {
 						$iMaxNbCharsInLabel = mb_strlen($sValue);
 					}
@@ -1043,9 +1045,9 @@ EOF
 				$sJson = json_encode($aValues);
 				$oPage->add_ready_script(
 <<<EOF
-//calculate height of chart : 200px (height of the chart) + 6*iMaxNbCharsInLabel for the legend
-var iHeightOfChar = (200 + 6 * $iMaxNbCharsInLabel);
-$('#my_chart_$sId').height(iHeightOfChar + 'px');
+// Calculate height of chart : 200px (height of the chart) + 6*iMaxNbCharsInLabel for the legend
+var iChartHeight = (200 + 6 * $iMaxNbCharsInLabel);
+$('#my_chart_$sId').height(iChartHeight + 'px');
 var chart = c3.generate({
     bindto: d3.select('#my_chart_$sId'),
     data: {
@@ -1121,7 +1123,7 @@ EOF
 				}
 				$oPage->add_ready_script(
 <<<EOF
-//calculate height of graph : 200px (minimum height for the chart) + 20*iNbLinesToAddForName for the legend
+// Calculate height of graph : 200px (minimum height for the chart) + 20*iNbLinesToAddForName for the legend
 var iChartHeight = (200 + 20 * $iNbLinesToAddForName);
 $('#my_chart_$sId').height(iChartHeight + 'px');
 var chart = c3.generate({

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -1124,9 +1124,10 @@ EOF
 				}
 				$oPage->add_ready_script(
 <<<EOF
-// Calculate height of graph : 200px (minimum height for the chart) + 20*iNbLinesToAddForName for the legend
-var iChartHeight = (200 + 20 * $iNbLinesToAddForName);
-$('#my_chart_$sId').height(iChartHeight + 'px');
+var iChartDefaultHeight = 200,
+      iChartLegendHeight = 20 * $iNbLinesToAddForName,
+      iChartTotalHeight = (200 + iChartLegendHeight);
+$('#my_chart_$sId').height(iChartTotalHeight + 'px');
 var chart = c3.generate({
     bindto: d3.select('#my_chart_$sId'),
     data: {

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -1045,9 +1045,10 @@ EOF
 				$sJson = json_encode($aValues);
 				$oPage->add_ready_script(
 <<<EOF
-// Calculate height of chart : 200px (height of the chart) + 6*iMaxNbCharsInLabel for the legend
-var iChartHeight = (200 + 6 * $iMaxNbCharsInLabel);
-$('#my_chart_$sId').height(iChartHeight + 'px');
+var iChartDefaultHeight = 200,
+      iChartLegendHeight = 6 * $iMaxNbCharsInLabel,
+      iChartTotalHeight = iChartDefaultHeight + iChartLegendHeight;
+$('#my_chart_$sId').height(iChartTotalHeight+ 'px');
 var chart = c3.generate({
     bindto: d3.select('#my_chart_$sId'),
     data: {

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -1017,8 +1017,8 @@ EOF
 					$aGroupBy[(int)$iRow] = (int) $aRow[$sFctVar];
 					$iTotalCount += $aRow['_itop_count_'];
 					$aValues[] = array('label' => html_entity_decode(strip_tags($sHtmlValue), ENT_QUOTES, 'UTF-8'), 'label_html' => $sHtmlValue, 'value' => (int) $aRow[$sFctVar]);
-					if ($iMaxNbCharsInLabel < strlen($sValue)) {
-						$iMaxNbCharsInLabel = strlen($sValue);
+					if ($iMaxNbCharsInLabel < mb_strlen($sValue)) {
+						$iMaxNbCharsInLabel = mb_strlen($sValue);
 					}
 
 					// Build the search for this subset
@@ -1043,8 +1043,9 @@ EOF
 				$sJson = json_encode($aValues);
 				$oPage->add_ready_script(
 <<<EOF
-var iSizeOfChar = (200 + 6 * $iMaxNbCharInLabel);
-$('#my_chart_$sId').height(iSizeOfChar + 'px');
+//calculate height of chart : 200px (height of the chart) + 6*iMaxNbCharsInLabel for the legend
+var iHeightOfChar = (200 + 6 * $iMaxNbCharsInLabel);
+$('#my_chart_$sId').height(iHeightOfChar + 'px');
 var chart = c3.generate({
     bindto: d3.select('#my_chart_$sId'),
     data: {
@@ -1114,11 +1115,13 @@ EOF
 				$sJSNames = json_encode($aNames);
 				$iNbLinesToAddForName = 0;
 				if (count($aNames) > 50) {
-					// Increase size of the graph in order to have a maximum of 5 columns of legend
+					// Calculation of the number of legends line add to the height of the graph to have a maximum of 5 legend columns
+					// 10 corresponds to the number of lines already included in the chart height
 					$iNbLinesToAddForName = ceil(count($aNames) / 5) - 10;
 				}
 				$oPage->add_ready_script(
 <<<EOF
+//calculate height of graph : 200px (minimum height for the chart) + 20*iNbLinesToAddForName for the legend
 var iChartHeight = (200 + 20 * $iNbLinesToAddForName);
 $('#my_chart_$sId').height(iChartHeight + 'px');
 var chart = c3.generate({

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -1112,10 +1112,10 @@ EOF
 				}
 				$sJSColumns = json_encode($aColumns);
 				$sJSNames = json_encode($aNames);
-				$iNbLineToAddForName = 0;
-				if( count($aNames)>50) {
-					//increase size of the graph in order to have a maximum of 5 columns of legend
-					$iNbLineToAddForName = ceil ( count($aNames) / 5) - 10;
+				$iNbLinesToAddForName = 0;
+				if (count($aNames) > 50) {
+					// Increase size of the graph in order to have a maximum of 5 columns of legend
+					$iNbLinesToAddForName = ceil(count($aNames) / 5) - 10;
 				}
 				$oPage->add_ready_script(
 <<<EOF

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -1119,8 +1119,8 @@ EOF
 				$iNbLinesToAddForName = 0;
 				if (count($aNames) > 50) {
 					// Calculation of the number of legends line add to the height of the graph to have a maximum of 5 legend columns
-					// 10 corresponds to the number of lines already included in the chart height
-					$iNbLinesToAddForName = ceil(count($aNames) / 5) - 10;
+					$iNbLinesIncludedInChartHeight = 10;
+					$iNbLinesToAddForName = ceil(count($aNames) / 5) - $iNbLinesIncludedInChartHeight;
 				}
 				$oPage->add_ready_script(
 <<<EOF


### PR DESCRIPTION
For bar chart: set chart size depending on label size
For pie chart : increase the size of the chart proportionnaly to number of labels if there are more than 50 labels (5 columns) in the legend

Before :
![image](https://user-images.githubusercontent.com/57360138/230613611-c0f335fa-db28-4d2c-8607-c241358898e3.png)
After :
![image](https://user-images.githubusercontent.com/57360138/230613720-f74de09b-2a02-4398-83bb-27069b03957c.png)
