### PR TITLE
N°6105 - Cleanup unnecessary use of dirname(__FILE__)

### DIFF
--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -1753,7 +1753,6 @@ SQL;
 	 * it at all (losing the direct access to the page) :
 	 *
 	 * ```php
-	 * if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
 	 * require_once(__DIR__.'/../../approot.inc.php');
 	 * ```
 	 *

--- a/approot.inc.php
+++ b/approot.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-define('APPROOT', dirname(__FILE__).'/');
+define('APPROOT', __DIR__.'/');
 define('APPCONF', APPROOT.'conf/');
 
 /**

--- a/datamodels/2.x/itop-backup/ajax.backup.php
+++ b/datamodels/2.x/itop-backup/ajax.backup.php
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU Affero General Public License
  */
 
-if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
 if (!defined('APPROOT')) require_once(__DIR__.'/../../approot.inc.php');
 require_once(APPROOT.'/application/application.inc.php');
 
@@ -166,7 +165,7 @@ JS
 			require_once(APPROOT."setup/runtimeenv.class.inc.php");
 			require_once(APPROOT.'/application/utils.inc.php');
 			require_once(APPROOT.'/setup/backup.class.inc.php');
-			require_once(dirname(__FILE__).'/dbrestore.class.inc.php');
+			require_once(__DIR__.'/dbrestore.class.inc.php');
 
 			$sEnvironment = utils::ReadParam('environment', 'production', false, 'raw_data');
 			try

--- a/datamodels/2.x/itop-backup/backup.php
+++ b/datamodels/2.x/itop-backup/backup.php
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU Affero General Public License
  */
 
-if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
 if (!defined('APPROOT'))
 {
 	if (file_exists(__DIR__.'/../../approot.inc.php'))
@@ -155,4 +154,4 @@ function ExecuteMainOperation($oP){
 	}
 }
 
-require_once(dirname(__FILE__).'/common.cli-execution.php');
+require_once(__DIR__.'/common.cli-execution.php');

--- a/datamodels/2.x/itop-backup/common.cli-execution.php
+++ b/datamodels/2.x/itop-backup/common.cli-execution.php
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU Affero General Public License
  */
 
-if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
 if (!defined('APPROOT'))
 {
 	if (file_exists(__DIR__.'/../../approot.inc.php'))

--- a/datamodels/2.x/itop-backup/restore.php
+++ b/datamodels/2.x/itop-backup/restore.php
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU Affero General Public License
  */
 
-if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
 if (!defined('APPROOT'))
 {
 	if (file_exists(__DIR__.'/../../approot.inc.php'))
@@ -32,7 +31,7 @@ if (!defined('APPROOT'))
 require_once(APPROOT.'application/application.inc.php');
 require_once(APPROOT.'core/log.class.inc.php');
 require_once(APPROOT.'application/startup.inc.php');
-require_once(dirname(__FILE__).'/dbrestore.class.inc.php');
+require_once(__DIR__.'/dbrestore.class.inc.php');
 
 /**
  * @since 3.0.0 N°4227 new class to handle iTop restore manually via a CLI command
@@ -146,4 +145,4 @@ function ExecuteMainOperation($oP){
 	}
 }
 
-require_once(dirname(__FILE__).'/common.cli-execution.php');
+require_once(__DIR__.'/common.cli-execution.php');

--- a/datamodels/2.x/itop-backup/status.php
+++ b/datamodels/2.x/itop-backup/status.php
@@ -27,9 +27,6 @@ use Combodo\iTop\Application\UI\Base\Layout\UIContentBlock;
 use Combodo\iTop\Application\UI\Base\UIBlock;
 use Combodo\iTop\Renderer\BlockRenderer;
 
-if (!defined('__DIR__')) {
-	define('__DIR__', dirname(__FILE__));
-}
 if (!defined('APPROOT')) {
 	require_once(__DIR__.'/../../approot.inc.php');
 }

--- a/datamodels/2.x/itop-hub-connector/ajax.php
+++ b/datamodels/2.x/itop-hub-connector/ajax.php
@@ -22,9 +22,6 @@
  * @copyright Copyright (C) 2010-2021 Combodo SARL
  * @license http://opensource.org/licenses/AGPL-3.0
  */
-if (!defined('__DIR__')) {
-	define('__DIR__', dirname(__FILE__));
-}
 
 require_once(APPROOT.'application/utils.inc.php');
 require_once(APPROOT.'core/log.class.inc.php');

--- a/datamodels/2.x/itop-tickets/module.itop-tickets.php
+++ b/datamodels/2.x/itop-tickets/module.itop-tickets.php
@@ -94,10 +94,10 @@ class TicketsInstaller extends ModuleInstallerAPI
 				$sLang = str_replace(' ', '_', strtolower($oConfiguration->GetDefaultLanguage()));
 			}
 
-			$sFileName = dirname(__FILE__)."/data/{$sLang}.data.itop-tickets.xml";
+			$sFileName = __DIR__."/data/{$sLang}.data.itop-tickets.xml";
 			SetupLog::Info("Searching file: $sFileName");
 			if (!file_exists($sFileName)) {
-				$sFileName = dirname(__FILE__)."/data/en_us.data.itop-tickets.xml";
+				$sFileName = __DIR__."/data/en_us.data.itop-tickets.xml";
 			}
 			SetupLog::Info("Loading file: $sFileName");
 			$oDataLoader->StartSession($oMyChange);

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@ require_once('approot.inc.php');
  * Check that the configuration file exists and has the appropriate access rights
  * If the file does not exist, launch the configuration wizard to create it
  */  
-if (file_exists(dirname(__FILE__).'/'.$sConfigFile))
+if (file_exists(APPROOT.$sConfigFile))
 {
 	if (!is_readable($sConfigFile))
 	{

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -945,7 +945,7 @@ EOF
 			}
 			else
 			{
-				$sPHP = "dirname(__FILE__).'/$sPath'";
+				$sPHP = "__DIR__.'/$sPath'";
 			}
 		}
 		return $sPHP;

--- a/synchro/priv_sync_chunk.php
+++ b/synchro/priv_sync_chunk.php
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU Affero General Public License
  */
 
-if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
 require_once(__DIR__.'/../approot.inc.php');
 require_once(APPROOT.'/application/application.inc.php');
 

--- a/synchro/synchro_exec.php
+++ b/synchro/synchro_exec.php
@@ -27,7 +27,6 @@
 // - not outputing xml when a wrong input is given (class, attribute names)
 //
 
-if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
 require_once(__DIR__.'/../approot.inc.php');
 require_once(APPROOT.'/application/application.inc.php');
 

--- a/synchro/synchro_import.php
+++ b/synchro/synchro_import.php
@@ -22,11 +22,6 @@
 // - reconciliation is made on the column primary_key
 //
 
-if (!defined('__DIR__'))
-{
-	/** @noinspection DirectoryConstantCanBeUsedInspection */
-	define('__DIR__', dirname(__FILE__));
-}
 require_once __DIR__.'/../approot.inc.php';
 require_once APPROOT.'/application/application.inc.php';
 require_once APPROOT.'/application/startup.inc.php';

--- a/webservices/createfrommail.php
+++ b/webservices/createfrommail.php
@@ -35,7 +35,6 @@ define('DEFAULT_SUBSERVICE_ID', 12);
 define('DEFAULT_PRODUCT', 'Request via eMail');
 define('DEFAULT_WORKGROUP_ID', 5);
 
-if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
 require_once(__DIR__.'/../approot.inc.php');
 require_once(APPROOT.'/application/application.inc.php');
 require_once(APPROOT.'/application/startup.inc.php');

--- a/webservices/cron.php
+++ b/webservices/cron.php
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU Affero General Public License
  */
 
-if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
 require_once(__DIR__.'/../approot.inc.php');
 
 const EXIT_CODE_ERROR = -1;

--- a/webservices/export-v2.php
+++ b/webservices/export-v2.php
@@ -16,9 +16,6 @@ use Combodo\iTop\Application\UI\Base\Component\Input\TextArea;
 use Combodo\iTop\Application\UI\Base\Component\Panel\PanelUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Layout\UIContentBlockUIBlockFactory;
 
-if (!defined('__DIR__')) {
-	define('__DIR__', dirname(__FILE__));
-}
 require_once(__DIR__.'/../approot.inc.php');
 require_once(APPROOT.'/application/application.inc.php');
 require_once(APPROOT.'/application/excelexporter.class.inc.php');

--- a/webservices/export.php
+++ b/webservices/export.php
@@ -26,7 +26,6 @@
  * @link https://www.itophub.io/wiki/page?id=latest:advancedtopics:exportdata_v1 script documentation
  */
 
-if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
 require_once(__DIR__.'/../approot.inc.php');
 require_once(APPROOT.'/application/application.inc.php');
 require_once(APPROOT.'/application/excelexporter.class.inc.php');

--- a/webservices/import.php
+++ b/webservices/import.php
@@ -27,7 +27,6 @@
 // - not outputing xml when a wrong input is given (class, attribute names)
 //
 
-if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
 require_once(__DIR__.'/../approot.inc.php');
 require_once(APPROOT.'/application/application.inc.php');
 

--- a/webservices/rest.php
+++ b/webservices/rest.php
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU Affero General Public License
  */
 
-if (!defined('__DIR__')) define('__DIR__', dirname(__FILE__));
 require_once(__DIR__.'/../approot.inc.php');
 require_once(APPROOT.'/application/application.inc.php');
 require_once(APPROOT.'/application/loginwebpage.class.inc.php');


### PR DESCRIPTION
The `__DIR__` constant is available [since php 5.3](https://3v4l.org/1lRa2) so the boilerplate can be removed.

I thought of not changing it in `approot.inc.php` or the setup files so they can be compatible with older versions of php to show warnings/errors, but it seems the `setup/index.php` is loading `lib/autoload.php` which is using `__DIR__` as well, so there is no reason to keep the boilerplate at all..