### PR TITLE
Fix transaction retries on deadlock not working

### DIFF
--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -2744,10 +2744,13 @@ abstract class DBObject implements iDisplay
 		if ($bIsTransactionEnabled)
 		{
 			// TODO Deep clone this object before the transaction (to use it in case of rollback)
-			// $iTransactionRetryCount = MetaModel::GetConfig()->Get('db_core_transactions_retry_count');
-			$iTransactionRetryCount = 1;
-			$iTransactionRetryDelay = MetaModel::GetConfig()->Get('db_core_transactions_retry_delay_ms');
+			$oConfig = MetaModel::GetConfig();
+			if (is_null($oConfig)) {
+				throw new ConfigException('Cannot load config');
+			}
+			$iTransactionRetryCount = $oConfig->Get('db_core_transactions_retry_count');
 			$iTransactionRetry = $iTransactionRetryCount;
+			$iTransactionRetryDelay = $oConfig->Get('db_core_transactions_retry_delay_ms');
 		}
 		while ($iTransactionRetry > 0) {
 			try {
@@ -2794,6 +2797,7 @@ abstract class DBObject implements iDisplay
 						{
 							// wait and retry
 							IssueLog::Error("Insert TRANSACTION Retrying...");
+							/** @noinspection PhpUndefinedVariableInspection */
 							usleep(random_int(1, 5) * 1000 * $iTransactionRetryDelay * ($iTransactionRetryCount - $iTransactionRetry));
 							continue;
 						}
@@ -3178,13 +3182,15 @@ abstract class DBObject implements iDisplay
 
 			$iTransactionRetry = 1;
 			$bIsTransactionEnabled = MetaModel::GetConfig()->Get('db_core_transactions_enabled');
-			if ($bIsTransactionEnabled)
-			{
+			if ($bIsTransactionEnabled) {
 				// TODO Deep clone this object before the transaction (to use it in case of rollback)
-				// $iTransactionRetryCount = MetaModel::GetConfig()->Get('db_core_transactions_retry_count');
-				$iTransactionRetryCount = 1;
-				$iIsTransactionRetryDelay = MetaModel::GetConfig()->Get('db_core_transactions_retry_delay_ms');
+				$oConfig = MetaModel::GetConfig();
+				if (is_null($oConfig)) {
+					throw new ConfigException('Cannot load config');
+				}
+				$iTransactionRetryCount = $oConfig->Get('db_core_transactions_retry_count');
 				$iTransactionRetry = $iTransactionRetryCount;
+				$iTransactionRetryDelay = $oConfig->Get('db_core_transactions_retry_delay_ms');
 			}
 			while ($iTransactionRetry > 0)
 			{
@@ -3276,7 +3282,7 @@ abstract class DBObject implements iDisplay
 							{
 								// wait and retry
 								IssueLog::Error("Update TRANSACTION Retrying...");
-								usleep(random_int(1, 5) * 1000 * $iIsTransactionRetryDelay * ($iTransactionRetryCount - $iTransactionRetry));
+								usleep(random_int(1, 5) * 1000 * $iTransactionRetryDelay * ($iTransactionRetryCount - $iTransactionRetry));
 								continue;
 							}
 							else
@@ -3520,13 +3526,15 @@ abstract class DBObject implements iDisplay
 		}
 		$iTransactionRetry = 1;
 		$bIsTransactionEnabled = MetaModel::GetConfig()->Get('db_core_transactions_enabled');
-		if ($bIsTransactionEnabled)
-		{
+		if ($bIsTransactionEnabled) {
 			// TODO Deep clone this object before the transaction (to use it in case of rollback)
-			// $iTransactionRetryCount = MetaModel::GetConfig()->Get('db_core_transactions_retry_count');
-			$iTransactionRetryCount = 1;
-			$iTransactionRetryDelay = MetaModel::GetConfig()->Get('db_core_transactions_retry_delay_ms');
+			$oConfig = MetaModel::GetConfig();
+			if (is_null($oConfig)) {
+				throw new ConfigException('Cannot load config');
+			}
+			$iTransactionRetryCount = $oConfig->Get('db_core_transactions_retry_count');
 			$iTransactionRetry = $iTransactionRetryCount;
+			$iTransactionRetryDelay = $oConfig->Get('db_core_transactions_retry_delay_ms');
 		}
 		while ($iTransactionRetry > 0)
 		{
@@ -3560,6 +3568,7 @@ abstract class DBObject implements iDisplay
 						{
 							// wait and retry
 							IssueLog::Error("Delete TRANSACTION Retrying...");
+							/** @noinspection PhpUndefinedVariableInspection */
 							usleep(random_int(1, 5) * 1000 * $iTransactionRetryDelay * ($iTransactionRetryCount - $iTransactionRetry));
 							continue;
 						}

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -2744,6 +2744,7 @@ abstract class DBObject implements iDisplay
 		if ($bIsTransactionEnabled)
 		{
 			// TODO Deep clone this object before the transaction (to use it in case of rollback)
+			// using MetaModel instead of utils method as we need the config related to the loaded datamodel
 			$oConfig = MetaModel::GetConfig();
 			if (is_null($oConfig)) {
 				throw new ConfigException('Cannot load config');
@@ -3184,6 +3185,7 @@ abstract class DBObject implements iDisplay
 			$bIsTransactionEnabled = MetaModel::GetConfig()->Get('db_core_transactions_enabled');
 			if ($bIsTransactionEnabled) {
 				// TODO Deep clone this object before the transaction (to use it in case of rollback)
+				// using MetaModel instead of utils method as we need the config related to the loaded datamodel
 				$oConfig = MetaModel::GetConfig();
 				if (is_null($oConfig)) {
 					throw new ConfigException('Cannot load config');
@@ -3528,6 +3530,7 @@ abstract class DBObject implements iDisplay
 		$bIsTransactionEnabled = MetaModel::GetConfig()->Get('db_core_transactions_enabled');
 		if ($bIsTransactionEnabled) {
 			// TODO Deep clone this object before the transaction (to use it in case of rollback)
+			// using MetaModel instead of utils method as we need the config related to the loaded datamodel
 			$oConfig = MetaModel::GetConfig();
 			if (is_null($oConfig)) {
 				throw new ConfigException('Cannot load config');

--- a/tests/php-unit-tests/unitary-tests/core/CMDBSource/TransactionsTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/CMDBSource/TransactionsTest.php
@@ -76,17 +76,21 @@ class TransactionsTest extends ItopTestCase
 	{
 		// Create a UserRequest with 2 contacts
 		$oTicket = MetaModel::NewObject('UserRequest', [
-			'ref' => 'Test Ticket',
-			'title' => 'Create OK',
+			'ref'         => 'Test Ticket',
+			'title'       => 'Create OK',
 			'description' => 'Create OK',
-			'caller_id' => 15,
-			'org_id' => 3,
+			'caller_id'   => 15,
+			'org_id'      => 3,
 		]);
 		$oLinkSet = $oTicket->Get('contacts_list');
 		$oLinkSet->AddItem(MetaModel::NewObject('lnkContactToTicket', ['contact_id' => 6]));
 		$oLinkSet->AddItem(MetaModel::NewObject('lnkContactToTicket', ['contact_id' => 7]));
 
 		$this->oMySQLiMock->SetFailAt($iFailAt);
+		// we don't want to retry !
+		$oConfig = MetaModel::GetConfig();
+		$oConfig->Set('db_core_transactions_retry_count', 1);
+
 		$this->debug("---> DBInsert()");
 		try {
 			$oTicket->DBWrite();
@@ -201,6 +205,10 @@ class TransactionsTest extends ItopTestCase
 
 		// Provoke an error during the update
 		$this->oMySQLiMock->SetFailAt($iFailAt);
+		// we don't want to retry !
+		$oConfig = MetaModel::GetConfig();
+		$oConfig->Set('db_core_transactions_retry_count', 1);
+
 		$this->debug("---> DBUpdate()");
 		try {
 			$oTicket->DBWrite();


### PR DESCRIPTION
In 2.7.0 we added transactions in CRUD operations, and we also tried to add a retry mechanism in case of a deadlock.
This wasn't working : the `$iTransactionRetry` was always initialized to 1, thus the retry did never happen. 
With this fix we are getting the retries count from the existing `db_core_transactions_retry_count` config parameter. Default value is 3, so we will try one time, and if a deadlock occurs we will retry 2 times max.