### PR TITLE
N°6098 updateLicenses : check availability of the required JQ command

### DIFF
--- a/.make/license/updateLicenses.php
+++ b/.make/license/updateLicenses.php
@@ -19,17 +19,25 @@
  * The target license file path is in `$xmlFilePath`
  */
 
-$iTopFolder = __DIR__ . "/../../" ;
-$xmlFilePath = $iTopFolder . "setup/licenses/community-licenses.xml";
+$iTopFolder = __DIR__."/../../";
+$xmlFilePath = $iTopFolder."setup/licenses/community-licenses.xml";
+
+$jqExec = shell_exec("jq --help"); // --help param is mandatory otherwise the script will freeze
+if ((null === $jqExec) || (false === $jqExec)) {
+	echo "/!\ JQ is required but cannot be launched :( \n";
+	echo "Check this script PHPDoc block for instructions\n";
+	die - 1;
+}
+
 
 function get_scope($product_node)
 {
 	$scope = $product_node->getAttribute("scope");
 
-	if ($scope === "")
-	{   //put iTop first
+	if ($scope === "") {   //put iTop first
 		return "aaaaaaaaa";
 	}
+
 	return $scope;
 }
 

--- a/.make/license/updateLicenses.php
+++ b/.make/license/updateLicenses.php
@@ -22,7 +22,7 @@
 $iTopFolder = __DIR__."/../../";
 $xmlFilePath = $iTopFolder."setup/licenses/community-licenses.xml";
 
-$jqExec = shell_exec("jq -V"); // --help param is mandatory otherwise the script will freeze
+$jqExec = shell_exec("jq -V"); // a param is mandatory otherwise the script will freeze
 if ((null === $jqExec) || (false === $jqExec)) {
 	echo "/!\ JQ is required but cannot be launched :( \n";
 	echo "Check this script PHPDoc block for instructions\n";

--- a/.make/license/updateLicenses.php
+++ b/.make/license/updateLicenses.php
@@ -22,7 +22,7 @@
 $iTopFolder = __DIR__."/../../";
 $xmlFilePath = $iTopFolder."setup/licenses/community-licenses.xml";
 
-$jqExec = shell_exec("jq --help"); // --help param is mandatory otherwise the script will freeze
+$jqExec = shell_exec("jq -V"); // --help param is mandatory otherwise the script will freeze
 if ((null === $jqExec) || (false === $jqExec)) {
 	echo "/!\ JQ is required but cannot be launched :( \n";
 	echo "Check this script PHPDoc block for instructions\n";
@@ -30,8 +30,7 @@ if ((null === $jqExec) || (false === $jqExec)) {
 }
 
 
-function get_scope($product_node)
-{
+function get_scope($product_node) {
 	$scope = $product_node->getAttribute("scope");
 
 	if ($scope === "") {   //put iTop first

--- a/.make/license/updateLicenses.php
+++ b/.make/license/updateLicenses.php
@@ -26,7 +26,7 @@ $jqExec = shell_exec("jq --help"); // --help param is mandatory otherwise the sc
 if ((null === $jqExec) || (false === $jqExec)) {
 	echo "/!\ JQ is required but cannot be launched :( \n";
 	echo "Check this script PHPDoc block for instructions\n";
-	die - 1;
+	die(-1);
 }
 
 


### PR DESCRIPTION
This packaging script requires both bash and the JQ command.
If the later isn't available, it will run without throwing an error...

With this change the script will now check directly at launch for the JQ command availability, and exit in error if it isn't.