### PR TITLE
🐛 Cleanup deprecated global variable

### DIFF
--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -1942,10 +1942,10 @@ SQL;
 			$fp = @fopen($sUrl, 'rb', false, $ctx);
 			if (!$fp)
 			{
-				global $php_errormsg;
-				if (isset($php_errormsg))
+				$aError = error_get_last();
+				if (is_array($aError))
 				{
-					throw new Exception("Wrong URL: $sUrl, $php_errormsg");
+					throw new Exception("Wrong URL: $sUrl, ".$aError['message']);
 				}
 				elseif ((strtolower(substr($sUrl, 0, 5)) == 'https') && !extension_loaded('openssl'))
 				{

--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -1959,7 +1959,9 @@ SQL;
 			$response = @stream_get_contents($fp);
 			if ($response === false)
 			{
-				throw new Exception("Problem reading data from $sUrl, $php_errormsg");
+				$aError = error_get_last();
+				if (is_array($aError)) throw new Exception("Problem reading data from $sUrl, ".$aError['message']);
+				else throw new Exception("Problem reading data from $sUrl");
 			}
 			if (is_array($aResponseHeaders))
 			{


### PR DESCRIPTION
Variable [$php_errormsg](https://www.php.net/manual/en/reserved.variables.phperrormsg.php) has been deprecated since PHP 7.2 and has been removed in PHP 8.0, so I'm converting this code to make debugging easier.