### PR TITLE
N°7068 - Add emulation for apc_exists function

### DIFF
--- a/core/apc-emulation.php
+++ b/core/apc-emulation.php
@@ -211,8 +211,7 @@ class apcFile
 	 * @return bool
 	 */
 	static public function ExistsOneFile($sKey) {
-		if (is_file(self::GetCacheFileName('-'.$sKey))) return true;
-		else return is_file(self::GetCacheFileName($sKey));
+		return is_file(self::GetCacheFileName('-' . $sKey)) || is_file(self::GetCacheFileName($sKey));
 	}
 
 	/** Get one cache entry content.

--- a/core/apc-emulation.php
+++ b/core/apc-emulation.php
@@ -109,10 +109,14 @@ function apc_exists($keys)
 	if (is_array($keys)) {
 		$aExistingKeys = [];
 		foreach ($keys as $sKey) {
-			if (apcFile::ExistsOneFile($sKey)) $aExistingKeys[] = $sKey;
+			if (apcFile::ExistsOneFile($sKey)) {
+				$aExistingKeys[] = $sKey;
+			}
 		}
 		return $aExistingKeys;
-	} else return apcFile::ExistsOneFile($keys);
+	} else {
+		return apcFile::ExistsOneFile($keys);
+	}
 }
 
 class apcFile

--- a/core/apc-emulation.php
+++ b/core/apc-emulation.php
@@ -97,6 +97,24 @@ function apc_delete($key)
 	return $bRet1 || $bRet2;
 }
 
+/**
+ * Checks if APCu emulation key exists
+ * @param string|string[] $keys A string, or an array of strings, that contain keys.
+ * @return bool|string[] Returns TRUE if the key exists, otherwise FALSE
+ * Or if an array was passed to keys, then an array is returned that
+ * contains all existing keys, or an empty array if none exist.
+ */
+function apc_exists($keys)
+{
+	if (is_array($keys)) {
+		$aExistingKeys = [];
+		foreach ($keys as $sKey) {
+			if (apcFile::ExistsOneFile($sKey)) $aExistingKeys[] = $sKey;
+		}
+		return $aExistingKeys;
+	} else return apcFile::ExistsOneFile($keys);
+}
+
 class apcFile
 {
 	// Check only once per request
@@ -181,6 +199,16 @@ class apcFile
 
 		self::ResetFileCount();
 		return true;
+	}
+
+	/**
+	 * Check if cache key exists
+	 * @param $sKey
+	 * @return bool
+	 */
+	static public function ExistsOneFile($sKey) {
+		if (is_file(self::GetCacheFileName('-'.$sKey))) return true;
+		else return is_file(self::GetCacheFileName($sKey));
 	}
 
 	/** Get one cache entry content.


### PR DESCRIPTION
Since #201 wasn't accepted, we had a long time figuring out why a custom extension didn't work. It turned out APCu isn't available and the apc_exists method wasn't emulated in the apc-compat file caching replacement.