### PR TITLE
N°5594 - Dashboard Bug with Group by (table) - iTop 3.0

### DIFF
--- a/sources/Application/UI/Base/Component/DataTable/StaticTable/StaticTable.php
+++ b/sources/Application/UI/Base/Component/DataTable/StaticTable/StaticTable.php
@@ -151,7 +151,10 @@ class StaticTable extends UIContentBlock
 		return "$.post('".utils::GetAbsoluteUrlAppRoot()."pages/ajax.render.php?operation=refreshDashletList', ".json_encode($aParams).", 
 					function (data) {
 						$('#".$this->sId."').DataTable().clear();
-	                    $('#".$this->sId."').dataTable().fnAddData(data);
+						if (data.length>0)
+	                    {
+			                    $('#".$this->sId."').dataTable().fnAddData(data);
+						}
 					});";
 	}
 


### PR DESCRIPTION
Fix bug : 
Using a dashboard which includes at least on "group by"-table, which contains no data (for this user) leads into an JS error (alert) on automatic refresh.