### PR TITLE
N°6125 - Issue with GetAttributeFlags and GetInitialStateAttributeFlags within iTop 3.0.2

### DIFF
--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -3058,9 +3058,9 @@ EOF
 
 		$iFieldsCount = count($aFieldsMap);
 		$sJsonFieldsMap = json_encode($aFieldsMap);
-		$sState = '';
+		$sLifecycleStateForWizardHelper = '';
 		if (MetaModel::HasLifecycle($sClass)) {
-			$sState = $this->GetState();
+			$sLifecycleStateForWizardHelper = $this->GetState();
 		}
 		$sSessionStorageKey = $sClass.'_'.$iKey;
 		$sTempId = utils::GetUploadTempId($iTransactionId);
@@ -3071,7 +3071,7 @@ EOF
 		sessionStorage.removeItem('$sSessionStorageKey');
 		
 		// Create the object once at the beginning of the page...
-		var oWizardHelper$sPrefix = new WizardHelper('$sClass', '$sPrefix', '$sState');
+		var oWizardHelper$sPrefix = new WizardHelper('$sClass', '$sPrefix', '$sLifecycleStateForWizardHelper');
 		oWizardHelper$sPrefix.SetFieldsMap($sJsonFieldsMap);
 		oWizardHelper$sPrefix.SetFieldsCount($iFieldsCount);
 EOF

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -3058,7 +3058,10 @@ EOF
 
 		$iFieldsCount = count($aFieldsMap);
 		$sJsonFieldsMap = json_encode($aFieldsMap);
-		$sState = $this->GetState();
+		$sState = '';
+		if (MetaModel::HasLifecycle($sClass)) {
+			$sState = $this->GetState();
+		}
 		$sSessionStorageKey = $sClass.'_'.$iKey;
 		$sTempId = utils::GetUploadTempId($iTransactionId);
 		$oPage->add_ready_script(InlineImage::EnableCKEditorImageUpload($this, $sTempId));


### PR DESCRIPTION
In 2.7, the parameter _status_ in WizardHelper was empty when the object have no life cycle. This is not the case in 3.0.
Consequence : in 3.0, when the fields are refreshed thanks to an ajax call, objet remains in old status even if we have changed it in the page.
This PR fix this issue