### PR TITLE
N°6179 - Tooltip attribute in field component (in Twig)

### DIFF
--- a/sources/Application/UI/Base/Component/Field/Field.php
+++ b/sources/Application/UI/Base/Component/Field/Field.php
@@ -9,6 +9,7 @@ namespace Combodo\iTop\Application\UI\Base\Component\Field;
 
 use Combodo\iTop\Application\UI\Base\Layout\UIContentBlock;
 use Combodo\iTop\Application\UI\Base\UIBlock;
+use utils;
 
 /**
  * @since 3.0.0
@@ -45,8 +46,11 @@ class Field extends UIContentBlock
 	protected $sValueRaw;
 	/** @var string */
 	protected $sLabel;
-	/** @var string */
-	protected $sTooltip = '';
+	/**
+	 * @var string
+	 * @since 3.1.0
+	 */
+	protected $sDescription = '';
 	/** @var string */
 	protected $sValueId;
 
@@ -359,25 +363,31 @@ class Field extends UIContentBlock
 
 	/**
 	 * @return string
+	 * @since 3.1.0
 	 */
-	public function GetTooltip(): string
+	public function GetDescription(): string
 	{
-		return $this->sTooltip;
+		return $this->sDescription;
 	}
 
 	/**
-	 * @param string $sTooltip
+	 * @param string $sDescription
 	 *
 	 * @return $this
+	 * @since 3.1.0
 	 */
-	public function SetTooltip(string $sTooltip)
+	public function SetDescription(string $sDescription)
 	{
-		$this->sTooltip = $sTooltip;
+		$this->sDescription = $sDescription;
 		return $this;
 	}
 
-	public function HasTooltip() : bool
+	/*
+	 * @return bool
+	 * @since 3.1.0
+	 */
+	public function HasDescription(): bool
 	{
-		return $this->GetTooltip() !== '';
+		return utils::IsNotNullOrEmptyString($this->GetDescription());
 	}
 }

--- a/sources/Application/UI/Base/Component/Field/Field.php
+++ b/sources/Application/UI/Base/Component/Field/Field.php
@@ -46,6 +46,8 @@ class Field extends UIContentBlock
 	/** @var string */
 	protected $sLabel;
 	/** @var string */
+	protected $sTooltip = '';
+	/** @var string */
 	protected $sValueId;
 
 	/** @var string */
@@ -353,5 +355,29 @@ class Field extends UIContentBlock
 		$this->AddDataAttribute('input-type', $sInputType);
 
 		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function GetTooltip(): string
+	{
+		return $this->sTooltip;
+	}
+
+	/**
+	 * @param string $sTooltip
+	 *
+	 * @return $this
+	 */
+	public function SetTooltip(string $sTooltip)
+	{
+		$this->sTooltip = $sTooltip;
+		return $this;
+	}
+
+	public function HasTooltip() : bool
+	{
+		return $this->GetTooltip() !== '';
 	}
 }

--- a/sources/Application/UI/Base/Component/Field/FieldUIBlockFactory.php
+++ b/sources/Application/UI/Base/Component/Field/FieldUIBlockFactory.php
@@ -105,14 +105,14 @@ class FieldUIBlockFactory extends AbstractUIBlockFactory
 	 * @api
 	 * @param string $sLabel
 	 * @param string $sValueHtml
-	 * @param string $sTooltip
+	 * @param string $sDescription
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Field\Field
 	 */
-	public static function MakeLarge(string $sLabel, string $sValueHtml = '', string $sTooltip = '')
+	public static function MakeLarge(string $sLabel, string $sValueHtml = '', string $sDescription = '')
 	{
 		$oField = new Field($sLabel, new Html($sValueHtml));
-		$oField->SetTooltip($sTooltip);
+		$oField->SetDescription($sDescription);
 		$oField->SetLayout(Field::ENUM_FIELD_LAYOUT_LARGE);
 		return $oField;
 	}
@@ -121,14 +121,14 @@ class FieldUIBlockFactory extends AbstractUIBlockFactory
 	 * @api
 	 * @param string $sLabel
 	 * @param string $sValueHtml
-	 * @param string $sTooltip
+	 * @param string $sDescription
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Field\Field
 	 */
-	public static function MakeSmall(string $sLabel, string $sValueHtml = '', string $sTooltip = '')
+	public static function MakeSmall(string $sLabel, string $sValueHtml = '', string $sDescription = '')
 	{
 		$oField = new Field($sLabel, new Html($sValueHtml));
-		$oField->SetTooltip($sTooltip);
+		$oField->SetDescription($sDescription);
 		$oField->SetLayout(Field::ENUM_FIELD_LAYOUT_SMALL);
 		return $oField;
 	}
@@ -138,14 +138,14 @@ class FieldUIBlockFactory extends AbstractUIBlockFactory
 	 * @param string $sLabel
 	 * @param string $sLayout
 	 * @param string|null $sId
-	 * @param string $sTooltip
+	 * @param string $sDescription
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Field\Field
 	 */
-	public static function MakeStandard(string $sLabel = '', string $sLayout = Field::ENUM_FIELD_LAYOUT_SMALL, ?string $sId = null, string $sTooltip = '')
+	public static function MakeStandard(string $sLabel = '', string $sLayout = Field::ENUM_FIELD_LAYOUT_SMALL, ?string $sId = null, string $sDescription = '')
 	{
 		$oField = new Field($sLabel, null, $sId);
-		$oField->SetTooltip($sTooltip);
+		$oField->SetDescription($sDescription);
 		$oField->SetLayout($sLayout);
 		return $oField;
 

--- a/sources/Application/UI/Base/Component/Field/FieldUIBlockFactory.php
+++ b/sources/Application/UI/Base/Component/Field/FieldUIBlockFactory.php
@@ -105,12 +105,14 @@ class FieldUIBlockFactory extends AbstractUIBlockFactory
 	 * @api
 	 * @param string $sLabel
 	 * @param string $sValueHtml
+	 * @param string $sTooltip
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Field\Field
 	 */
-	public static function MakeLarge(string $sLabel, string $sValueHtml = '')
+	public static function MakeLarge(string $sLabel, string $sValueHtml = '', string $sTooltip = '')
 	{
 		$oField = new Field($sLabel, new Html($sValueHtml));
+		$oField->SetTooltip($sTooltip);
 		$oField->SetLayout(Field::ENUM_FIELD_LAYOUT_LARGE);
 		return $oField;
 	}
@@ -119,12 +121,14 @@ class FieldUIBlockFactory extends AbstractUIBlockFactory
 	 * @api
 	 * @param string $sLabel
 	 * @param string $sValueHtml
+	 * @param string $sTooltip
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Field\Field
 	 */
-	public static function MakeSmall(string $sLabel, string $sValueHtml = '')
+	public static function MakeSmall(string $sLabel, string $sValueHtml = '', string $sTooltip = '')
 	{
 		$oField = new Field($sLabel, new Html($sValueHtml));
+		$oField->SetTooltip($sTooltip);
 		$oField->SetLayout(Field::ENUM_FIELD_LAYOUT_SMALL);
 		return $oField;
 	}
@@ -134,12 +138,14 @@ class FieldUIBlockFactory extends AbstractUIBlockFactory
 	 * @param string $sLabel
 	 * @param string $sLayout
 	 * @param string|null $sId
+	 * @param string $sTooltip
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Field\Field
 	 */
-	public static function MakeStandard(string $sLabel = '', string $sLayout = Field::ENUM_FIELD_LAYOUT_SMALL, ?string $sId = null)
+	public static function MakeStandard(string $sLabel = '', string $sLayout = Field::ENUM_FIELD_LAYOUT_SMALL, ?string $sId = null, string $sTooltip = '')
 	{
 		$oField = new Field($sLabel, null, $sId);
+		$oField->SetTooltip($sTooltip);
 		$oField->SetLayout($sLayout);
 		return $oField;
 

--- a/templates/base/components/field/layout.html.twig
+++ b/templates/base/components/field/layout.html.twig
@@ -23,8 +23,8 @@
         {% endif %}
 >
     <div class="ibo-field--label">{{ oUIBlock.GetLabel()|raw }}
-        {% if oUIBlock.HasTooltip() %}
-            <span class="ibo-has-description" data-tooltip-content="{{ oUIBlock.GetTooltip() }}" data-tooltip-max-width="600px" ></span>
+        {% if oUIBlock.HasDescription() %}
+            <span class="ibo-has-description" data-tooltip-content="{{ oUIBlock.GetDescription() }}" data-tooltip-max-width="600px" ></span>
         {% endif %}
         {% if oUIBlock.GetLayout() == constant("Combodo\\iTop\\Application\\UI\\Base\\Component\\Field\\Field::ENUM_FIELD_LAYOUT_LARGE") %}
             {% if oUIBlock.GetComments() %}

--- a/templates/base/components/field/layout.html.twig
+++ b/templates/base/components/field/layout.html.twig
@@ -23,6 +23,9 @@
         {% endif %}
 >
     <div class="ibo-field--label">{{ oUIBlock.GetLabel()|raw }}
+        {% if oUIBlock.HasTooltip() %}
+            <span class="ibo-has-description" data-tooltip-content="{{ oUIBlock.GetTooltip() }}" data-tooltip-max-width="600px" ></span>
+        {% endif %}
         {% if oUIBlock.GetLayout() == constant("Combodo\\iTop\\Application\\UI\\Base\\Component\\Field\\Field::ENUM_FIELD_LAYOUT_LARGE") %}
             {% if oUIBlock.GetComments() %}
                 <div class="ibo-field--comments">{{ oUIBlock.GetComments()|raw }}</div>


### PR DESCRIPTION
New way to add a tooltip to a field component.

Example :

{% UIField Standard {sLabel: 'myLabel', sTooltip:'myTooltip'} %}
