### PR TITLE
N°5039 - DataSynchro: TEXT field too small for big linkset

### DIFF
--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -2069,7 +2069,7 @@ class AttributeLinkedSet extends AttributeDefinition
 	public function GetImportColumns()
 	{
 		$aColumns = array();
-		$aColumns[$this->GetCode()] = 'TEXT'.CMDBSource::GetSqlStringColumnDefinition();
+		$aColumns[$this->GetCode()] = 'MEDIUMTEXT'.CMDBSource::GetSqlStringColumnDefinition();
 
 		return $aColumns;
 	}


### PR DESCRIPTION
This change is in order to be able to synchronise large linksets.