### PR TITLE
 N°6047 - Make iTop scripts work by HTTP via token with specific scopes

### DIFF
--- a/core/contexttag.class.inc.php
+++ b/core/contexttag.class.inc.php
@@ -3,7 +3,7 @@
 //
 //   This file is part of iTop.
 //
-//   iTop is free software; you can redistribute it and/or modify	
+//   iTop is free software; you can redistribute it and/or modify
 //   it under the terms of the GNU Affero General Public License as published by
 //   the Free Software Foundation, either version 3 of the License, or
 //   (at your option) any later version.
@@ -58,6 +58,13 @@ class ContextTag
 	public const TAG_SETUP   = 'Setup';
 	public const TAG_SYNCHRO = 'Synchro';
 	public const TAG_REST    = 'REST/JSON';
+
+	/**
+	 * @since 3.1.0 N°6047
+	 */
+	public const TAG_IMPORT    = 'Import';
+	public const TAG_EXPORT    = 'Export';
+
 	/**
 	 * @var string
 	 * @since 3.1.0 N°3200
@@ -75,7 +82,7 @@ class ContextTag
 	{
 		static::$aStack[] = $sTag;
 	}
-	
+
 	public static function AddContext($sTag)
 	{
 		static::$aStack[] = $sTag;

--- a/core/contexttag.class.inc.php
+++ b/core/contexttag.class.inc.php
@@ -63,6 +63,9 @@ class ContextTag
 	 * @since 3.1.0 N°6047
 	 */
 	public const TAG_IMPORT    = 'Import';
+		/**
+	 * @since 3.1.0 N°6047
+	 */
 	public const TAG_EXPORT    = 'Export';
 
 	/**

--- a/webservices/export-v2.php
+++ b/webservices/export-v2.php
@@ -548,6 +548,12 @@ function DoExport(WebPage $oP, BulkExport $oExporter, $bInteractive = false)
 // Command Line mode
 //
 /////////////////////////////////////////////////////////////////////////////
+///
+/**
+ * @since 3.1.0 N°6047
+ */
+$oCtx = new ContextTag(ContextTag::TAG_EXPORT);
+
 if (utils::IsModeCLI()) {
 	SetupUtils::CheckPhpAndExtensionsForCli(new CLIPage('iTop - Export'));
 

--- a/webservices/export.php
+++ b/webservices/export.php
@@ -48,29 +48,33 @@ catch(Exception $e)
 	exit(EXIT_CODE_FATAL);
 }
 
-if (utils::IsModeCLI()) 
+/**
+ * @since 3.1.0 N°6047
+ */
+$oCtx = new ContextTag(ContextTag::TAG_EXPORT);
+if (utils::IsModeCLI())
 {
 	$oP = new CLIPage("iTop - Export");
 	SetupUtils::CheckPhpAndExtensionsForCli($oP, EXIT_CODE_FATAL);
 
 	$sAuthUser = utils::ReadParam('auth_user', null, true /* Allow CLI */, 'raw_data');
-	$sAuthPwd = utils::ReadParam('auth_pwd', null, true /* Allow CLI */, 'raw_data'); 
+	$sAuthPwd = utils::ReadParam('auth_pwd', null, true /* Allow CLI */, 'raw_data');
 
-	if (UserRights::CheckCredentials($sAuthUser, $sAuthPwd)) 
-	{ 
-		UserRights::Login($sAuthUser); // Login & set the user's language 
-	} 
-	else 
-	{ 
+	if (UserRights::CheckCredentials($sAuthUser, $sAuthPwd))
+	{
+		UserRights::Login($sAuthUser); // Login & set the user's language
+	}
+	else
+	{
 		$oP->p("Access restricted or wrong credentials ('$sAuthUser')");
-		$oP->output(); 
+		$oP->output();
 		exit(EXIT_CODE_ERROR);
 	}
-} 
-else 
+}
+else
 {
-	require_once(APPROOT.'/application/loginwebpage.class.inc.php'); 
-	LoginWebPage::DoLogin(); // Check user rights and prompt if needed 
+	require_once(APPROOT.'/application/loginwebpage.class.inc.php');
+	LoginWebPage::DoLogin(); // Check user rights and prompt if needed
 }
 ApplicationContext::SetUrlMakerClass('iTopStandardURLMaker');
 
@@ -111,7 +115,7 @@ if (strlen($sExpression) == 0)
 			if (strlen($sFields) == 0)
 			{
 				$sFields = trim($oQuery->Get('fields'));
-			} 
+			}
 		}
 	}
 }
@@ -279,13 +283,13 @@ if (!empty($sExpression))
 				}
 				$oP->add($sOutputData);
 				break;
-				
+
 				case 'spreadsheet':
 				$oP = new WebPage("iTop - Export for spreadsheet");
 
 				// Integration within MS-Excel web queries + HTTPS + IIS:
 				// MS-IIS set these header values with no-cache... while Excel fails to do the job if using HTTPS
-				// Then the fix is to force the reset of header values Pragma and Cache-control 
+				// Then the fix is to force the reset of header values Pragma and Cache-control
 				header("Pragma:", true);
 				header("Cache-control:", true);
 
@@ -298,12 +302,12 @@ if (!empty($sExpression))
 				$oP = new XMLPage("iTop - Export", true /* passthrough */);
 				cmdbAbstractObject::DisplaySetAsXML($oP, $oSet, array('localize_values' => $bLocalize));
 				break;
-				
+
 				case 'xlsx':
 				$oP = new AjaxPage('');
 				$oExporter = new ExcelExporter();
 				$oExporter->SetObjectList($oFilter);
-				
+
 				// Run the export by chunk of 1000 objects to limit memory usage
 				$oExporter->SetChunkSize(1000);
 				do
@@ -311,7 +315,7 @@ if (!empty($sExpression))
 					$aStatus = $oExporter->Run(); // process one chunk
 				}
 				while( ($aStatus['code'] != 'done') && ($aStatus['code'] != 'error'));
-				
+
 				if ($aStatus['code'] == 'done')
 				{
 					$oP->SetContentType('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
@@ -324,7 +328,7 @@ if (!empty($sExpression))
 					$oP->add('Error, xlsx export failed: '.$aStatus['message']);
 				}
 				break;
-				
+
 				default:
 				$oP = new WebPage("iTop - Export");
 				$oP->add("Unsupported format '$sFormat'. Possible values are: html, csv, spreadsheet or xml.");
@@ -336,13 +340,13 @@ if (!empty($sExpression))
 		$oP = new WebPage("iTop - Export");
 		$oP->p("Error the query can not be executed.");
 		if ($e instanceof CoreException)
-		{		
+		{
 			$oP->p($e->GetHtmlDesc());
 		}
 		else
 		{
 			$oP->p($e->getMessage());
-		}		
+		}
 	}
 }
 if (!$oP)
@@ -356,7 +360,7 @@ if (!$oP)
 	else
 	{
 		$oP = new WebPage("iTop - Export");
-	} 
+	}
 	$oP->p("General purpose export page.");
 	$oP->p("Parameters:");
 	$oP->p(" * expression: an OQL expression (URL encoded if needed)");

--- a/webservices/import.php
+++ b/webservices/import.php
@@ -206,6 +206,10 @@ function ReadMandatoryParam($oP, $sParam, $sSanitizationFilter)
 /////////////////////////////////
 // Main program
 
+/**
+ * @since 3.1.0 N°6047
+ */
+$oCtx = new ContextTag(ContextTag::TAG_IMPORT);
 if (utils::IsModeCLI())
 {
 	$oP = new CLIPage("iTop - Bulk import");


### PR DESCRIPTION
Import/export scripts are run under new specific ContextTag (IMPORT/EXPORT). 

This is an easy way to let our dedicated extension know whether authentication is authorized for specific CLI calls.