### PR TITLE
N° 8058 - 🐛 Fix: when editing text, the original Wiki syntax should be visible - using the class and not the class label.

### DIFF
--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -4518,8 +4518,7 @@ class AttributeText extends AttributeString
 					$sLabel = (!empty($aMatches[4])) ? trim($aMatches[4]) : null;
 
 					if (MetaModel::IsValidClass($sClass)) {
-						$sClassLabel = MetaModel::GetName($sClass);
-						$sReplacement = "[[$sClassLabel:$sName".(!empty($sLabel) ? " | $sLabel" : "")."]]";
+						$sReplacement = "[[$sClass:$sName".(!empty($sLabel) ? " | $sLabel" : "")."]]";
 						$sValue = str_replace($aMatches[0], $sReplacement, $sValue);
 					}
 				}


### PR DESCRIPTION
Fix: when editing text, the original Wiki syntax should be visible - using the class and not the class label.

Try: in a text field of an object, refer to an object using wiki syntax, such as `[[WebServer::1]]`. Save. So far, everything works as expected. In view mode, it will show a link to Web Server (id 1).

However, when modifying the object (with the text field referencing Web Server 1), the text area will show the class label: `[[Web Server::1]]` . Easily overlooked, but it breaks the wiki syntax when saving the object again.

This PR changes the edit value to actually contain the original reference, using the class name instead of the class label.

See https://sourceforge.net/p/itop/tickets/1841/?limit=25#ddc5