### PR TITLE
🐛 N°5218 Fix compiler for state_attribute classes without lifecycle (causing toolkit "object state" errors)

### DIFF
--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -1807,11 +1807,10 @@ EOF;
 					throw new DOMFormatException("Non existing attribute '$sStateAttCode'", null, null, $oStateAttribute);
 				}
 			}
-			$oValues = $oField->GetUniqueElement('values');
-			$oValueNodes = $oValues->getElementsByTagName('value');
-			foreach ($oValueNodes as $oValue) {
+			$oCodeNodes = $this->oFactory->GetNodes('values/value/code', $oField);
+			foreach ($oCodeNodes as $oCode) {
 				$sLifecycle .= "		MetaModel::Init_DefineState(\n";
-				$sLifecycle .= "			\"".$oValue->GetText()."\",\n";
+				$sLifecycle .= "			\"".$oCode->GetText()."\",\n";
 				$sLifecycle .= "			array(\n";
 				$sLifecycle .= "				\"attribute_inherit\" => '',\n";
 				$sLifecycle .= "				\"attribute_list\" => array()\n";


### PR DESCRIPTION
Currently, the compiler is generating this for `ApplicationSolution`:
```php
		// States but no lifecycle declared in XML (status attribute: status)
		//
		MetaModel::Init_DefineState(
			"",
			array(
				"attribute_inherit" => '',
				"attribute_list" => array()
			)
		);
		MetaModel::Init_DefineState(
			"",
			array(
				"attribute_inherit" => '',
				"attribute_list" => array()
			)
		);
```

After this change it should become this:
```php
		// States but no lifecycle declared in XML (status attribute: status)
		//
		MetaModel::Init_DefineState(
			"active",
			array(
				"attribute_inherit" => '',
				"attribute_list" => array()
			)
		);
		MetaModel::Init_DefineState(
			"inactive",
			array(
				"attribute_inherit" => '',
				"attribute_list" => array()
			)
		);
```