### PR TITLE
N°7292 - Improve Clear function in ExtKeyWidget

### DIFF
--- a/js/extkeywidget.js
+++ b/js/extkeywidget.js
@@ -600,12 +600,16 @@ function ExtKeyWidget(id, sTargetClass, sFilter, sTitle, bSelectMode, oWizHelper
 	};
 
 	this.Clear = function () {
-		$('#'+me.id).val('');
-		$('#label_'+me.id).val('');
-		$('#label_'+me.id).data('selected_value', '');
-		$('#'+me.id).trigger('validate');
-		$('#'+me.id).trigger('extkeychange');
-		$('#'+me.id).trigger('change');
+		if (me.bSelectMode) {
+			$('#'+me.id)[0].selectize.clear();
+		} else {
+			$('#'+me.id).val('');
+			$('#label_'+me.id).val('');
+			$('#label_'+me.id).data('selected_value', '');
+			$('#'+me.id).trigger('validate');
+			$('#'+me.id).trigger('extkeychange');
+			$('#'+me.id).trigger('change');
+		}
 	};
 
 // Workaround for a ui.jquery limitation: if the content of


### PR DESCRIPTION
Currently, the function Clear reset the field only if it's an autocomplete (and is used only in this case). 
Add the hability to reset the field in all cases.