### PR TITLE
N°6543 - Fix display of AttributeText with width parameter

### DIFF
--- a/application/ui.htmleditorwidget.class.inc.php
+++ b/application/ui.htmleditorwidget.class.inc.php
@@ -74,7 +74,7 @@ class UIHTMLEditorWidget
 		$aConfig = utils::GetCkeditorPref();
 		$sWidthSpec = addslashes(trim($this->m_oAttDef->GetWidth()));
 		if ($sWidthSpec != '') {
-			/*the function min allow to keep text inside the column when width is defined*/
+			/*N°6543 - the function min allow to keep text inside the column when width is defined*/
 			$aConfig['width'] = "min($sWidthSpec,100%)";
 		}
 		$sHeightSpec = addslashes(trim($this->m_oAttDef->GetHeight()));

--- a/application/ui.htmleditorwidget.class.inc.php
+++ b/application/ui.htmleditorwidget.class.inc.php
@@ -71,11 +71,13 @@ class UIHTMLEditorWidget
 		// To change the default settings of the editor,
 		// a) edit the file /js/ckeditor/config.js
 		// b) or override some of the configuration settings, using the second parameter of ckeditor()
+		$sJSDefineWidth = '';
 		$aConfig = utils::GetCkeditorPref();
 		$sWidthSpec = addslashes(trim($this->m_oAttDef->GetWidth()));
 		if ($sWidthSpec != '') {
 			/*N°6543 - the function min allow to keep text inside the column when width is defined*/
 			$aConfig['width'] = "min($sWidthSpec,100%)";
+			$sJSDefineWidth = '$("#cke_'.$iId.' iframe").contents().find("body").css("width", "'.$sWidthSpec.'")';
 		}
 		$sHeightSpec = addslashes(trim($this->m_oAttDef->GetHeight()));
 		if ($sHeightSpec != '') {
@@ -109,6 +111,7 @@ $('#$iId').on('update', function(evt){
 		else
 		{
 			oMe.data('ckeditorInstance').setReadOnly(oMe.prop('disabled'));
+			$sJSDefineWidth
 		}
 	};
 	setTimeout(delayedSetReadOnly, 50);

--- a/application/ui.htmleditorwidget.class.inc.php
+++ b/application/ui.htmleditorwidget.class.inc.php
@@ -73,13 +73,12 @@ class UIHTMLEditorWidget
 		// b) or override some of the configuration settings, using the second parameter of ckeditor()
 		$aConfig = utils::GetCkeditorPref();
 		$sWidthSpec = addslashes(trim($this->m_oAttDef->GetWidth()));
-		if ($sWidthSpec != '')
-		{
-			$aConfig['width'] = $sWidthSpec;
+		if ($sWidthSpec != '') {
+			/*the function min allow to keep text inside the column when width is defined*/
+			$aConfig['width'] = "min($sWidthSpec,100%)";
 		}
 		$sHeightSpec = addslashes(trim($this->m_oAttDef->GetHeight()));
-		if ($sHeightSpec != '')
-		{
+		if ($sHeightSpec != '') {
 			$aConfig['height'] = $sHeightSpec;
 		}
 		$sConfigJS = json_encode($aConfig);

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -4534,7 +4534,6 @@ class AttributeText extends AttributeString
 		$sStyle = '';
 		if (count($aStyles) > 0)
 		{
-			$aStyles[] = 'overflow:auto';
 			$sStyle = 'style="'.implode(';', $aStyles).'"';
 		}
 

--- a/css/backoffice/components/_field.scss
+++ b/css/backoffice/components/_field.scss
@@ -80,7 +80,7 @@ $ibo-field--enable-bulk--checkbox--margin-left: $ibo-spacing-300 !default;
       }
     }
   }
-  /*We need the rule to keep text inside the column when width is defined*/
+  /*N°6543 - We need the rule to keep text inside the column when width is defined*/
   &[data-attribute-type="AttributeHtml"]:not([data-input-type="html_editor"]),
   &[data-attribute-type="AttributeText"]:not([data-input-type="html_editor"]) {
     display: grid;

--- a/css/backoffice/components/_field.scss
+++ b/css/backoffice/components/_field.scss
@@ -80,16 +80,25 @@ $ibo-field--enable-bulk--checkbox--margin-left: $ibo-spacing-300 !default;
       }
     }
   }
+  /*We need the rule to keep text inside the column when width is defined*/
+  &[data-attribute-type="AttributeText"]:not([data-input-type="html_editor"]) {
+    display: grid;
+
+    > .ibo-field--value {
+      max-width: 100%;
+      overflow: auto;
+    }
+  }
 }
 
-/* Large field = Label on top, value below */
-.ibo-field-large {
-  display: block;
+  /* Large field = Label on top, value below */
+  .ibo-field-large {
+    display: block;
 
-  .ibo-field--label {
-    position: relative; /* Necessary for fullscreen toggler */
-    display: flex;
-    align-items: center;
+    .ibo-field--label {
+      position: relative; /* Necessary for fullscreen toggler */
+      display: flex;
+      align-items: center;
     max-width: initial;
     width: 100%;
   }

--- a/css/backoffice/components/_field.scss
+++ b/css/backoffice/components/_field.scss
@@ -80,14 +80,17 @@ $ibo-field--enable-bulk--checkbox--margin-left: $ibo-spacing-300 !default;
       }
     }
   }
-  /*N°6543 - We need the rule to keep text inside the column when width is defined*/
-  &[data-attribute-type="AttributeHtml"]:not([data-input-type="html_editor"]),
-  &[data-attribute-type="AttributeText"]:not([data-input-type="html_editor"]) {
-    display: grid;
 
-    > .ibo-field--value {
-      max-width: 100%;
-      overflow: auto;
+  /*N°6543 - We need the rule to keep text inside the column when width is defined*/
+  &[data-attribute-type="AttributeHtml"],
+  &[data-attribute-type="AttributeText"] {
+    &[data-attribute-flag-read-only="true"] {
+      display: grid;
+
+      > .ibo-field--value {
+        max-width: 100%;
+        overflow: auto;
+      }
     }
   }
 }

--- a/css/backoffice/components/_field.scss
+++ b/css/backoffice/components/_field.scss
@@ -81,6 +81,7 @@ $ibo-field--enable-bulk--checkbox--margin-left: $ibo-spacing-300 !default;
     }
   }
   /*We need the rule to keep text inside the column when width is defined*/
+  &[data-attribute-type="AttributeHtml"]:not([data-input-type="html_editor"]),
   &[data-attribute-type="AttributeText"]:not([data-input-type="html_editor"]) {
     display: grid;
 

--- a/css/backoffice/components/datatable/_datatable.scss
+++ b/css/backoffice/components/datatable/_datatable.scss
@@ -123,9 +123,9 @@ $ibo-fieldsorter--selected--background-color: $ibo-color-blue-200 !default;
     .ibo-datatable--row-actions-toolbar{
       justify-content: end;
     }
-    /*N°6543 - We need the rule to keep text inside the column when width is defined*/
-    >[data-attribute-type="AttributeHtml"],
-    >[data-attribute-type="AttributeText"] {
+    /* N°6543 - We need the rule to keep text inside the column when width is defined */
+    > [data-attribute-type="AttributeHtml"],
+    > [data-attribute-type="AttributeText"] {
           max-width: 100%;
           overflow: auto;
     }

--- a/css/backoffice/components/datatable/_datatable.scss
+++ b/css/backoffice/components/datatable/_datatable.scss
@@ -123,6 +123,13 @@ $ibo-fieldsorter--selected--background-color: $ibo-color-blue-200 !default;
     .ibo-datatable--row-actions-toolbar{
       justify-content: end;
     }
+    /*N°6543 - We need the rule to keep text inside the column when width is defined*/
+    >[data-attribute-type="AttributeHtml"],
+    >[data-attribute-type="AttributeText"] {
+          max-width: 100%;
+          overflow: auto;
+    }
+
   }
 }
 


### PR DESCRIPTION
If I define width on a AttributeText field by example with this delta :

  ```
<class id="Ticket" _created_in="itop-tickets" _delta="must_exist">
    <fields>
      <field id="description" xsi:type="AttributeText">
        <width _delta="define">1000px</width>
        <height _delta="define">200px</height>
      </field>
    </fields>
  </class>
```

Display of object is not good:
![image](https://github.com/Combodo/iTop/assets/57360138/a207d308-3ef4-4786-9b6a-b5e17838ead2)
And in edit mode:
![image](https://github.com/Combodo/iTop/assets/57360138/a991ad19-4066-4b77-aedc-64653810dc69)
This PR allow to fix the display. The result is:
![image](https://github.com/Combodo/iTop/assets/57360138/7e5f26b5-8e6c-4385-b1fb-684a731774d5)
And in edit mode:
![image](https://github.com/Combodo/iTop/assets/57360138/abe19ba2-029e-4dbf-a3ac-7d344cdc2da2)

In search, the change is not big : 
before 
![image](https://github.com/Combodo/iTop/assets/57360138/1ef51b46-9a62-456e-8e7d-02d1397604b6)
after
![image](https://github.com/Combodo/iTop/assets/57360138/e4598913-a82a-446d-86bc-a92db21303c1)

