### PR TITLE
N°6600 Portal download attachment : don't display anymore SQL query on attachment not found error

### DIFF
--- a/core/metamodel.class.php
+++ b/core/metamodel.class.php
@@ -6723,7 +6723,13 @@ abstract class MetaModel
 
 		if ($bMustBeFound && empty($aRow))
 		{
-			throw new CoreException("No result for the single row query");
+			$sNotFoundErrorMessage = "No result for the single row query";
+			IssueLog::Info($sNotFoundErrorMessage, LogChannels::CMDB_SOURCE, [
+				'class' => $sClass,
+				'key' => $iKey,
+				'sql_query' => $sSQL,
+				]);
+			throw new CoreException($sNotFoundErrorMessage);
 		}
 
 		return $aRow;

--- a/core/metamodel.class.php
+++ b/core/metamodel.class.php
@@ -6723,7 +6723,7 @@ abstract class MetaModel
 
 		if ($bMustBeFound && empty($aRow))
 		{
-			throw new CoreException("No result for the single row query: '$sSQL'");
+			throw new CoreException("No result for the single row query");
 		}
 
 		return $aRow;

--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
@@ -1038,15 +1038,7 @@ class ObjectController extends BrickController
 			
 			$oAttachment = MetaModel::GetObject($sObjectClass, $sObjectId, false, true);
 			if ($oAttachment === null) {
-				utils::PushArchiveMode(true);
-				$oAttachment = MetaModel::GetObject($sObjectClass, $sObjectId, false);
-				utils::PopArchiveMode();
-				if (is_null($oAttachment)) {
-					IssueLog::Info(__METHOD__ . ' at line ' . __LINE__ . ' : Could not load object ' . $sObjectClass . '::' . $sObjectId . '.');
-					throw new HttpException(Response::HTTP_NOT_FOUND, Dict::S('UI:ObjectDoesNotExist'));
-				}
-
-				IssueLog::Info(__METHOD__ . ' at line ' . __LINE__ . ' : access to archived object ' . $sObjectClass . '::' . $sObjectId . '.');
+				throw new HttpException(Response::HTTP_NOT_FOUND, Dict::S('UI:ObjectDoesNotExist'));
 			}
 			$sHostClass = $oAttachment->Get('item_class');
 			$sHostId = $oAttachment->Get('item_id');

--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
@@ -20,7 +20,6 @@
 
 namespace Combodo\iTop\Portal\Controller;
 
-use ArchivedObjectException;
 use AttributeEnum;
 use AttributeFinalClass;
 use AttributeFriendlyName;
@@ -29,7 +28,6 @@ use BinaryExpression;
 use Combodo\iTop\Portal\Brick\CreateBrick;
 use Combodo\iTop\Portal\Helper\ApplicationHelper;
 use Combodo\iTop\Portal\Helper\ContextManipulatorHelper;
-use CoreException;
 use DBObject;
 use DBObjectSearch;
 use DBObjectSet;

--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
@@ -1038,8 +1038,15 @@ class ObjectController extends BrickController
 			
 			$oAttachment = MetaModel::GetObject($sObjectClass, $sObjectId, false, true);
 			if ($oAttachment === null) {
-				IssueLog::Info(__METHOD__.' at line '.__LINE__.' : Could not load object '.$sObjectClass.'::'.$sObjectId.'.');
-				throw new HttpException(Response::HTTP_NOT_FOUND, Dict::S('UI:ObjectDoesNotExist'));
+				utils::PushArchiveMode(true);
+				$oAttachment = MetaModel::GetObject($sObjectClass, $sObjectId, false);
+				utils::PopArchiveMode();
+				if (is_null($oAttachment)) {
+					IssueLog::Info(__METHOD__ . ' at line ' . __LINE__ . ' : Could not load object ' . $sObjectClass . '::' . $sObjectId . '.');
+					throw new HttpException(Response::HTTP_NOT_FOUND, Dict::S('UI:ObjectDoesNotExist'));
+				}
+
+				IssueLog::Info(__METHOD__ . ' at line ' . __LINE__ . ' : access to archived object ' . $sObjectClass . '::' . $sObjectId . '.');
 			}
 			$sHostClass = $oAttachment->Get('item_class');
 			$sHostId = $oAttachment->Get('item_id');

--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
@@ -20,6 +20,7 @@
 
 namespace Combodo\iTop\Portal\Controller;
 
+use ArchivedObjectException;
 use AttributeEnum;
 use AttributeFinalClass;
 use AttributeFriendlyName;
@@ -28,6 +29,7 @@ use BinaryExpression;
 use Combodo\iTop\Portal\Brick\CreateBrick;
 use Combodo\iTop\Portal\Helper\ApplicationHelper;
 use Combodo\iTop\Portal\Helper\ContextManipulatorHelper;
+use CoreException;
 use DBObject;
 use DBObjectSearch;
 use DBObjectSet;
@@ -1035,7 +1037,11 @@ class ObjectController extends BrickController
 		// When reaching to an Attachment, we have to check security on its host object instead of the Attachment itself
 		if ($sObjectClass === 'Attachment')
 		{
-			$oAttachment = MetaModel::GetObject($sObjectClass, $sObjectId, true, true);
+			try {
+				$oAttachment = MetaModel::GetObject($sObjectClass, $sObjectId, true, true);
+			} catch (ArchivedObjectException|CoreException $e) {
+				throw new HttpException(Response::HTTP_NOT_FOUND, Dict::S('UI:ObjectDoesNotExist'));
+			}
 			$sHostClass = $oAttachment->Get('item_class');
 			$sHostId = $oAttachment->Get('item_id');
 		}

--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
@@ -1037,9 +1037,10 @@ class ObjectController extends BrickController
 		// When reaching to an Attachment, we have to check security on its host object instead of the Attachment itself
 		if ($sObjectClass === 'Attachment')
 		{
-			try {
-				$oAttachment = MetaModel::GetObject($sObjectClass, $sObjectId, true, true);
-			} catch (ArchivedObjectException|CoreException $e) {
+			
+			$oAttachment = MetaModel::GetObject($sObjectClass, $sObjectId, false, true);
+			if ($oAttachment === null) {
+				IssueLog::Info(__METHOD__.' at line '.__LINE__.' : Could not load object '.$sObjectClass.'::'.$sObjectId.'.');
 				throw new HttpException(Response::HTTP_NOT_FOUND, Dict::S('UI:ObjectDoesNotExist'));
 			}
 			$sHostClass = $oAttachment->Get('item_class');


### PR DESCRIPTION
Before PR : 
![image](https://github.com/Combodo/iTop/assets/8947448/9252d844-f6c7-48ca-98f0-72e39101feaf)

After PR : 
![image](https://github.com/Combodo/iTop/assets/8947448/5aebe9dc-3292-4e4c-9dee-b546125fad6e)

Also, after PR a log is made on the CMDBSource channel, info level, containing the SQL query, and object class and id.

Note that on the admin console the behavior is to display an error page, and a simple message (no SQL query).
![image](https://github.com/Combodo/iTop/assets/8947448/bdd83522-c3e4-4da0-9e25-606a36059c3d)
