### PR TITLE
N°6618 - Fix crash due to router's cache containing an integer instead of an array

### DIFF
--- a/sources/Service/Router/Router.php
+++ b/sources/Service/Router/Router.php
@@ -144,7 +144,16 @@ class Router
 		// Try to read from cache
 		if ($bUseCache) {
 			if (is_file($sCacheFilePath)) {
-				$aRoutes = include $sCacheFilePath;
+				$aCachedRoutes = include $sCacheFilePath;
+
+				// N°6618 - Protection against corrupted cache returning `1` instead of an array of routes
+				if (is_array($aCachedRoutes)) {
+					$aRoutes = $aCachedRoutes;
+				} else {
+					// Invalid cache force re-generation
+					// Note that even if it is re-generated corrupted again, this protection should prevent crashes
+					$bMustWriteCache = true;
+				}
 			} else {
 				$bMustWriteCache = true;
 			}

--- a/sources/Service/Router/Router.php
+++ b/sources/Service/Router/Router.php
@@ -138,12 +138,15 @@ class Router
 	{
 		$aRoutes = [];
 		$bUseCache = false === utils::IsDevelopmentEnvironment();
+		$bMustWriteCache = false;
 		$sCacheFilePath = $this->GetCacheFileAbsPath();
 
 		// Try to read from cache
 		if ($bUseCache) {
 			if (is_file($sCacheFilePath)) {
 				$aRoutes = include $sCacheFilePath;
+			} else {
+				$bMustWriteCache = true;
 			}
 		}
 
@@ -180,11 +183,11 @@ class Router
 			}
 		}
 
-		// Save to cache
-		if ($bUseCache) {
+		// Save to cache if it doesn't exist already
+		if ($bMustWriteCache) {
 			$sCacheContent = "<?php\n\nreturn ".var_export($aRoutes, true).";";
 			SetupUtils::builddir(dirname($sCacheFilePath));
-			file_put_contents($sCacheFilePath, $sCacheContent);
+			file_put_contents($sCacheFilePath, $sCacheContent, LOCK_EX);
 		}
 
 		return $aRoutes;

--- a/tests/php-unit-tests/unitary-tests/sources/Service/Router/RouterTest.php
+++ b/tests/php-unit-tests/unitary-tests/sources/Service/Router/RouterTest.php
@@ -21,6 +21,16 @@ use utils;
 class RouterTest extends ItopTestCase
 {
 	/**
+	 * @inheritDoc
+	 */
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->RequireOnceItopFile('setup/setuputils.class.inc.php');
+	}
+
+	/**
 	 * @covers \Combodo\iTop\Service\Router\Router::GenerateUrl
 	 * @dataProvider GenerateUrlProvider
 	 *
@@ -167,6 +177,56 @@ class RouterTest extends ItopTestCase
 
 		$bIsPresent = array_key_exists($sRoute, $aTestedRoutes);
 		$this->assertEquals($bShouldBePresent, $bIsPresent, "Route '$sRoute' was not expected amongst the available routes.");
+	}
+
+	/**
+	 * @covers \Combodo\iTop\Service\Router\Router::GetRoutes
+	 * @return void
+	 *
+	 * @details Covers the cache generation within the GetRoutes method
+	 * @since N°6618
+	 */
+	public function testGetRoutesCacheGeneration(): void
+	{
+		$oRouter = Router::GetInstance();
+		$sRoutesCacheFilePath = $this->InvokeNonPublicMethod(Router::class, 'GetCacheFileAbsPath', $oRouter, []);
+
+		// Developer mode must be disabled for the routes cache to be used
+		$oConf = utils::GetConfig();
+		$mDeveloperModePreviousValue = $oConf->Get('developer_mode.enabled');
+		$oConf->Set('developer_mode.enabled', false);
+
+		// Generate cache for first time
+		$this->InvokeNonPublicMethod(Router::class, 'GetRoutes', $oRouter, []);
+
+		// Check that file exists and retrieve modification timestamp
+		if (false === is_file($sRoutesCacheFilePath)) {
+			$this->fail("Cache file was not generated ($sRoutesCacheFilePath)");
+		}
+
+		clearstatcache();
+		$iFirstModificationTimestamp = filemtime($sRoutesCacheFilePath);
+		$this->debug("Initial timestamp: $iFirstModificationTimestamp");
+
+		// Wait for just 1s to ensure timestamps would be different is the file is re-generated
+		sleep(1);
+
+		// Call GetRoutes() again to see if cache gets re-generated or not
+		$this->InvokeNonPublicMethod(Router::class, 'GetRoutes', $oRouter, []);
+
+		// Check that file still exists and that modification timestamp has not changed
+		if (false === is_file($sRoutesCacheFilePath)) {
+			$this->fail("Cache file is no longer present, that should not happen! ($sRoutesCacheFilePath)");
+		}
+
+		clearstatcache();
+		$iSecondModificationTimestamp = filemtime($sRoutesCacheFilePath);
+		$this->debug("Second timestamp: $iSecondModificationTimestamp");
+
+		$this->assertSame($iFirstModificationTimestamp, $iSecondModificationTimestamp, "Cache file timestamp changed, seems like cache is not working and was re-generated when it should not!");
+
+		// Restore previous value for following tests
+		$oConf->Set('developer_mode.enabled', $mDeveloperModePreviousValue);
 	}
 
 	public function GetRoutesProvider(): array


### PR DESCRIPTION
## Symptom

Critical issue seen on our internal iTop instance, the application is no longer accessible:

```
Uncaught TypeError: Return value of Combodo\iTop\Service\Router\Router::GetRoutes() must be of the type array, int returned in <ITOP>/sources/Service/Router/Router.php:190
Stack trace:
#0 <ITOP>/sources/Service/Router/Router.php(276): Combodo\iTop\Service\Router\Router->GetRoutes()
#1 <ITOP>m/sources/Service/Router/Router.php(205): Combodo\iTop\Service\Router\Router->FindHandlerFromRoute()
#2 <ITOP>/sources/Service/Router/Router.php(98): Combodo\iTop\Service\Router\Router->GetDispatchSpecsForRoute()
#3 <ITOP>m/pages/ajax.render.php(77): Combodo\iTop\Service\Router\Router->CanDispatchRoute()
#4 {main}
thrown
```

## Reproduction

We don't know how it happened nor how to reproduce all the steps to the crash state.
We don't know what triggers the corruption. It worked fine for a couple months, then it happened twice in a day.
We just know how to reproduce the crash itself:

  * On a community iTop, NOT in "dev" mode (either by using a package, or if on a Git clone by setting `'developer_mode.enabled'` to `false`)
  * Open an object in the backoffice to generate the router's cache
  * Open `<ITOP>data/cache-production/router/available-routes.php` and replace content with:
```
<?php

return 1;
```
  * Re-open an object
  * It should crash
 
## Cause

We don't know what caused the corrupted cache file with content `return 1;` instead of `return [.......];`
We see that the cache file is actually re-generated at each call (not much of a cache 💩)

In the [PHP documentation](https://www.php.net/manual/en/function.include.php#example-141) of the `include` statement, we see that _"if an included file as no return statement, then it will return 1"_.

This seems to be consistent with our issue, we just don't know how / why it would include a file that doesn't have the routes as an array.
An hypethesis would be that in the case of multiple concurrent accesses, a first process could have emptied the file but written in it yet, while a second process is reading it before its content is flushed. But we have no way of verifying it. 

## Solution

  * Do NOT re-generate the file at each call
  * Check that cache file actually returns an array and not `1` 

## Workaround

  * Delete the corrupted cache file (<ITOP>data/cache-production/router/availables-route.php)
  * Re-generate it by opening an object in the backoffice
  * Change cache file permissions on the file system to read-only for everybody

This solution works until the next setup / MTT / MTP is done, as it will delete the file.