### PR TITLE
N°3465 - Fix attachment file name hardcoded to "uploaded-file" when imported from CSV import

### DIFF
--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -2499,14 +2499,16 @@ SQL;
 						$aHeaders = static::ParseHeaders($http_response_header);
 						$sMimeType = array_key_exists('Content-Type', $aHeaders) ? strtolower($aHeaders['Content-Type']) : 'application/x-octet-stream';
 						// Compute the file extension from the MIME Type
-						foreach($aKnownExtensions as $sExtValue => $sMime)
-						{
-							if ($sMime === $sMimeType)
-							{
+						foreach ($aKnownExtensions as $sExtValue => $sMime) {
+							if ($sMime === $sMimeType) {
 								$sExtension = '.'.$sExtValue;
 								break;
 							}
 						}
+					}
+					$sPathName = pathinfo($sPath, PATHINFO_FILENAME);
+					if (Utils::IsNotNullOrEmptyString($sPathName)) {
+						$sFileName = $sPathName;
 					}
 					$sFileName .= $sExtension;
 				}

--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -2507,7 +2507,7 @@ SQL;
 						}
 					}
 					$sPathName = pathinfo($sPath, PATHINFO_FILENAME);
-					if (Utils::IsNotNullOrEmptyString($sPathName)) {
+					if (utils::IsNotNullOrEmptyString($sPathName)) {
 						$sFileName = $sPathName;
 					}
 					$sFileName .= $sExtension;


### PR DESCRIPTION
Import this csv file in Attachment class : 
![image](https://github.com/Combodo/iTop/assets/57360138/ae874650-7b54-4996-9762-4da8b71a8493)

Before PR name of imported file is : 
![image](https://github.com/Combodo/iTop/assets/57360138/9e158a5b-9524-490a-8b63-c17b3a68e1c0)

And after : 
![image](https://github.com/Combodo/iTop/assets/57360138/58fccb17-327e-434e-a25a-ee02ea816805)

