### PR TITLE
N°6644 - Add static analysis for PHP

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ node(){
 
   checkout scm
 
-  infra = load '/var/lib/jenkins/workspace/itop-test-infra_master/src/Infra.groovy'
+  infra = load '/var/lib/jenkins/workspace/itop-test-infra_6644-phpstan/src/Infra.groovy'
 }
 
 

--- a/tests/ci_description.ini
+++ b/tests/ci_description.ini
@@ -11,4 +11,4 @@ itop_backup=tests/backups/backup-itop.tar.gz
 [phpunit]
 ; when empty phpunit_xml => no phpunit test performed
 ; phpunit xml file description. required for phpunit testing
-phpunit_xml=tests/php-unit-tests/phpunit.xml.dist
+;phpunit_xml=tests/php-unit-tests/phpunit.xml.dist

--- a/tests/php-static-analysis/README.md
+++ b/tests/php-static-analysis/README.md
@@ -1,0 +1,129 @@
+# PHP static analysis
+
+- [Installation](#installation)
+- [Usages](#usages)
+  - [Analysing a package](#analysing-a-package)
+  - [Analysing a module](#analysing-a-module)
+- [Configuration](#configuration)
+  - [Adjust local configuration to your needs](#adjust-local-configuration-to-your-needs)
+  - [Adjust configuration for a particular CI repository / job](#adjust-configuration-for-a-particular-ci-repository--job)
+
+## Installation
+- Install dependencies by running `composer install` in this folder
+- You should be all set! 🚀
+
+## Usages
+### Analysing a package
+_Do this if you want to analyse the whole iTop package (iTop core, extensions, third-party libs, ...)_
+
+- Make sure you ran a setup on your iTop as it will analyse the `env-production` folder
+- Open a prompt in your iTop folder
+- Run the following command
+  ```bash
+  tests/php-static-analysis/vendor/bin/phpstan analyse \
+    --configuration ./tests/php-static-analysis/config/for-package.dist.neon \
+    --error-format raw
+  ```
+  
+You will then have an output like this listing all errors:
+```bash
+tests/php-static-analysis/vendor/bin/phpstan analyse \
+  --configuration ./tests/php-static-analysis/config/for-package.dist.neon \
+  --error-format raw
+  
+ 1049/1049 [============================] 100%
+
+<ITOP>\addons\userrights\userrightsprofile.class.inc.php:552:Call to static method InitSharedClassProperties() on an unknown class SharedObject.
+<ITOP>\addons\userrights\userrightsprofile.db.class.inc.php:927:Call to static method GetSharedClassProperties() on an unknown class SharedObject.
+<ITOP>\addons\userrights\userrightsprojection.class.inc.php:722:Access to an undefined property UserRightsProjection::$m_aClassProjs.
+<ITOP>\application\applicationextension.inc.php:295:Method AbstractPreferencesExtension::ApplyPreferences() should return bool but return statement is missing.
+<ITOP>\application\cmdbabstract.class.inc.php:1010:Class utils referenced with incorrect case: Utils.
+[...]
+```
+
+### Analysing a module
+_Do this if you only want to analyse one or more modules within this iTop but not the whole package_
+
+- Make sure you ran a setup on your iTop as it will analyse the `env-production` folder
+- Open a prompt in your iTop folder
+- Run the following command
+  ```
+  tests/php-static-analysis/vendor/bin/phpstan analyse \
+    --configuration ./tests/php-static-analysis/config/for-package.dist.neon \
+    --error-format raw \
+    env-production/<MODULE_CODE_1> [env-production/<MODULE_CODE_2> ...]
+  ```
+
+You will then have an output like this listing all errors:
+```
+  tests/php-static-analysis/vendor/bin/phpstan analyse \
+    --configuration ./tests/php-static-analysis/config/for-module.dist.neon \
+    --error-format raw \
+    env-production/authent-ldap env-production/itop-oauth-client
+  
+ 49/49 [============================] 100%
+
+<ITOP>\env-production\authent-ldap\model.authent-ldap.php:79:Undefined variable: $hDS
+<ITOP>\env-production\authent-ldap\model.authent-ldap.php:80:Undefined variable: $name
+<ITOP>\env-production\authent-ldap\model.authent-ldap.php:80:Undefined variable: $value
+<ITOP>\env-production\itop-oauth-client\vendor\composer\InstalledVersions.php:105:Parameter $parser of method Composer\InstalledVersions::satisfies() has invalid type Composer\Semver\VersionParser.
+[...]
+```
+
+## Configuration
+### Adjust local configuration to your needs
+#### Define which PHP version to run the analysis for
+The way we configured PHPStan in this project changes how it will find the PHP version to run the analysis for. \
+By default PHPStan check the information from the composer.json file, but we changed that (via the `config/php-includes/set-php-version-from-process.php` include) so it used the PHP 
+version currently ran by the CLI.
+
+So all you have to do is either:
+- Prepend your command line with the path of the executable of the desired PHP version
+- Change the default PHP interpreter in your IDE settings
+
+#### Change some parameters for a local run
+If you want to change some particular settings (eg. the memory limit, the rules level, ...) for a local run of the analysis you have 2 choices.
+
+##### Method 1: CLI parameter
+For most parameters there is a good chance you can just add the parameter and its value in your command, which will override the one defined in the configuration file. \
+Below are some example, but your can find the complete reference [here](https://phpstan.org/user-guide/command-line-usage).
+
+```bash
+--memory-limit 1G
+--level 5
+--error-format raw
+[...]
+```
+
+**Pros** Quick and easy to try different parameters \
+**Cons** Parameters aren't saved, so you'll have to remember them and put them again next time
+
+##### Method 2: Configuration file
+Crafting your own configuration file gives you the ability to fine tune any parameters, it's way more powerful but can also quickly lead to crashes if you mess with the symbols discovery (classes, ...). \
+But mostly it can be saved, shared, re-used; which is it's main purpose.
+
+It is recommended that you create your configuration file from scratch and that you include the `base.dist.neon` so you are bootstrapped for the symbols discovery. Then you can override any parameter. \
+Check [the documentation](https://phpstan.org/config-reference#multiple-files) for more information.
+
+```neon
+includes:
+    - base.dist.neon
+
+parameters:
+    # Override parameters here
+```
+
+#### Analyse only one (or some) folder(s) quicker
+It's pretty easy and good news you don't need to create a new configuration file or change an existing one. \
+Just adapt and use command lines from the [usages section](#usages) and add the folders you want to analyse at the end of the command, exactly like when analysing modules.
+
+For example if you want to analyse just `<ITOP>/setup` and `<ITOP>/sources`, use something like:
+```
+tests/php-static-analysis/vendor/bin/phpstan analyse \
+  --configuration ./tests/php-static-analysis/config/for-package.dist.neon \
+  --error-format raw \
+  setup sources
+```
+
+### Adjust configuration for a particular CI repository / job
+TODO

--- a/tests/php-static-analysis/composer.json
+++ b/tests/php-static-analysis/composer.json
@@ -1,0 +1,5 @@
+{
+   "require": {
+    "phpstan/phpstan": "^1.10"
+  }
+}

--- a/tests/php-static-analysis/composer.lock
+++ b/tests/php-static-analysis/composer.lock
@@ -1,0 +1,81 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "14812c2a05a5972f00f9d67abbd710a9",
+    "packages": [
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.10.26",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "5d660cbb7e1b89253a47147ae44044f49832351f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/5d660cbb7e1b89253a47147ae44044f49832351f",
+                "reference": "5d660cbb7e1b89253a47147ae44044f49832351f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-19T12:44:37+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/tests/php-static-analysis/config/README.md
+++ b/tests/php-static-analysis/config/README.md
@@ -1,0 +1,29 @@
+## Disclaimer
+DON'T modify the following files without knowledge and discussing with the team:
+- base.dist.neon
+- for-package.dist.neon
+- for-module.dist.neon
+
+## Purpose of these files
+### base.dist.neon
+This configuration file contains the common parameters for all analysis, whereas it is a package, a module or something specific. Among others:
+- Rules level for analysis
+- PHP version to compare
+- Necessary files for autoloaders discovery and such
+- ...
+
+This file should not be modified for your specific needs, you should always include it and override the desired parameters. \
+See how it is done in `for-package.dist.neon` and `for-module.dist.neon` or on the documentation [here](https://phpstan.org/config-reference#multiple-files).
+
+### for-package.dist.neon
+This configuration file contains the parameters to analyse a package (iTop core, modules, third-party libs).
+
+### for-module.dist.neon
+This configuration file contains the parameters to analyse one or more modules only.
+
+## How / when can I modify these files?
+**You CAN'T!** \
+Well, unless there is a good reason and you talked about it with the team. But you should never modify them for a specific need on your local environment.
+
+- If you have a particular need for your local environment (eg. increase memory limit, change rules levels, analyse only a specific folder), check the [Configuration section](../#configuration) of the main README.md.
+- If you feel like there is need for an adjustment in the default configurations, discuss it with th team and make a PR.

--- a/tests/php-static-analysis/config/base.dist.neon
+++ b/tests/php-static-analysis/config/base.dist.neon
@@ -1,0 +1,32 @@
+includes:
+    - php-includes/set-php-version-from-process.php # Workaround to set PHP version to the on running the CLI
+    # for an explanation of the baseline concept, see: https://phpstan.org/user-guide/baseline
+    #baseline HERE DO NOT REMOVE FOR CI 
+
+parameters:
+    level: 0
+    #phpVersion: null                   # Explicitly commented as we rather use the detected version from the above include (`php-includes/target-php-version.php`)
+    editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'    # Open in PHPStorm asit is Combodo's default IDE
+    bootstrapFiles:
+        - ../../../approot.inc.php
+        - ../../../bootstrap.inc.php
+
+    scanFiles:
+        # Files necessary as they contain some declarations (constants, classes, functions, ...)
+        - ../../../approot.inc.php
+        - ../../../bootstrap.inc.php
+    excludePaths:
+        analyse:
+            # For third-party libs we should analyse them in a dedicated configuration as we can't improve / clean them which would
+            # prevent us from raising the rules level as we improve / clean our codebase
+            - ../../../lib              # Irrelevant as we only want to analyze our codebase
+            - ../../../node_modules     # Irrelevant as we only want to analyze our codebase
+        analyseAndScan:
+            #- ../../../data            # Left and commented on purpose to show that we want to analyse the generated cache files
+            # Note 1: We can analyse these folders as if a PHP file requires another PHP element declared in an XML file, it won't find it. So we rely only on `env-production`
+            # Note 2: Only the options selected during the setup will be analysed correctly in `env-production`. For unselected options, we still want to ignore them during the analysis as they would only give a false sentiment of security as their XML PHP classes / snippets / etc would not be tested.
+            - ../../../data/production-modules  # Irrelevent as it will already be in `env-production` (for local run only, not useful in the CI)
+            - ../../../datamodels       # Irrelevent as it will already be in `env-production`
+            - ../../../extensions       # Irrelevent as it will already be in `env-production` (for local run only, not useful in the CI)
+            - ../../../tests            # Exclude tests for now
+            - ../../../toolkit          # Exlclude toolkit for now

--- a/tests/php-static-analysis/config/for-module.dist.neon
+++ b/tests/php-static-analysis/config/for-module.dist.neon
@@ -1,0 +1,15 @@
+includes:
+    - base.dist.neon
+
+parameters:
+    paths:
+        # We just want to analyse the module folder(s), either:
+        # - Create your own `for-module.neon` file, include this one and override this parameter (see https://phpstan.org/config-reference#multiple-files)
+        # - Pass the module folder(s) in the commande line (see https://phpstan.org/config-reference#analysed-files)
+    scanDirectories:
+        # Unlike for `for-package.dist.neon`, here we need to scan all the folders to discover symbols, but we only want to analyse the module folder.
+        # We initially thought of doing it through the `excludePaths` param. by excluding everything but the module folder, but it doesn't seem to be possible, because it uses the `fnmatch()` function.
+        # As a workaround, we list here all the folders to scan.
+        #
+        # Scan the whole project and rely on the `excludePaths` param. to filter the unnecessary
+        - ../../..

--- a/tests/php-static-analysis/config/for-package.dist.neon
+++ b/tests/php-static-analysis/config/for-package.dist.neon
@@ -1,0 +1,7 @@
+includes:
+    - base.dist.neon
+
+parameters:
+    paths:
+        # We want to analyse almost the whole project, so we do a negative selection between the `paths` and `excludePaths` (see base.dist.neon) parameters
+        - ../../../

--- a/tests/php-static-analysis/config/php-includes/set-php-version-from-process.php
+++ b/tests/php-static-analysis/config/php-includes/set-php-version-from-process.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * @copyright   Copyright (C) 2010-2023 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+declare(strict_types = 1);
+
+/**
+ * This file is only here to allow setting a specific PHP version to run the analysis for without
+ * having to explicitly set it in the .neon file. This is the best way we found so far.
+ *
+ * @link https://phpstan.org/config-reference#phpversion
+ *
+ * Usage: Uses the CLI PHP version by default, which would work fine for
+ *   - The CI as the docker image has the target PHP version in both CLI and web
+ *   - The developer's IDE as PHPStorm also has a default PHP version configured which can be changed on the fly
+ */
+
+// Default PHP version to analyse is the one running in CLI
+$config = [];
+$config['parameters']['phpVersion'] = PHP_VERSION_ID;
+
+return $config;


### PR DESCRIPTION
_Internal PR_

## Objective
Introduce static analysis in iTop and our modules to better detect code issues and compatibility with the PHP versions supported by each branches.

## Framework choice
### Initial choice
At first, I was really into Phan for the following reasons:
- Ability to run analysis for a range of PHP version at once (eg. 7.4 => 8.1)
- Configuration file made out of a PHP array which made it easy to craft depending on many conditions, which was perfect for the CI
- Community
- Ability to develop a plugin if the need comes

But it has a main drawback, **its baseline**.

The generated baseline only keeps track of the types of issues in a file but neither their counts nor their lines, which means that if an issue is already present for a file in the baseline, it won't detect a new occurrence of that issue.

_Example of baseline_
```php
return [
    'file_suppressions' => [
        'foo/file-a.php' => ['PhanTypeMismatchArgumentInternal'],
        'foo/file-b.php' => ['PhanTypeUndeclaredClass'],
        'bar/file-c.php' => ['PhanTypeMismatchArgumentInternal', 'PhanTypeUndeclaredClass'],
        [...]
    ],
];
```

This is a no-go for us as we want to keep a accurate baseline so we can fix any issue from new pieces of code and leave existing (non critical) issues in baseline for correction over time.

### New choice
Finally, I chose PHPStan because it was the closest contender to Phan with a good enough baseline. It offers almost everything we look for in Phan except:
- Ability to run analysis for a range of PHP version at once (eg. 7.4 => 8.1)
  => We will rely on the PHP versions rotation of the CI
- Configuration file made out of a PHP file
  => It's made out of a NEON file, but handles includes and PHP files to bootstrap the analysis, so we'll be able to do what we need

Also, PHPStan seems to offer better ways to suppress false positives due to polymorphism.

The baseline still isn't perfect as it doesn't keep track of the issues line numbers, so if we fix one but introduce another, the analysis result will see no change. \
But keeping track of line numbers in a baseline is difficult as they change all the time due to codebase modifications. So we accept that, having the counts seems good enough.

_Example of baseline_
```neon
parameters:
    ignoreErrors:
        -
            message: "#^Call to static method GetSharedClassProperties\\(\\) on an unknown class SharedObject\\.$#"
            count: 1
            path: ../../../addons/userrights/userrightsprofile.class.inc.php

        -
            message: "#^Call to static method InitSharedClassProperties\\(\\) on an unknown class SharedObject\\.$#"
            count: 1
            path: ../../../addons/userrights/userrightsprofile.class.inc.php

        -
            message: "#^Call to static method GetSharedClassProperties\\(\\) on an unknown class SharedObject\\.$#"
            count: 1
            path: ../../../addons/userrights/userrightsprofile.db.class.inc.php

        [...]
```

## How the PR works
This PR was designed to be **very easy to use either for a developer on it's computer and in the CI**.
- Everything lies in the `<ITOP>/tests/php-static-analysis` folder
- Installation is as easy as for unit tests (see included [README.md](https://github.com/Combodo/iTop/blob/feature/4678-add-static-analysis-for-php/tests/php-static-analysis/README.md)) : composer install and the documented command line
- Comes with 2 configuration files and command lines:
  - 1 for analysing an iTop package (iTop core, included modules, third-party libs)
  - 1 for analysing 1 or more modules only
- Can also be configured to show as regular PHPStorm inspection warnings ([Tutorial here](https://www.jetbrains.com/help/phpstorm/using-phpstan.html)) but it's pretty slow

If you are interested in testing this PR, you should take a look at the included [README.md](https://github.com/Combodo/iTop/blob/feature/4678-add-static-analysis-for-php/tests/php-static-analysis/README.md).

## Proposed approach for static analysis deployment
- iTop
  - Support branches (2.7, 3.0, 3.1)
    - Generate baseline with basecode as-is and fix only issues found during new developments
    - Eventually fix existing PHP compatibilty issues after discussing it with the QA team
  - Develop branch (3.2) and future releases
    - Generate baseline with basecode as-is
    - Fix issues found during new developments
    - Fix existing PHP compatibility issues
    - Start fixing existing issues during the modernization phase, that way each version we could clean the basecode a bit more while keeping maximum stability
- Modules
  - TBD

As for the [rules level](https://phpstan.org/user-guide/rule-levels) we should start with, it as to be discussed to define what we want to try to match for new developments. I would go with level 5 for new developments and at least level 1 (or 3) for what we want to fix in the existing codebase.

## What remains to be done in this PR
- [ ] Discuss if going with PHPStan is ok with the rest of the team
- [ ] Discuss which [rules level](https://phpstan.org/user-guide/rule-levels) we want to match with new developments
- [ ] Check if it can be added to the CI pipeline with the current implementation
  - [ ] PHPStan requires PHP 7.2+ to run, so it won't run on CI jobs with PHP 5.6-7.1. We have to find a solution. Olivier talked about running PHPStan in a separate container like it was done for Behat earlier.
  - [ ] Find best way to [pass PHP version](https://phpstan.org/config-reference#phpversion) to check to the CI
    - First option, check if it works out of the box. As the docker image will "composer install" PHPStan, its "platform_check.php" file might contain the PHP version executed at that time, which will roll as expected
    - Second option, we could have a .neon file for each PHP version extending the `for-package.dist.neon` file, but seems rather heavy to maintain
    - Third option, add a PHP include in the base config file that sets PHP version from the PHP version running in the CLI to work around [the current limitation](https://phpstan.org/config-reference#phpversion).
      Main drawback is that it defines the PHP version running PHPStan as well and it won't allow to analyse PHP 5.6 => 7.1. So we might not consider it.
    - ~Make a PR on PHPStan to add the `--php-version` argument to the command line. [Issue created](https://github.com/phpstan/phpstan/issues/9731) to see if a PR would be considered.~
      Issue rejected, they recommend option 2. 
- [ ] Generating baseline for iTop repo and packages