### PR TITLE
5491 brokenui dictformat

### DIFF
--- a/core/dict.class.inc.php
+++ b/core/dict.class.inc.php
@@ -159,7 +159,9 @@ class Dict
 	 * @param string $sDefault Default value if there is no match in the dictionary
 	 * @param bool $bUserLanguageOnly True to allow the use of the default language as a fallback, false otherwise
 	 *
-	 * @return array with localized label string and used lang code
+	 * @return array{
+	 *     lang: string, label: string
+	 * } with localized label string and used lang code
 	 */
 	private static function GetLabelAndLangCode($sStringCode, $sDefault = null, $bUserLanguageOnly = false)
 	{
@@ -168,9 +170,9 @@ class Dict
 		$sLangCode = self::GetUserLanguage();
 		self::InitLangIfNeeded($sLangCode);
 
-		if (!array_key_exists($sLangCode, self::$m_aData))
+		if (! array_key_exists($sLangCode, self::$m_aData))
 		{
-			IssueLog::Warning("Cannot find $sLangCode in dictionnaries. default labels displayed");
+			IssueLog::Warning("Cannot find $sLangCode in all registered dictionaries.");
 			// It may happen, when something happens before the dictionaries get loaded
 			return [ 'label' => $sStringCode, 'lang' => $sLangCode ];
 		}
@@ -223,18 +225,7 @@ class Dict
 	 */
 	public static function Format($sFormatCode /*, ... arguments ....*/)
 	{
-		$aInfo = self::GetLabelAndLangCode($sFormatCode);
-		if (array_key_exists('label', $aInfo)){
-			$sLocalizedFormat = $aInfo['label'];
-		} else {
-			$sLocalizedFormat = $sFormatCode;
-		}
-
-		if (array_key_exists('lang', $aInfo)){
-			$sLangCode = $aInfo['lang'];
-		} else {
-			$sLangCode = null;
-		}
+		['label' => $sLocalizedFormat, 'lang' => $sLangCode] = self::GetLabelAndLangCode($sFormatCode);
 
 		$aArguments = func_get_args();
 		array_shift($aArguments);
@@ -248,7 +239,7 @@ class Dict
 		try{
 			return vsprintf($sLocalizedFormat, $aArguments);
 		} catch(\Throwable $e){
-			\IssueLog::Error("Broken label", null, ["sFormatCode" => $sFormatCode, "sLangCode" => $sLangCode ]);
+			\IssueLog::Error("Cannot format dict key", null, ["sFormatCode" => $sFormatCode, "sLangCode" => $sLangCode, 'exception_msg' => $e->getMessage() ]);
 			return $sFormatCode.' - '.implode(', ', $aArguments);
 		}
 	}

--- a/core/dict.class.inc.php
+++ b/core/dict.class.inc.php
@@ -146,10 +146,7 @@ class Dict
 	public static function S($sStringCode, $sDefault = null, $bUserLanguageOnly = false)
 	{
 		$aInfo = self::GetLabelAndLangCode($sStringCode, $sDefault, $bUserLanguageOnly);
-		if (array_key_exists('label', $aInfo)){
-			return $aInfo['label'];
-		}
-		return $sDefault;
+		return $aInfo['label'];
 	}
 
 	/**

--- a/core/dict.class.inc.php
+++ b/core/dict.class.inc.php
@@ -247,7 +247,7 @@ class Dict
 
 		try{
 			return vsprintf($sLocalizedFormat, $aArguments);
-		} catch(\Exception $e){
+		} catch(\Throwable $e){
 			\IssueLog::Error("Broken label", null, ["sFormatCode" => $sFormatCode, "sLangCode" => $sLangCode ]);
 			return $sFormatCode.' - '.implode(', ', $aArguments);
 		}

--- a/dictionaries/hu.dictionary.itop.core.php
+++ b/dictionaries/hu.dictionary.itop.core.php
@@ -20,7 +20,7 @@
  * @license     http://opensource.org/licenses/AGPL-3.0
  */
 Dict::Add('HU HU', 'Hungarian', 'Magyar', array(
-	'Core:DeletedObjectLabel' => '%1s (deleted)~~',
+	'Core:DeletedObjectLabel' => '%1$s (deleted)~~',
 	'Core:DeletedObjectTip' => 'The object has been deleted on %1$s (%2$s)~~',
 
 	'Core:UnknownObjectLabel' => 'Object not found (class: %1$s, id: %2$d)~~',
@@ -201,7 +201,7 @@ Operators:<br/>
 
 	'Core:AttributeTag' => 'Tags~~',
 	'Core:AttributeTag+' => 'Tags~~',
-	
+
 	'Core:Context=REST/JSON' => 'REST~~',
 	'Core:Context=Synchro' => 'Synchro~~',
 	'Core:Context=Setup' => 'Setup~~',

--- a/dictionaries/hu.dictionary.itop.ui.php
+++ b/dictionaries/hu.dictionary.itop.ui.php
@@ -433,7 +433,7 @@ Dict::Add('HU HU', 'Hungarian', 'Magyar', array(
 	'UI:Error:2ParametersMissing' => 'Hiba: a következő paramétereket meg kell adni ennél a műveletnél: %1$s és %2$s.',
 	'UI:Error:3ParametersMissing' => 'Hiba: a következő paramétereket meg kell adni ennél a műveletnél: %1$s, %2$s és %3$s.',
 	'UI:Error:4ParametersMissing' => 'Hiba: a következő paramétereket meg kell adni ennél a műveletnél: %1$s, %2$s, %3$s és %4$s.',
-	'UI:Error:IncorrectOQLQuery_Message' => 'Hiba: nem megfelelő OQL lekérdezés: %1$',
+	'UI:Error:IncorrectOQLQuery_Message' => 'Hiba: nem megfelelő OQL lekérdezés: %1$s',
 	'UI:Error:AnErrorOccuredWhileRunningTheQuery_Message' => 'Hiba történt a lekérdezs futtatása közben: %1$s',
 	'UI:Error:ObjectAlreadyUpdated' => 'Hiba: az objketum már korábban módosításra került.',
 	'UI:Error:ObjectCannotBeUpdated' => 'Hiba: az objektum nem frissíthető.',
@@ -1004,7 +1004,7 @@ Akció kiváltó okhoz rendelésekor kap egy sorszámot , amely meghatározza az
 
 	'Menu:UserAccountsMenu' => 'Felhasználói fiókok', // Duplicated into itop-welcome-itil (will be removed from here...)
 	'Menu:UserAccountsMenu+' => '', // Duplicated into itop-welcome-itil (will be removed from here...)
-	'Menu:UserAccountsMenu:Title' => 'Felhasználói fiókok', // Duplicated into itop-welcome-itil (will be removed from here...)	
+	'Menu:UserAccountsMenu:Title' => 'Felhasználói fiókok', // Duplicated into itop-welcome-itil (will be removed from here...)
 
 	'UI:iTopVersion:Short' => '%1$s verzió: %2$s',
 	'UI:iTopVersion:Long' => '%1$s verzió: %2$s-%3$s %4$s',
@@ -1019,7 +1019,7 @@ Akció kiváltó okhoz rendelésekor kap egy sorszámot , amely meghatározza az
 	'UI:Deadline_LessThan1Min' => '< 1 perc',
 	'UI:Deadline_Minutes' => '%1$d perc',
 	'UI:Deadline_Hours_Minutes' => '%1$dóra %2$dperc',
-	'UI:Deadline_Days_Hours_Minutes' => '%1$nap %2$dóra %3$dperc',
+	'UI:Deadline_Days_Hours_Minutes' => '%1$dnap %2$dóra %3$dperc',
 	'UI:Help' => 'Segítség',
 	'UI:PasswordConfirm' => '(Jóváhagyás)',
 	'UI:BeforeAdding_Class_ObjectsSaveThisObject' => '%1$s objektumok hozzáadása előtt mentse ezt az  objektumot',

--- a/dictionaries/ja.dictionary.itop.core.php
+++ b/dictionaries/ja.dictionary.itop.core.php
@@ -20,7 +20,7 @@
  * @licence	http://opensource.org/licenses/AGPL-3.0
  */
 Dict::Add('JA JP', 'Japanese', '日本語', array(
-	'Core:DeletedObjectLabel' => '%1s (削除されました)',
+	'Core:DeletedObjectLabel' => '%1$s (削除されました)',
 	'Core:DeletedObjectTip' => 'オブジェクトは削除されました %1$s (%2$s)',
 
 	'Core:UnknownObjectLabel' => 'オブジェクトは見つかりません (クラス: %1$s, id: %2$d)',
@@ -201,7 +201,7 @@ Operators:<br/>
 
 	'Core:AttributeTag' => 'Tags~~',
 	'Core:AttributeTag+' => 'Tags~~',
-	
+
 	'Core:Context=REST/JSON' => 'REST~~',
 	'Core:Context=Synchro' => 'Synchro~~',
 	'Core:Context=Setup' => 'Setup~~',

--- a/dictionaries/ja.dictionary.itop.ui.php
+++ b/dictionaries/ja.dictionary.itop.ui.php
@@ -794,7 +794,7 @@ Dict::Add('JA JP', 'Japanese', '日本語', array(
 	'UI:Delete:ConfirmDeletionOf_Count_ObjectsOf_Class' => '%2$sクラスの%1$dオブジェクトの削除',
 	'UI:Delete:CannotDeleteBecause' => '削除できません: %1$s',
 	'UI:Delete:ShouldBeDeletedAtomaticallyButNotPossible' => '自動的に削除されるべきですが、出来ません。: %1$s',
-	'UI:Delete:MustBeDeletedManuallyButNotPossible' => '手動で削除されるべきですが、出来ません。: %1$',
+	'UI:Delete:MustBeDeletedManuallyButNotPossible' => '手動で削除されるべきですが、出来ません。: %1$s',
 	'UI:Delete:WillBeDeletedAutomatically' => '自動的に削除されます。',
 	'UI:Delete:MustBeDeletedManually' => '手動で削除されるべきです。',
 	'UI:Delete:CannotUpdateBecause_Issue' => '自動的に更新されるべきですが、しかし: %1$s',
@@ -1005,7 +1005,7 @@ Dict::Add('JA JP', 'Japanese', '日本語', array(
 
 	'Menu:UserAccountsMenu' => 'ユーザアカウント', // Duplicated into itop-welcome-itil (will be removed from here...)
 	'Menu:UserAccountsMenu+' => 'ユーザアカウント', // Duplicated into itop-welcome-itil (will be removed from here...)
-	'Menu:UserAccountsMenu:Title' => 'ユーザアカウント', // Duplicated into itop-welcome-itil (will be removed from here...)	
+	'Menu:UserAccountsMenu:Title' => 'ユーザアカウント', // Duplicated into itop-welcome-itil (will be removed from here...)
 
 	'UI:iTopVersion:Short' => '%1$sバージョン%2$s',
 	'UI:iTopVersion:Long' => '%1$sバージョン%2$s-%3$s ビルド%4$s',
@@ -1094,7 +1094,7 @@ Dict::Add('JA JP', 'Japanese', '日本語', array(
 	'Enum:Undefined' => '未定義',
 	'UI:DurationForm_Days_Hours_Minutes_Seconds' => '%1$s 日 %2$s 時 %3$s 分 %4$s 秒',
 	'UI:ModifyAllPageTitle' => '全てを修正',
-	'UI:Modify_N_ObjectsOf_Class' => 'クラス%2$Sの%1$dオブジェクトを修正',
+	'UI:Modify_N_ObjectsOf_Class' => 'クラス%2$sの%1$dオブジェクトを修正',
 	'UI:Modify_M_ObjectsOf_Class_OutOf_N' => 'クラス%2$sの%3$d中%1$dを修正',
 	'UI:Menu:ModifyAll' => '修正...',
 	'UI:Button:ModifyAll' => '全て修正',
@@ -1111,7 +1111,7 @@ Dict::Add('JA JP', 'Japanese', '日本語', array(
 	'UI:BulkModify_Count_DistinctValues' => '%1$d 個の個別の値:',
 	'UI:BulkModify:Value_Exists_N_Times' => '%1$s, %2$d 回存在',
 	'UI:BulkModify:N_MoreValues' => '%1$d 個以上の値...',
-	'UI:AttemptingToSetAReadOnlyAttribute_Name' => '読み込み専用フィールド %1$にセットしょうとしています。',
+	'UI:AttemptingToSetAReadOnlyAttribute_Name' => '読み込み専用フィールド %1$sにセットしょうとしています。',
 	'UI:FailedToApplyStimuli' => 'アクションは失敗しました。',
 	'UI:StimulusModify_N_ObjectsOf_Class' => '%1$s: クラス%3$sの%2$dオブジェクトを修正',
 	'UI:CaseLogTypeYourTextHere' => 'テキストを入力ください:',

--- a/dictionaries/ru.dictionary.itop.core.php
+++ b/dictionaries/ru.dictionary.itop.core.php
@@ -9,7 +9,7 @@
  *
  */
 Dict::Add('RU RU', 'Russian', 'Русский', array(
-	'Core:DeletedObjectLabel' => '%1ы (удален)',
+	'Core:DeletedObjectLabel' => '%1$sы (удален)',
 	'Core:DeletedObjectTip' => 'Объект был удален %1$s (%2$s)',
 
 	'Core:UnknownObjectLabel' => 'Объект не найден (class: %1$s, id: %2$d)',
@@ -190,7 +190,7 @@ Dict::Add('RU RU', 'Russian', 'Русский', array(
 
 	'Core:AttributeTag' => 'Тег',
 	'Core:AttributeTag+' => 'Тег',
-	
+
 	'Core:Context=REST/JSON' => 'REST',
 	'Core:Context=Synchro' => 'Synchro',
 	'Core:Context=Setup' => 'Setup',

--- a/dictionaries/sk.dictionary.itop.ui.php
+++ b/dictionaries/sk.dictionary.itop.ui.php
@@ -4,7 +4,7 @@
  *
  * This file is part of iTop.
  *
- * iTop is free software; you can redistribute it and/or modify	
+ * iTop is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -419,7 +419,7 @@ Dict::Add('SK SK', 'Slovak', 'Slovenčina', array(
 	'UI:Error:MandatoryTemplateParameter_group_by' => 'Parameter group_by je povinný. Skontrolujte definíciu šablóny zobrazenia.',
 	'UI:Error:InvalidGroupByFields' => 'Neplatný zoznam polí pre skupinu podľa: "%1$s".',
 	'UI:Error:UnsupportedStyleOfBlock' => 'Chyba: nepodporovaný štýl bloku: "%1$s".',
-	'UI:Error:IncorrectLinkDefinition_LinkedClass_Class' => 'Nesprávna definícia spojenia : trieda objektov na manažovanie : %l$s nebol nájdený ako externý kľúč v triede %2$s',
+	'UI:Error:IncorrectLinkDefinition_LinkedClass_Class' => 'Nesprávna definícia spojenia : trieda objektov na manažovanie : %1$s nebol nájdený ako externý kľúč v triede %2$s',
 	'UI:Error:Object_Class_Id_NotFound' => 'Objekt: %1$s:%2$d nebol nájdený.',
 	'UI:Error:WizardCircularReferenceInDependencies' => 'Chyba: Cyklický odkaz v závislostiach medzi poliami, skontrolujte dátový model.',
 	'UI:Error:UploadedFileTooBig' => 'Nahraný súbor je príliš veľký. (Max povolená veľkosť je %1$s). Ak chcete zmeniť tento limit, obráťte sa na správcu ITOP . (Skontrolujte, PHP konfiguráciu pre upload_max_filesize a post_max_size na serveri).',
@@ -1007,7 +1007,7 @@ Keď sú priradené spúštačom, každej akcii je dané číslo "príkazu", šp
 
 	'Menu:UserAccountsMenu' => 'Užívateľské účty', // Duplicated into itop-welcome-itil (will be removed from here...)
 	'Menu:UserAccountsMenu+' => '', // Duplicated into itop-welcome-itil (will be removed from here...)
-	'Menu:UserAccountsMenu:Title' => 'Užívateľské účty', // Duplicated into itop-welcome-itil (will be removed from here...)	
+	'Menu:UserAccountsMenu:Title' => 'Užívateľské účty', // Duplicated into itop-welcome-itil (will be removed from here...)
 
 	'UI:iTopVersion:Short' => 'iTop verzia %1$s',
 	'UI:iTopVersion:Long' => 'iTop verzia %1$s-%2$s postavená na %3$s',
@@ -1238,7 +1238,7 @@ Keď sú priradené spúštačom, každej akcii je dané číslo "príkazu", šp
 	'UI:DashletGroupBy:Prop-GroupBy:DayOfMonth' => 'Deň v mesiaci pre %1$s',
 	'UI:DashletGroupBy:Prop-GroupBy:Select-Hour' => '%1$s (hodina)',
 	'UI:DashletGroupBy:Prop-GroupBy:Select-Month' => '%1$s (mesiac)',
-	'UI:DashletGroupBy:Prop-GroupBy:Select-DayOfWeek' => '%1$ (deň v týžni)',
+	'UI:DashletGroupBy:Prop-GroupBy:Select-DayOfWeek' => '%1$s (deň v týžni)',
 	'UI:DashletGroupBy:Prop-GroupBy:Select-DayOfMonth' => '%1$s (deň v mesiaci)',
 	'UI:DashletGroupBy:MissingGroupBy' => 'Prosím zvoľte pole na ktorom objekty budú zoskupené spolu',
 

--- a/dictionaries/tr.dictionary.itop.core.php
+++ b/dictionaries/tr.dictionary.itop.core.php
@@ -211,7 +211,7 @@ Operators:<br/>
 
 	'Core:AttributeTag' => 'Tags~~',
 	'Core:AttributeTag+' => 'Tags~~',
-	
+
 	'Core:Context=REST/JSON' => 'REST~~',
 	'Core:Context=Synchro' => 'Synchro~~',
 	'Core:Context=Setup' => 'Setup~~',
@@ -309,7 +309,7 @@ Dict::Add('TR TR', 'Turkish', 'Türkçe', array(
 	'Change:AttName_SetTo_NewValue_PreviousValue_OldValue' => '%1$s\'nin değeri %2$s olarak atandı (önceki değer: %3$s)',
 	'Change:AttName_SetTo' => '%1$s\'nin değeri %2$s olarak atandı',
 	'Change:Text_AppendedTo_AttName' => '%2$s\'ye %1$s eklendi',
-	'Change:AttName_Changed_PreviousValue_OldValue' => '%1$\'nin değeri deiştirildi, önceki değer: %2$s',
+	'Change:AttName_Changed_PreviousValue_OldValue' => '%1$snin değeri deiştirildi, önceki değer: %2$s',
 	'Change:AttName_Changed' => '%1$s değiştirildi',
 	'Change:AttName_EntryAdded' => '%1$s değiştirilmiş, yeni giriş eklendi.',
 	'Change:LinkSet:Added' => '%1$s \'eklendi',

--- a/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
+++ b/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright (C) 2013-2020 Combodo SARL
+ * This file is part of iTop.
+ * iTop is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * iTop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ */
+
+namespace Combodo\iTop\Test\UnitTest\Integration;
+
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+
+class DictionariesConsistencyAfterSetupTest extends ItopTestCase
+{
+	public function FormatProvider(){
+		return [
+			'key does not exist in dictionnary' => [
+				'sTemplate' => null,
+				'sExpectedTraduction' => 'ITOP::DICT:FORMAT:BROKEN:KEY - 1',
+			],
+			'traduction that breaks expected nb of arguments' => [
+				'sTemplate' => 'toto %1$s titi %2$s',
+				'sExpectedTraduction' => 'ITOP::DICT:FORMAT:BROKEN:KEY - 1',
+			],
+			'traduction ok' => [
+				'sTemplate' => 'toto %1$s titi',
+				'sExpectedTraduction' => 'toto 1 titi',
+			],
+		];
+	}
+
+	/**
+	 * @since 2.7.10 N°5491 - Inconsistent dictionary entries regarding arguments to pass to Dict::Format
+	 * Dict::Format
+	 * @dataProvider FormatProvider
+	 */
+	public function testFormat($sTemplate, $sExpectedTraduction){
+		$sLangCode = \Dict::GetUserLanguage();
+		$aDictByLang = $this->GetNonPublicStaticProperty(\Dict::class, 'm_aData');
+		$sDictKey = 'ITOP::DICT:FORMAT:BROKEN:KEY';
+
+		if (! is_null($sTemplate)){
+			if (array_key_exists($sLangCode, $aDictByLang)){
+				$aDictByLang[$sLangCode][$sDictKey] = $sTemplate;
+			} else {
+				$aDictByLang[$sLangCode] = [$sDictKey => $sTemplate];
+			}
+		}
+
+		$this->SetNonPublicStaticProperty(\Dict::class, 'm_aData', $aDictByLang);
+
+		$this->assertEquals($sExpectedTraduction, \Dict::Format($sDictKey, "1"));
+	}
+}

--- a/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
+++ b/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
@@ -83,6 +83,7 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 		foreach ($aDictEntry as $sKey => $sValue){
 			$aKeyArgsCount[$sKey] = $this->countArg($sValue);
 		}
+		ksort($aKeyArgsCount);
 		return $aKeyArgsCount;
 	}
 
@@ -146,12 +147,29 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 		$this->SetNonPublicStaticProperty(\Dict::class, 'm_sCurrentLanguage', $sCode);
 
 		$aMismatchedKeys = [];
+		$aLabelCodeNotToCheck = [
+			//use of Dict::S not Format
+			"UI:Audit:PercentageOk",
+
+			//unused dead labels
+			"Class:DatacenterDevice/Attribute:redundancy/count",
+			"Class:DatacenterDevice/Attribute:redundancy/disabled",
+			"Class:DatacenterDevice/Attribute:redundancy/percent",
+			"Class:TriggerOnThresholdReached/Attribute:threshold_index+"
+		];
+
+
 		foreach ($aKeyArgsCountMap[$sReferenceLangCode] as $sKey => $iExpectedNbOfArgs){
-			if ($iExpectedNbOfArgs === 0){
+			if (in_array($sKey, $aLabelCodeNotToCheck)){
+				//false positive: do not test
+				continue;
+			}
+
+				/*if ($iExpectedNbOfArgs === 0){
 				//there is a good chance Dict:S is called, not Dict::Format
 				//avoid to raise false positive broken traductions
 				continue;
-			}
+				}*/
 			if (array_key_exists($sKey, $aDictEntry)){
 				$aPlaceHolders = [];
 				for ($i=0; $i<$iExpectedNbOfArgs; $i++){

--- a/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
+++ b/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
@@ -147,6 +147,11 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 
 		$aMismatchedKeys = [];
 		foreach ($aKeyArgsCountMap[$sReferenceLangCode] as $sKey => $iExpectedNbOfArgs){
+			if ($iExpectedNbOfArgs === 0){
+				//there is a good chance Dict:S is called, not Dict::Format
+				//avoid to raise false positive broken traductions
+				continue;
+			}
 			if (array_key_exists($sKey, $aDictEntry)){
 				$aPlaceHolders = [];
 				for ($i=0; $i<$iExpectedNbOfArgs; $i++){
@@ -155,15 +160,8 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 
 				$sLabelTemplate = $aDictEntry[$sKey];
 				try{
-					if (is_null(vsprintf($sLabelTemplate, $aPlaceHolders))){
-						$sError = 'null label';
-						if (array_key_exists($sError, $aMismatchedKeys)){
-							$aMismatchedKeys[$sError][$sKey] = $iExpectedNbOfArgs;
-						} else {
-							$aMismatchedKeys[$sError] = [$sKey => $iExpectedNbOfArgs];
-						}
-					}
-				} catch(\Exception $e){
+					vsprintf($sLabelTemplate, $aPlaceHolders);
+				} catch(\Throwable $e){
 					$sError = $e->getMessage();
 					if (array_key_exists($sError, $aMismatchedKeys)){
 						$aMismatchedKeys[$sError][$sKey] = $iExpectedNbOfArgs;
@@ -199,4 +197,41 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 		$sErrorMsg = sprintf("%s broken propertie(s) on $sCode dictionaries!", $iCount);
 		$this->assertEquals([], $aMismatchedKeys, $sErrorMsg);
 	}
+
+	/*public function VsprintfProvider(){
+		return [
+			'not enough args' => [
+				"sLabelTemplate" => "$1%s",
+				"aPlaceHolders" => [],
+			],
+			'exact nb of args' => [
+				"sLabelTemplate" => "$1%s",
+				"aPlaceHolders" => ["1"],
+			],
+			'too much args' => [
+				"sLabelTemplate" => "$1%s",
+				"aPlaceHolders" => ["1", "2"],
+			],
+			'\"% ok\" without args' => [
+				"sLabelTemplate" => "% ok",
+				"aPlaceHolders" => [],
+			],
+			'\"% ok $1%s\" without args' => [
+				"sLabelTemplate" => "% ok",
+				"aPlaceHolders" => ['1'],
+			],
+		];
+	}*/
+
+	/**
+	 * @dataProvider VsprintfProvider
+	 */
+	/*public function testVsprintf($sLabelTemplate, $aPlaceHolders){
+		try{
+			vsprintf($sLabelTemplate, $aPlaceHolders);
+			$this->assertTrue(true);
+		} catch(\Throwable $e) {
+			$this->assertTrue(false, "label \'" .  $sLabelTemplate . " failed with " . var_export($aPlaceHolders, true)  );
+		}
+	}*/
 }

--- a/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
+++ b/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
@@ -58,4 +58,222 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 
 		$this->assertEquals($sExpectedTraduction, \Dict::Format($sDictKey, "1"));
 	}
+
+
+	/**
+	 * return a map linked to *.dict.php files that are generated after setup
+	 * each entry key is lang code (example 'en')
+	 * each value is an array with lang code (again) and dict file path
+	 * @return array
+	 */
+	private function GetDictFiles() : array {
+		$aDictFiles = [];
+
+		foreach (glob(APPROOT.'env-'.\utils::GetCurrentEnvironment().'/dictionaries/*.dict.php') as $sDictFile){
+			if (preg_match('/.*\\/(.*).dict.php/', $sDictFile, $aMatches)){
+				$sLangCode = $aMatches[1];
+				$aDictFiles[$sLangCode] = [
+					'lang' => $sLangCode,
+					'file' => $sDictFile
+				];
+			}
+		}
+		return $aDictFiles;
+	}
+
+	/**
+	 * return a map generated with all *dict.php files content
+	 * each entry key is the lang code (example 'en)
+	 * each value is an array with localization code (ex. 'EN US') and a map of label key/values
+	 * map is sorted by keys: en is first, then fr and then other lang code
+	 * @return array
+	 */
+	private function ReadAllDictKeys() : array{
+		clearstatcache();
+		$aDictFiles =  $this->GetDictFiles();
+		$aDictEntries = [];
+		$aTmpValue=[];
+		foreach ($aDictFiles as $sCode => $aData){
+			$sContent = file_get_contents($aData['file']);
+			$sReplacedContent = str_replace('Dict::SetEntries(', "\$aTmpValue['$sCode'] = array(", $sContent);
+			$sTempFilePath = tempnam(sys_get_temp_dir(), 'tmp_dict').'.php';
+			file_put_contents($sTempFilePath, $sReplacedContent);
+			require_once($sTempFilePath);
+			unlink($sTempFilePath);
+
+			$aDictEntries[$sCode] = $aTmpValue[$sCode];
+		}
+
+		uksort($aDictEntries, function (string $sLangCode1, string $sLangCode2) {
+			$sEnUsCode = "en-us";
+			$sFrCode = "fr-fr";
+
+			if ($sLangCode1 === $sEnUsCode) {
+				return -1;
+			}
+			if ($sLangCode2 === $sEnUsCode) {
+				return 1;
+			}
+			if ($sLangCode1 === $sFrCode) {
+				return -1;
+			}
+			if ($sLangCode2 === $sFrCode) {
+				return 1;
+			}
+			return ($sLangCode1 < $sLangCode2) ? 1 : -1;
+		});
+
+		return $aDictEntries;
+	}
+
+	/**
+	 * @group beforeSetup
+	 * this test checks that there are the exact same count of labels between 'en'
+	 * it checks also that label keys are the same as well (we could have the same count with 'toto' label key on 'en' side and 'titi' on another dict side)
+	 */
+	public function testDictEntryKeys()
+	{
+		$aDictEntries =  $this->ReadAllDictKeys();
+		$this->assertNotEquals([], $aDictEntries, "No entries found from *.dict.php");
+
+		$sPreviousCode = null;
+		$sPreviousSize = null;
+		$sPreviousKeys = null;
+		foreach ($aDictEntries as $sCode => $aData){
+			$aLabelEntries = $aData[1];
+			$iCurrentSize = sizeof($aLabelEntries);
+			$aCurrentKeys = array_keys($aLabelEntries);
+			sort($aCurrentKeys);
+
+			if ($sPreviousCode===null){
+				$sPreviousCode = $sCode;
+				$sPreviousSize = $iCurrentSize;
+				$aPreviousKeys = $aCurrentKeys;
+			} else {
+				$this->assertEquals($sPreviousSize, $iCurrentSize, "$sPreviousCode and $sCode  dictionnaries dont have the same amount of labels ($iCurrentSize vs $sPreviousSize)");
+				$this->assertEquals($aPreviousKeys, $aCurrentKeys, "$sPreviousCode and $sCode dictionnaries dont have the same label keys");
+			}
+		}
+	}
+
+	public function DictEntryValuesProvider(){
+		//first entry should be linked to 'en' dictionnary
+		//it is linked to sorting order used on ReadAllDictKeys
+		$aFirstDictEntry = [];
+		$sFirstEntryCode = null;
+
+		$aUseCases = [];
+
+		foreach ($this->ReadAllDictKeys() as $sCode => $aDictEntry){
+			if (null === $sFirstEntryCode){
+				$sFirstEntryCode = $sCode;
+				$aFirstDictEntry = $aDictEntry;
+			}
+			$aUseCases[$sCode] = [
+				'firstDict' => $aFirstDictEntry,
+				'firstCode' => $sFirstEntryCode,
+				'currentCode' => $sCode,
+				'currentDict' => $aDictEntry,
+			];
+		}
+
+		return $aUseCases;
+	}
+
+	/**
+	 * foreach dictionnary label map (key/value) it counts the number argument that should be passed to use Dict::Format
+	 * examples:
+	 *  for "gabu zomeu" label there are no args
+	 *  for "shadok %1 %2 %3" there are 3 args
+	 *
+	 * limitation: there is no validation check for "%3 itop %2 combodo" which seems unconsistent
+	 * @param $aDictEntry
+	 *
+	 * @return array
+	 */
+	private function GetKeyArgCountMap($aDictEntry) : array{
+		$aKeyArgsCount = [];
+		$aLabelEntries = $aDictEntry[1];
+		foreach ($aLabelEntries as $sKey => $sValue){
+			$iMaxIndex = 0;
+			if (preg_match_all("/%(\d+)/", $sValue, $aMatches)){
+				$aSubMatches = $aMatches[1];
+				if (is_array($aSubMatches)){
+					foreach ($aSubMatches as $aCurrentMatch){
+						$iIndex = $aCurrentMatch;
+						$iMaxIndex = ($iMaxIndex < $iIndex) ? $iIndex : $iMaxIndex;
+					}
+				}
+			} else if ((false !== strpos($sValue, "%s"))
+				|| (false !== strpos($sValue, "%d"))
+			){
+				$iMaxIndex = 1;
+			}
+
+			$aKeyArgsCount[$sKey] = $iMaxIndex;
+		}
+		return $aKeyArgsCount;
+	}
+
+	/**
+	 * @group beforeSetup
+	 * compare en and other dictionnaries and check that for all labels there it the same number of arguments
+	 * if not Dict::Format could raise an exception for some languages. translation should be done again...
+	 * @dataProvider DictEntryValuesProvider
+	 */
+	public function testDictEntryValues($aFirstDictEntry, $sFirstEntryCode, $sCode, $aDictEntry)
+	{
+		$aKeyArgsCountMap = [];
+		$aKeyArgsCountMap[$sFirstEntryCode] = $this->GetKeyArgCountMap($aFirstDictEntry);
+		//$aKeyArgsCountMap[$sCode] = $this->GetKeyArgCountMap($aDictEntry);
+
+		//set user language
+		$this->SetNonPublicStaticProperty(\Dict::class, 'm_sCurrentLanguage', $sCode);
+
+		$aMismatchedKeys = [];
+		foreach ($aKeyArgsCountMap[$sFirstEntryCode] as $sKey => $iCount){
+			if (array_key_exists($sKey, $aDictEntry[1])){
+				$aPlaceHolders = [];
+				for ($i=0; $i<$iCount; $i++){
+					$aPlaceHolders[]=$i;
+				}
+
+				$sLabelTemplate = $aDictEntry[1][$sKey];
+				try{
+					if (is_null(vsprintf($sLabelTemplate, $aPlaceHolders))){
+						$aMismatchedKeys['null label'] = $sKey;
+					}
+				} catch(\Exception $e){
+					if (array_key_exists($e->getMessage(), $aMismatchedKeys)){
+						$aMismatchedKeys[$e->getMessage()][] = $sKey;
+					} else {
+						$aMismatchedKeys[$e->getMessage()] = [$sKey];
+					}
+				}
+			}
+		}
+
+		foreach ($aMismatchedKeys as $sError => $aKeys){
+			var_dump($sError);
+			foreach ($aKeys as $sKey) {
+				if ($sFirstEntryCode === $sCode) {
+					var_dump([
+						'label key' => $sKey,
+						'expected nb of args' => $iCount,
+						$sCode => $aDictEntry[1][$sKey],
+					]);
+				} else {
+					var_dump([
+						'label key' => $sKey,
+						'expected nb of args' => $iCount,
+						$sCode => $aDictEntry[1][$sKey],
+						"label value in $sFirstEntryCode" => $aFirstDictEntry[1][$sKey],
+					]);
+				}
+			}
+		}
+
+		$sErrorMsg = "$sFirstEntryCode and $sCode dictionnaries dont have the proper args provided to Dict::Format method and UI could explode without try/catch N°5491 dirty fix!";
+		$this->assertEquals([], $aMismatchedKeys, $sErrorMsg);
+	}
 }

--- a/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
+++ b/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
@@ -105,45 +105,6 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 		return $iMaxIndex;
 	}
 
-	public function test(){
-		$aLanguagesList = [];
-		foreach ($this->LangCodeProvider() as $sKey => $aLangCode){
-			$aLanguagesList[]= array_pop($aLangCode);
-		}
-		sort($aLanguagesList);
-
-		$aDictFiles = array_merge(
-			glob(APPROOT.'datamodels/2.x/*/*.dict*.php'), // legacy form in modules
-			glob(APPROOT.'datamodels/2.x/*/dictionaries/*.dict*.php'), // modern form in modules
-			glob(APPROOT.'dictionaries/*.dict*.php') // framework
-		);
-		sort($aDictFiles);
-
-		$aDictLangageLangCode=[];
-		foreach ($aDictFiles as $sFile){
-			$aInfo = null;
-			$sContent = file_get_contents($sFile);
-			if(preg_match_all('/^.*Dict::Add.*,.*$/m', $sContent, $sContent)){
-				$sLine = $sContent[0][0];
-				var_dump($sLine);
-				$sCode = str_replace('Dict::Add', '$aInfo = array', $sLine);
-			}
-			$sTempFile = tempnam(sys_get_temp_dir(), 'dict_');
-			file_put_contents($sTempFile, );
-			var_dump(file_get_contents($sTempFile));
-			require_once $sTempFile;
-			unlink($sTempFile);
-			if (! is_null($aInfo)){
-				var_dump($aInfo);
-				$aDictLangageLangCode = $aInfo[0];
-			}
-		}
-
-		sort($aDictLangageLangCode);
-
-		$this->assertEquals($aDictLangageLangCode, $aLanguagesList);
-	}
-
 	public function LangCodeProvider(){
 		return [
 			'cs' => [ 'CS CZ' ],

--- a/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
+++ b/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
@@ -105,24 +105,23 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 		return $iMaxIndex;
 	}
 
-	public function LangCodeProvider() {
+	public function LangCodeProvider(){
 		return [
-			'cs' => ['CS CZ'],
-			'da' => ['DA DA'],
-			'de' => ['DE DE'],
-			'en' => ['EN US'],
-			'es_cr' => ['ES CR'],
-			'fr' => ['FR FR'],
-			'hu' => ['HU HU'],
-			'it' => ['IT IT'],
-			'ja' => ['JA JP'],
-			'nl' => ['NL NL'],
-			'pl' => ['PL PL'],
-			'pt_br' => ['PT BR'],
-			'ru' => ['RU RU'],
-			'sk' => ['SK SK'],
-			'tr' => ['TR TR'],
-			'zh_cn' => ['ZH CN'],
+			'cs' => [ 'CS CZ' ],
+			'da' => [ 'DA DA' ],
+			'de' => [ 'DE DE' ],
+			'en' => [ 'EN US' ],
+			'es' => [ 'ES CR' ],
+			'fr' => [ 'FR FR' ],
+			'hu' => [ 'HU HU' ],
+			'it' => [ 'IT IT' ],
+			'ja' => [ 'JA JP' ],
+			'nl' => [ 'NL NL' ],
+			'pt' => [ 'PT BR' ],
+			'ru' => [ 'RU RU' ],
+			'sk' => [ 'SK SK' ],
+			'tr' => [ 'TR TR' ],
+			'zh' => [ 'ZH CN' ],
 		];
 	}
 

--- a/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
+++ b/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
@@ -105,6 +105,45 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 		return $iMaxIndex;
 	}
 
+	public function test(){
+		$aLanguagesList = [];
+		foreach ($this->LangCodeProvider() as $sKey => $aLangCode){
+			$aLanguagesList[]= array_pop($aLangCode);
+		}
+		sort($aLanguagesList);
+
+		$aDictFiles = array_merge(
+			glob(APPROOT.'datamodels/2.x/*/*.dict*.php'), // legacy form in modules
+			glob(APPROOT.'datamodels/2.x/*/dictionaries/*.dict*.php'), // modern form in modules
+			glob(APPROOT.'dictionaries/*.dict*.php') // framework
+		);
+		sort($aDictFiles);
+
+		$aDictLangageLangCode=[];
+		foreach ($aDictFiles as $sFile){
+			$aInfo = null;
+			$sContent = file_get_contents($sFile);
+			if(preg_match_all('/^.*Dict::Add.*,.*$/m', $sContent, $sContent)){
+				$sLine = $sContent[0][0];
+				var_dump($sLine);
+				$sCode = str_replace('Dict::Add', '$aInfo = array', $sLine);
+			}
+			$sTempFile = tempnam(sys_get_temp_dir(), 'dict_');
+			file_put_contents($sTempFile, );
+			var_dump(file_get_contents($sTempFile));
+			require_once $sTempFile;
+			unlink($sTempFile);
+			if (! is_null($aInfo)){
+				var_dump($aInfo);
+				$aDictLangageLangCode = $aInfo[0];
+			}
+		}
+
+		sort($aDictLangageLangCode);
+
+		$this->assertEquals($aDictLangageLangCode, $aLanguagesList);
+	}
+
 	public function LangCodeProvider(){
 		return [
 			'cs' => [ 'CS CZ' ],
@@ -156,13 +195,19 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 				$sLabelTemplate = $aDictEntry[$sKey];
 				try{
 					if (is_null(vsprintf($sLabelTemplate, $aPlaceHolders))){
-						$aMismatchedKeys['null label'] = $sKey;
+						$sError = 'null label';
+						if (array_key_exists($sError, $aMismatchedKeys)){
+							$aMismatchedKeys[$sError][$sKey] = $iExpectedNbOfArgs;
+						} else {
+							$aMismatchedKeys[$sError] = [$sKey => $iExpectedNbOfArgs];
+						}
 					}
 				} catch(\Exception $e){
-					if (array_key_exists($e->getMessage(), $aMismatchedKeys)){
-						$aMismatchedKeys[$e->getMessage()][$sKey] = $iExpectedNbOfArgs;
+					$sError = $e->getMessage();
+					if (array_key_exists($sError, $aMismatchedKeys)){
+						$aMismatchedKeys[$sError][$sKey] = $iExpectedNbOfArgs;
 					} else {
-						$aMismatchedKeys[$e->getMessage()] = [$sKey => $iExpectedNbOfArgs];
+						$aMismatchedKeys[$sError] = [$sKey => $iExpectedNbOfArgs];
 					}
 				}
 			}
@@ -170,7 +215,7 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 
 		$iCount = 0;
 		foreach ($aMismatchedKeys as $sError => $aKeys){
-			//var_dump($sError);
+			var_dump($sError);
 			foreach ($aKeys as $sKey => $iExpectedNbOfArgs) {
 				$iCount++;
 				if ($sReferenceLangCode === $sCode) {

--- a/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
+++ b/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
@@ -105,25 +105,25 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 		return $iMaxIndex;
 	}
 
-	public function LangCodeProvider(){
-		$aUseCases = [];
-
-		$aLanguagesList = null;
-		$this->setUp();
-		$sFile = APPROOT.'env-'.\utils::GetCurrentEnvironment().'/dictionaries/languages.php';
-		$this->tearDown(); //release transaction
-		$sContent = file_get_contents($sFile);
-		$sTempFile = tempnam(sys_get_temp_dir(), 'dict_');
-		file_put_contents($sTempFile, str_replace('Dict::SetLanguagesList', '$aLanguagesList = array', $sContent));
-		require_once $sTempFile;
-		unlink($sTempFile);
-
-		$aDictInfo = array_pop($aLanguagesList);
-		$aLangCode = array_keys($aDictInfo);
-		foreach ($aLangCode as $sLangCode){
-			$aUseCases[$sLangCode] = [$sLangCode];
-		}
-		return $aUseCases;
+	public function LangCodeProvider() {
+		return [
+			'cs' => ['CS CZ'],
+			'da' => ['DA DA'],
+			'de' => ['DE DE'],
+			'en' => ['EN US'],
+			'es_cr' => ['ES CR'],
+			'fr' => ['FR FR'],
+			'hu' => ['HU HU'],
+			'it' => ['IT IT'],
+			'ja' => ['JA JP'],
+			'nl' => ['NL NL'],
+			'pl' => ['PL PL'],
+			'pt_br' => ['PT BR'],
+			'ru' => ['RU RU'],
+			'sk' => ['SK SK'],
+			'tr' => ['TR TR'],
+			'zh_cn' => ['ZH CN'],
+		];
 	}
 
 	/**

--- a/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
+++ b/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
@@ -69,32 +69,11 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 	private function ReadAllDictKeys() : array{
 		$this->setUp();
 
-		$aPrefixToLanguageData = array(
-			'cs' => array('CS CZ', 'Czech', 'Čeština'),
-			'da' => array('DA DA', 'Danish', 'Dansk'),
-			'de' => array('DE DE', 'German', 'Deutsch'),
-			'en' => array('EN US', 'English', 'English'),
-			'es_cr' => array('ES CR', 'Spanish', array(
-				'Español, Castellaño', // old value
-				'Español, Castellano', // new value since N°3635
-			)),
-			'fr' => array('FR FR', 'French', 'Français'),
-			'hu' => array('HU HU', 'Hungarian', 'Magyar'),
-			'it' => array('IT IT', 'Italian', 'Italiano'),
-			'ja' => array('JA JP', 'Japanese', '日本語'),
-			'nl' => array('NL NL', 'Dutch', 'Nederlands'),
-			'pl' => array('PL PL', 'Polish', 'Polski'),
-			'pt_br' => array('PT BR', 'Brazilian', 'Brazilian'),
-			'ru' => array('RU RU', 'Russian', 'Русский'),
-			'sk' => array('SK SK', 'Slovak', 'Slovenčina'),
-			'tr' => array('TR TR', 'Turkish', 'Türkçe'),
-			'zh_cn' => array('ZH CN', 'Chinese', '简体中文'),
-		);
-
-		foreach($aPrefixToLanguageData as $sLang => $aLangInfo){
-			$sLangCode = $aLangInfo[0];
+		$aAvailableLanguages = \Dict::GetLanguages();
+		foreach($aAvailableLanguages as $sLangCode => $aInfo){
 			\Dict::InitLangIfNeeded($sLangCode);
 		}
+
 		$aDictEntries = $this->GetNonPublicStaticProperty(\Dict::class, 'm_aData');
 
 		uksort($aDictEntries, function (string $sLangCode1, string $sLangCode2) {

--- a/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
+++ b/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
@@ -162,7 +162,6 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 	}
 
 	/**
-	 * @group beforeSetup
 	 * compare en and other dictionnaries and check that for all labels there it the same number of arguments
 	 * if not Dict::Format could raise an exception for some languages. translation should be done again...
 	 * @dataProvider DictEntryValuesProvider

--- a/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
+++ b/tests/php-unit-tests/integration-tests/DictionariesConsistencyAfterSetupTest.php
@@ -229,7 +229,6 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 
 	/**
 	 * @dataProvider VsprintfProvider
-	 */
 	public function testVsprintf($sLabelTemplate, $aPlaceHolders){
 		try{
 			$this->markTestSkipped("usefull to check a specific PHP version behavior");
@@ -239,4 +238,5 @@ class DictionariesConsistencyAfterSetupTest extends ItopTestCase
 			$this->assertTrue(false, "label \'" .  $sLabelTemplate . " failed with " . var_export($aPlaceHolders, true)  );
 		}
 	}
+	 */
 }

--- a/tests/php-unit-tests/integration-tests/DictionariesConsistencyTest.php
+++ b/tests/php-unit-tests/integration-tests/DictionariesConsistencyTest.php
@@ -117,44 +117,4 @@ class DictionariesConsistencyTest extends ItopTestCase
 		}
 		return $aTestCases;
 	}
-
-	public function FormatProvider(){
-		return [
-			'key does not exist in dictionnary' => [
-				'sTemplate' => null,
-				'sExpectedTraduction' => 'ITOP::DICT:FORMAT:BROKEN:KEY - 1',
-			],
-			'traduction that breaks expected nb of arguments' => [
-				'sTemplate' => 'toto %1$s titi %2$s',
-				'sExpectedTraduction' => 'ITOP::DICT:FORMAT:BROKEN:KEY - 1',
-			],
-			'traduction ok' => [
-				'sTemplate' => 'toto %1$s titi',
-				'sExpectedTraduction' => 'toto 1 titi',
-			],
-		];
-	}
-
-	/**
-	 * @since 2.7.10 N°5491 - Inconsistent dictionnary entries regarding arguments to pass to Dict::Format
-	 * Dict::Format
-	 * @dataProvider FormatProvider
-	 */
-	public function testFormat($sTemplate, $sExpectedTraduction){
-		$sLangCode = \Dict::GetUserLanguage();
-		$aDictByLang = $this->GetNonPublicStaticProperty(\Dict::class, 'm_aData');
-		$sDictKey = 'ITOP::DICT:FORMAT:BROKEN:KEY';
-
-		if (! is_null($sTemplate)){
-			if (array_key_exists($sLangCode, $aDictByLang)){
-				$aDictByLang[$sLangCode][$sDictKey] = $sTemplate;
-			} else {
-				$aDictByLang[$sLangCode] = [$sDictKey => $sTemplate];
-			}
-		}
-
-		$this->SetNonPublicStaticProperty(\Dict::class, 'm_aData', $aDictByLang);
-
-		$this->assertEquals($sExpectedTraduction, \Dict::Format($sDictKey, "1"));
-	}
 }

--- a/tests/php-unit-tests/integration-tests/DictionariesConsistencyTest.php
+++ b/tests/php-unit-tests/integration-tests/DictionariesConsistencyTest.php
@@ -117,4 +117,44 @@ class DictionariesConsistencyTest extends ItopTestCase
 		}
 		return $aTestCases;
 	}
+
+	public function FormatProvider(){
+		return [
+			'key does not exist in dictionnary' => [
+				'sTemplate' => null,
+				'sExpectedTraduction' => 'ITOP::DICT:FORMAT:BROKEN:KEY - 1',
+			],
+			'traduction that breaks expected nb of arguments' => [
+				'sTemplate' => 'toto %1$s titi %2$s',
+				'sExpectedTraduction' => 'ITOP::DICT:FORMAT:BROKEN:KEY - 1',
+			],
+			'traduction ok' => [
+				'sTemplate' => 'toto %1$s titi',
+				'sExpectedTraduction' => 'toto 1 titi',
+			],
+		];
+	}
+
+	/**
+	 * @since 2.7.10 N°5491 - Inconsistent dictionnary entries regarding arguments to pass to Dict::Format
+	 * Dict::Format
+	 * @dataProvider FormatProvider
+	 */
+	public function testFormat($sTemplate, $sExpectedTraduction){
+		$sLangCode = \Dict::GetUserLanguage();
+		$aDictByLang = $this->GetNonPublicStaticProperty(\Dict::class, 'm_aData');
+		$sDictKey = 'ITOP::DICT:FORMAT:BROKEN:KEY';
+
+		if (! is_null($sTemplate)){
+			if (array_key_exists($sLangCode, $aDictByLang)){
+				$aDictByLang[$sLangCode][$sDictKey] = $sTemplate;
+			} else {
+				$aDictByLang[$sLangCode] = [$sDictKey => $sTemplate];
+			}
+		}
+
+		$this->SetNonPublicStaticProperty(\Dict::class, 'm_aData', $aDictByLang);
+
+		$this->assertEquals($sExpectedTraduction, \Dict::Format($sDictKey, "1"));
+	}
 }

--- a/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
@@ -223,41 +223,6 @@ abstract class ItopTestCase extends TestCase
 	}
 
 	/**
-	 * @since 3.1.0 2.7.10
-	 * @param string $sClass
-	 * @param string $sProperty
-	 *
-	 * @return \ReflectionProperty
-	 *
-	 * @throws \ReflectionException
-	 */
-	private function GetProperty(string $sClass, string $sProperty)
-	{
-		$class = new \ReflectionClass($sClass);
-		$property = $class->getProperty($sProperty);
-		$property->setAccessible(true);
-
-		return $property;
-	}
-
-	/**
-	 * @param object $oObject
-	 * @param string $sProperty
-	 *
-	 * @return mixed property
-	 *
-	 * @throws \ReflectionException
-	 * @since 2.7.8 3.0.3 3.1.0
-	 */
-	public function GetNonPublicProperty(object $oObject, string $sProperty)
-	{
-		$property = $this->GetProperty(get_class($oObject), $sProperty);
-		$property->setAccessible(true);
-
-		return $property->getValue($oObject);
-	}
-
-	/**
 	 * @param string $sClass
 	 * @param string $sProperty
 	 *
@@ -276,6 +241,40 @@ abstract class ItopTestCase extends TestCase
 	/**
 	 * @param object $oObject
 	 * @param string $sProperty
+	 *
+	 * @return mixed property
+	 *
+	 * @throws \ReflectionException
+	 * @since 2.7.8 3.0.3 3.1.0
+	 */
+	public function GetNonPublicProperty(object $oObject, string $sProperty)
+	{
+		$oProperty = $this->GetProperty(get_class($oObject), $sProperty);
+
+		return $oProperty->getValue($oObject);
+	}
+
+	/**
+	 * @param string $sClass
+	 * @param string $sProperty
+	 *
+	 * @return \ReflectionProperty
+	 *
+	 * @throws \ReflectionException
+	 * @since 2.7.10 3.1.0
+	 */
+	private function GetProperty(string $sClass, string $sProperty)
+	{
+		$oClass = new \ReflectionClass($sClass);
+		$oProperty = $oClass->getProperty($sProperty);
+		$oProperty->setAccessible(true);
+
+		return $oProperty;
+	}
+
+	/**
+	 * @param object $oObject
+	 * @param string $sProperty
 	 * @param $value
 	 *
 	 * @throws \ReflectionException
@@ -283,10 +282,8 @@ abstract class ItopTestCase extends TestCase
 	 */
 	public function SetNonPublicProperty(object $oObject, string $sProperty, $value)
 	{
-		$property = $this->GetProperty(get_class($oObject), $sProperty);
-		$property->setAccessible(true);
-
-		$property->setValue($oObject, $value);
+		$oProperty = $this->GetProperty(get_class($oObject), $sProperty);
+		$oProperty->setValue($oObject, $value);
 	}
 
 	/**
@@ -302,4 +299,5 @@ abstract class ItopTestCase extends TestCase
 		$oProperty = $this->GetProperty($sClass, $sProperty);
 		$oProperty->setValue($value);
 	}
+
 }

--- a/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
@@ -257,4 +257,16 @@ abstract class ItopTestCase extends TestCase
 
 		$property->setValue($oObject, $value);
 	}
+
+	/**
+	 * @since 2.7.10 3.1.0
+	 */
+	public function GetNonPublicStaticProperty(string $sClass, string $sProperty)
+	{
+		$class = new \ReflectionClass($sClass);
+		$oProperty = $class->getProperty($sProperty);
+		$oProperty->setAccessible(true);
+
+		return $oProperty->getValue();
+	}
 }

--- a/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
@@ -222,6 +222,23 @@ abstract class ItopTestCase extends TestCase
 		return $method->invokeArgs($oObject, $aArgs);
 	}
 
+	/**
+	 * @since 3.1.0 2.7.10
+	 * @param string $sClass
+	 * @param string $sProperty
+	 *
+	 * @return \ReflectionProperty
+	 *
+	 * @throws \ReflectionException
+	 */
+	private function GetProperty(string $sClass, string $sProperty)
+	{
+		$class = new \ReflectionClass($sClass);
+		$property = $class->getProperty($sProperty);
+		$property->setAccessible(true);
+
+		return $property;
+	}
 
 	/**
 	 * @param object $oObject
@@ -234,11 +251,26 @@ abstract class ItopTestCase extends TestCase
 	 */
 	public function GetNonPublicProperty(object $oObject, string $sProperty)
 	{
-		$class = new \ReflectionClass(get_class($oObject));
-		$property = $class->getProperty($sProperty);
+		$property = $this->GetProperty(get_class($oObject), $sProperty);
 		$property->setAccessible(true);
 
 		return $property->getValue($oObject);
+	}
+
+	/**
+	 * @param string $sClass
+	 * @param string $sProperty
+	 *
+	 * @return mixed property
+	 *
+	 * @throws \ReflectionException
+	 * @since 2.7.10 3.1.0
+	 */
+	public function GetNonPublicStaticProperty(string $sClass, string $sProperty)
+	{
+		$oProperty = $this->GetProperty($sClass, $sProperty);
+
+		return $oProperty->getValue();
 	}
 
 	/**
@@ -251,22 +283,23 @@ abstract class ItopTestCase extends TestCase
 	 */
 	public function SetNonPublicProperty(object $oObject, string $sProperty, $value)
 	{
-		$class = new \ReflectionClass(get_class($oObject));
-		$property = $class->getProperty($sProperty);
+		$property = $this->GetProperty(get_class($oObject), $sProperty);
 		$property->setAccessible(true);
 
 		$property->setValue($oObject, $value);
 	}
 
 	/**
+	 * @param string $sClass
+	 * @param string $sProperty
+	 * @param $value
+	 *
+	 * @throws \ReflectionException
 	 * @since 2.7.10 3.1.0
 	 */
-	public function GetNonPublicStaticProperty(string $sClass, string $sProperty)
+	public function SetNonPublicStaticProperty(string $sClass, string $sProperty, $value)
 	{
-		$class = new \ReflectionClass($sClass);
-		$oProperty = $class->getProperty($sProperty);
-		$oProperty->setAccessible(true);
-
-		return $oProperty->getValue();
+		$oProperty = $this->GetProperty($sClass, $sProperty);
+		$oProperty->setValue($value);
 	}
 }


### PR DESCRIPTION
**Issue:**
iTop UI can explode anywhore because of unprotected Dict::Format API. it depends on language used and dictionaries label to display...

in details such a case can occur at any time translation is not safe to vsprint PHP API. for example if there are not enough placeholders provided in dictionary:

**Example**: labelkey = "this label breaks UI without current fix: %1$"

**Fix**
in this PR a try/catch has been added to avoid any UI white page (worst UX effect ever). in that case an error log is printed as well to identify which label/language has to be fixed. in UI the label key will be displayed.

we also added a testcase to identify all broken dictionaries to fix them as soon as possible...