### PR TITLE
N°5472 Notification Action objects : add a last executions tab

### DIFF
--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -177,6 +177,14 @@ abstract class Action extends cmdbAbstractObject
 	{
 		parent::DisplayBareRelations($oPage, false);
 
+		$this->GenerateLastExecutionsTab($oPage, $bEditMode);
+	}
+
+	/**
+	 * @since 3.2.0 N°5472 method creation
+	 */
+	protected function GenerateLastExecutionsTab(WebPage $oPage, $bEditMode)
+	{
 		if ($bEditMode) {
 			return;
 		}
@@ -184,12 +192,22 @@ abstract class Action extends cmdbAbstractObject
 		$oPage->SetCurrentTab('action_errors', Dict::S('Action:last_executions_tab'), Dict::S('Action:last_executions_tab+'));
 
 		$oFilter = DBObjectSearch::FromOQL(
-			"SELECT EventNotification WHERE action_id = :action_id AND date > DATE_SUB(NOW(), INTERVAL 2 MONTH)",
+			$this->GetLasExecutionsTabQuery(),
 			['action_id' => $this->GetKey()]
 		);
 		$oSet = new DBObjectSet($oFilter, ['date' => false]);
 		$oExecutionsListBlock = DataTableUIBlockFactory::MakeForResult($oPage, 'action_executions_list', $oSet);
 		$oPage->AddUiBlock($oExecutionsListBlock);
+	}
+
+	/**
+	 * @since 3.2.0 N°5472 method creation
+	 */
+	protected function GetLasExecutionsTabQuery(): string
+	{
+		return <<<OQL
+SELECT EventNotification WHERE action_id = :action_id AND date > DATE_SUB(NOW(), INTERVAL 2 MONTH)
+OQL;
 	}
 }
 

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -187,10 +187,6 @@ abstract class Action extends cmdbAbstractObject
 	 */
 	protected function GenerateLastExecutionsTab(iTopWebPage $oPage, $bEditMode)
 	{
-		if ($bEditMode) {
-			return;
-		}
-
 		$sActionLastExecutionsPageUrl = utils::GetAbsoluteUrlAppRoot()
 			. 'pages/ajax.render.php'
 			. '?operation=notification.action.last_execution_content'

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -180,7 +180,7 @@ abstract class Action extends cmdbAbstractObject
 			return;
 		}
 
-		$oPage->SetCurrentTab('action_errors', Dict::S('Action:activity_tab'), Dict::S('Action:activity_tab+'));
+		$oPage->SetCurrentTab('action_errors', Dict::S('Action:last_executions_tab'), Dict::S('Action:last_executions_tab+'));
 
 		$oFilter = DBObjectSearch::FromOQL(
 			"SELECT EventNotification WHERE action_id = :action_id AND date > DATE_SUB(NOW(), INTERVAL 2 MONTH)",

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -204,7 +204,7 @@ abstract class Action extends cmdbAbstractObject
 		$iLastExecutionDays = $oConfig->Get($sLastExecutionDaysConfigParamName);
 
 		if ($iLastExecutionDays <= 0) {
-			throw new InvalidConfigParamException("Invalid value in the {$sLastExecutionDaysConfigParamName} config parameter");
+			throw new InvalidConfigParamException("Invalid value for {$sLastExecutionDaysConfigParamName} config parameter. Param desc: " . $oConfig->GetDescription($sLastExecutionDaysConfigParamName));
 		}
 
 		$oFilter = DBObjectSearch::FromOQL(

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -45,16 +45,16 @@ abstract class Action extends cmdbAbstractObject
 	{
 		$aParams = array
 		(
-			"category" => "grant_by_profile,core/cmdb",
-			"key_type" => "autoincrement",
-			"name_attcode" => "name",
+			"category"                   => "grant_by_profile,core/cmdb",
+			"key_type"                   => "autoincrement",
+			"name_attcode"               => "name",
 			"complementary_name_attcode" => array('finalclass', 'description'),
-			"state_attcode" => "status",
-			"reconc_keys" => array('name'),
-			"db_table" => "priv_action",
-			"db_key_field" => "id",
-			"db_finalclass_field" => "realclass",
-			"style" => new ormStyle("ibo-dm-class--Action", "ibo-dm-class-alt--Action", "var(--ibo-dm-class--Action--main-color)", "var(--ibo-dm-class--Action--complementary-color)", null, '../images/icons/icons8-in-transit.svg'),
+			"state_attcode"              => "status",
+			"reconc_keys"                => array('name'),
+			"db_table"                   => "priv_action",
+			"db_key_field"               => "id",
+			"db_finalclass_field"        => "realclass",
+			"style"                      => new ormStyle("ibo-dm-class--Action", "ibo-dm-class-alt--Action", "var(--ibo-dm-class--Action--main-color)", "var(--ibo-dm-class--Action--complementary-color)", null, '../images/icons/icons8-in-transit.svg'),
 		);
 		MetaModel::Init_Params($aParams);
 		//MetaModel::Init_InheritAttributes();
@@ -62,17 +62,17 @@ abstract class Action extends cmdbAbstractObject
 		MetaModel::Init_AddAttribute(new AttributeString("description", array("allowed_values" => null, "sql" => "description", "default_value" => null, "is_null_allowed" => true, "depends_on" => array())));
 
 		MetaModel::Init_AddAttribute(new AttributeEnum("status", array(
-			"allowed_values" => new ValueSetEnum(array('test' => 'Being tested', 'enabled' => 'In production', 'disabled' => 'Inactive')),
-			"styled_values" => [
-				'test' => new ormStyle('ibo-dm-enum--Action-status-test', 'ibo-dm-enum-alt--Action-status-test', 'var(--ibo-dm-enum--Action-status-test--main-color)', 'var(--ibo-dm-enum--Action-status-test--complementary-color)', null, null),
-				'enabled' => new ormStyle('ibo-dm-enum--Action-status-enabled', 'ibo-dm-enum-alt--Action-status-enabled', 'var(--ibo-dm-enum--Action-status-enabled--main-color)', 'var(--ibo-dm-enum--Action-status-enabled--complementary-color)', 'fas fa-check', null),
+			"allowed_values"  => new ValueSetEnum(array('test' => 'Being tested', 'enabled' => 'In production', 'disabled' => 'Inactive')),
+			"styled_values"   => [
+				'test'     => new ormStyle('ibo-dm-enum--Action-status-test', 'ibo-dm-enum-alt--Action-status-test', 'var(--ibo-dm-enum--Action-status-test--main-color)', 'var(--ibo-dm-enum--Action-status-test--complementary-color)', null, null),
+				'enabled'  => new ormStyle('ibo-dm-enum--Action-status-enabled', 'ibo-dm-enum-alt--Action-status-enabled', 'var(--ibo-dm-enum--Action-status-enabled--main-color)', 'var(--ibo-dm-enum--Action-status-enabled--complementary-color)', 'fas fa-check', null),
 				'disabled' => new ormStyle('ibo-dm-enum--Action-status-disabled', 'ibo-dm-enum-alt--Action-status-disabled', 'var(--ibo-dm-enum--Action-status-disabled--main-color)', 'var(--ibo-dm-enum--Action-status-disabled--complementary-color)', null, null),
 			],
-			"display_style" => 'list',
-			"sql" => "status",
-			"default_value" => "test",
+			"display_style"   => 'list',
+			"sql"             => "status",
+			"default_value"   => "test",
 			"is_null_allowed" => false,
-			"depends_on" => array(),
+			"depends_on"      => array(),
 		)));
 
 		MetaModel::Init_AddAttribute(new AttributeLinkedSetIndirect("trigger_list",
@@ -106,7 +106,8 @@ abstract class Action extends cmdbAbstractObject
 	 */
 	public function IsActive()
 	{
-		switch ($this->Get('status')) {
+		switch($this->Get('status'))
+		{
 			case 'enabled':
 			case 'test':
 				return true;
@@ -125,7 +126,8 @@ abstract class Action extends cmdbAbstractObject
 	 */
 	public function IsBeingTested()
 	{
-		switch ($this->Get('status')) {
+		switch($this->Get('status'))
+		{
 			case 'test':
 				return true;
 

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -17,6 +17,7 @@
 //   along with iTop. If not, see <http://www.gnu.org/licenses/>
 
 use Combodo\iTop\Application\TwigBase\Twig\TwigHelper;
+use Combodo\iTop\Application\UI\Base\Component\DataTable\DataTableUIBlockFactory;
 use Combodo\iTop\Application\WebPage\WebPage;
 
 /**
@@ -186,9 +187,9 @@ abstract class Action extends cmdbAbstractObject
 			"SELECT EventNotification WHERE action_id = :action_id AND date > DATE_SUB(NOW(), INTERVAL 2 MONTH)",
 			['action_id' => $this->GetKey()]
 		);
-
-		$oBlock = new DisplayBlock($oFilter, 'list', false);
-		$oBlock->Display($oPage, 'eventnotification_list');
+		$oSet = new DBObjectSet($oFilter, ['date' => false]);
+		$oExecutionsListBlock = DataTableUIBlockFactory::MakeForResult($oPage, 'action_executions_list', $oSet);
+		$oPage->AddUiBlock($oExecutionsListBlock);
 	}
 }
 

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -204,7 +204,7 @@ abstract class Action extends cmdbAbstractObject
 		$sLastExecutionDaysConfigParamName = 'notifications.last_executions_days';
 		$iLastExecutionDays = $oConfig->Get($sLastExecutionDaysConfigParamName);
 
-		if (false === is_int($iLastExecutionDays)) {
+		if ($iLastExecutionDays <= 0) {
 			throw new InvalidConfigParamException("Invalid value in the {$sLastExecutionDaysConfigParamName} config parameter");
 		}
 

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -167,6 +167,9 @@ abstract class Action extends cmdbAbstractObject
 		}
 	}
 
+	/**
+	 * @since 3.2.0 N°5472 method creation
+	 */
 	public function DisplayBareRelations(WebPage $oPage, $bEditMode = false)
 	{
 		parent::DisplayBareRelations($oPage, false);
@@ -175,8 +178,16 @@ abstract class Action extends cmdbAbstractObject
 			return;
 		}
 
-		$oPage->SetCurrentTab('action_errors', Dict::S('Action:errors_tab'), Dict::S('Action:errors_tab+'));
+		$oPage->SetCurrentTab('action_errors', Dict::S('Action:activity_tab'), Dict::S('Action:activity_tab+'));
 		$oPage->Add('Hello world');
+
+		$oFilter = DBObjectSearch::FromOQL(
+			"SELECT EventNotification WHERE action_id = :action_id AND date > DATE_SUB(NOW(), INTERVAL 2 MONTH)",
+			['action_id' => $this->GetKey()]
+		);
+
+		$oBlock = new DisplayBlock($oFilter, 'list', false);
+		$oBlock->Display($oPage, 'eventnotification_list');
 	}
 }
 

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -189,7 +189,7 @@ abstract class Action extends cmdbAbstractObject
 	protected function GenerateLastExecutionsTab(iTopWebPage $oPage, $bEditMode)
 	{
 		$oRouter = Router::GetInstance();
-		$sActionLastExecutionsPageUrl = $oRouter->GenerateUrl('notifications.action.last_executions_tab', ['actionid' => $this->GetKey()]);
+		$sActionLastExecutionsPageUrl = $oRouter->GenerateUrl('notifications.action.last_executions_tab', ['action_id' => $this->GetKey()]);
 		$oPage->AddAjaxTab('action_errors', $sActionLastExecutionsPageUrl, false, Dict::S('Action:last_executions_tab'));
 	}
 

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -19,6 +19,7 @@
 use Combodo\iTop\Application\TwigBase\Twig\TwigHelper;
 use Combodo\iTop\Application\UI\Base\Component\DataTable\DataTableUIBlockFactory;
 use Combodo\iTop\Application\WebPage\WebPage;
+use Combodo\iTop\Service\Router\Router;
 
 /**
  * Persistent classes (internal): user defined actions
@@ -187,10 +188,8 @@ abstract class Action extends cmdbAbstractObject
 	 */
 	protected function GenerateLastExecutionsTab(iTopWebPage $oPage, $bEditMode)
 	{
-		$sActionLastExecutionsPageUrl = utils::GetAbsoluteUrlAppRoot()
-			. 'pages/ajax.render.php'
-			. '?operation=notification.action.last_execution_content'
-			. '&actionid=' . $this->GetKey();
+		$oRouter = Router::GetInstance();
+		$sActionLastExecutionsPageUrl = $oRouter->GenerateUrl('notifications.action.last_executions_tab', ['actionid' => $this->GetKey()]);
 		$oPage->AddAjaxTab('action_errors', $sActionLastExecutionsPageUrl, false, Dict::S('Action:last_executions_tab'));
 	}
 

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -179,7 +179,6 @@ abstract class Action extends cmdbAbstractObject
 		}
 
 		$oPage->SetCurrentTab('action_errors', Dict::S('Action:activity_tab'), Dict::S('Action:activity_tab+'));
-		$oPage->Add('Hello world');
 
 		$oFilter = DBObjectSearch::FromOQL(
 			"SELECT EventNotification WHERE action_id = :action_id AND date > DATE_SUB(NOW(), INTERVAL 2 MONTH)",

--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -45,16 +45,16 @@ abstract class Action extends cmdbAbstractObject
 	{
 		$aParams = array
 		(
-			"category"                   => "grant_by_profile,core/cmdb",
-			"key_type"                   => "autoincrement",
-			"name_attcode"               => "name",
+			"category" => "grant_by_profile,core/cmdb",
+			"key_type" => "autoincrement",
+			"name_attcode" => "name",
 			"complementary_name_attcode" => array('finalclass', 'description'),
-			"state_attcode"              => "status",
-			"reconc_keys"                => array('name'),
-			"db_table"                   => "priv_action",
-			"db_key_field"               => "id",
-			"db_finalclass_field"        => "realclass",
-			"style"                      => new ormStyle("ibo-dm-class--Action", "ibo-dm-class-alt--Action", "var(--ibo-dm-class--Action--main-color)", "var(--ibo-dm-class--Action--complementary-color)", null, '../images/icons/icons8-in-transit.svg'),
+			"state_attcode" => "status",
+			"reconc_keys" => array('name'),
+			"db_table" => "priv_action",
+			"db_key_field" => "id",
+			"db_finalclass_field" => "realclass",
+			"style" => new ormStyle("ibo-dm-class--Action", "ibo-dm-class-alt--Action", "var(--ibo-dm-class--Action--main-color)", "var(--ibo-dm-class--Action--complementary-color)", null, '../images/icons/icons8-in-transit.svg'),
 		);
 		MetaModel::Init_Params($aParams);
 		//MetaModel::Init_InheritAttributes();
@@ -62,17 +62,17 @@ abstract class Action extends cmdbAbstractObject
 		MetaModel::Init_AddAttribute(new AttributeString("description", array("allowed_values" => null, "sql" => "description", "default_value" => null, "is_null_allowed" => true, "depends_on" => array())));
 
 		MetaModel::Init_AddAttribute(new AttributeEnum("status", array(
-			"allowed_values"  => new ValueSetEnum(array('test' => 'Being tested', 'enabled' => 'In production', 'disabled' => 'Inactive')),
-			"styled_values"   => [
-				'test'     => new ormStyle('ibo-dm-enum--Action-status-test', 'ibo-dm-enum-alt--Action-status-test', 'var(--ibo-dm-enum--Action-status-test--main-color)', 'var(--ibo-dm-enum--Action-status-test--complementary-color)', null, null),
-				'enabled'  => new ormStyle('ibo-dm-enum--Action-status-enabled', 'ibo-dm-enum-alt--Action-status-enabled', 'var(--ibo-dm-enum--Action-status-enabled--main-color)', 'var(--ibo-dm-enum--Action-status-enabled--complementary-color)', 'fas fa-check', null),
+			"allowed_values" => new ValueSetEnum(array('test' => 'Being tested', 'enabled' => 'In production', 'disabled' => 'Inactive')),
+			"styled_values" => [
+				'test' => new ormStyle('ibo-dm-enum--Action-status-test', 'ibo-dm-enum-alt--Action-status-test', 'var(--ibo-dm-enum--Action-status-test--main-color)', 'var(--ibo-dm-enum--Action-status-test--complementary-color)', null, null),
+				'enabled' => new ormStyle('ibo-dm-enum--Action-status-enabled', 'ibo-dm-enum-alt--Action-status-enabled', 'var(--ibo-dm-enum--Action-status-enabled--main-color)', 'var(--ibo-dm-enum--Action-status-enabled--complementary-color)', 'fas fa-check', null),
 				'disabled' => new ormStyle('ibo-dm-enum--Action-status-disabled', 'ibo-dm-enum-alt--Action-status-disabled', 'var(--ibo-dm-enum--Action-status-disabled--main-color)', 'var(--ibo-dm-enum--Action-status-disabled--complementary-color)', null, null),
 			],
-			"display_style"   => 'list',
-			"sql"             => "status",
-			"default_value"   => "test",
+			"display_style" => 'list',
+			"sql" => "status",
+			"default_value" => "test",
 			"is_null_allowed" => false,
-			"depends_on"      => array(),
+			"depends_on" => array(),
 		)));
 
 		MetaModel::Init_AddAttribute(new AttributeLinkedSetIndirect("trigger_list",
@@ -106,8 +106,7 @@ abstract class Action extends cmdbAbstractObject
 	 */
 	public function IsActive()
 	{
-		switch($this->Get('status'))
-		{
+		switch ($this->Get('status')) {
 			case 'enabled':
 			case 'test':
 				return true;
@@ -126,8 +125,7 @@ abstract class Action extends cmdbAbstractObject
 	 */
 	public function IsBeingTested()
 	{
-		switch($this->Get('status'))
-		{
+		switch ($this->Get('status')) {
 			case 'test':
 				return true;
 
@@ -167,6 +165,18 @@ abstract class Action extends cmdbAbstractObject
 		if ($oTriggersSet->Count() === 0) {
 			$this->m_aCheckWarnings[] = Dict::S('Action:WarningNoTriggerLinked');
 		}
+	}
+
+	public function DisplayBareRelations(WebPage $oPage, $bEditMode = false)
+	{
+		parent::DisplayBareRelations($oPage, false);
+
+		if ($bEditMode) {
+			return;
+		}
+
+		$oPage->SetCurrentTab('action_errors', Dict::S('Action:errors_tab'), Dict::S('Action:errors_tab+'));
+		$oPage->Add('Hello world');
 	}
 }
 

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1622,7 +1622,7 @@ class Config
 		'notifications.last_executions_days' => [
 			'type' => 'integer',
 			'description' => 'Number of days to display in the Action\'s last executions tab',
-			'default' => 61,
+			'default' => 30 + 31, // 2 months
 			'value' => 61,
 			'source_of_value' => '',
 			'show_in_conf_sample' => false,

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1621,7 +1621,7 @@ class Config
 		],
 		'notifications.last_executions_days' => [
 			'type' => 'integer',
-			'description' => 'Number of days to display in the Action\'s last executions tab',
+			'description' => 'Number of days to display in the Action\'s last executions tab (0 means no limit)',
 			'default' => 30 + 31, // 2 months
 			'value' => 61,
 			'source_of_value' => '',

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1619,6 +1619,14 @@ class Config
 			'source_of_value' => '',
 			'show_in_conf_sample' => false,
 		],
+		'notifications.last_executions_days' => [
+			'type' => 'integer',
+			'description' => 'Number of days to display in the Action\'s last executions tab',
+			'default' => 61,
+			'value' => 61,
+			'source_of_value' => '',
+			'show_in_conf_sample' => false,
+		],
 		'regenerate_session_id_enabled' => [
 			'type' => 'bool',
 			'description' => 'If true then session id will be regenerated on each login, to prevent session fixation.',

--- a/dictionaries/en.dictionary.itop.core.php
+++ b/dictionaries/en.dictionary.itop.core.php
@@ -539,8 +539,8 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Class:Action/Attribute:finalclass' => 'Action sub-class',
 	'Class:Action/Attribute:finalclass+' => 'Name of the final class',
 	'Action:WarningNoTriggerLinked' => 'Warning, no trigger is linked to the action. It will not be active until it has at least 1.',
-	'Action:activity_tab' => 'Last executions',
-	'Action:activity_tab+' => 'Executions of this action in the past 2 months',
+	'Action:last_executions_tab' => 'Last executions',
+	'Action:last_executions_tab+' => 'Executions of this action in the past 2 months',
 ));
 
 //

--- a/dictionaries/en.dictionary.itop.core.php
+++ b/dictionaries/en.dictionary.itop.core.php
@@ -540,7 +540,7 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Class:Action/Attribute:finalclass+' => 'Name of the final class',
 	'Action:WarningNoTriggerLinked' => 'Warning, no trigger is linked to the action. It will not be active until it has at least 1.',
 	'Action:last_executions_tab' => 'Last executions',
-	'Action:last_executions_tab+' => 'Executions of this action in the past 2 months',
+	'Action:last_executions_tab_panel_title' => 'Executions of this action in the past %1$s days',
 ));
 
 //

--- a/dictionaries/en.dictionary.itop.core.php
+++ b/dictionaries/en.dictionary.itop.core.php
@@ -540,7 +540,9 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Class:Action/Attribute:finalclass+' => 'Name of the final class',
 	'Action:WarningNoTriggerLinked' => 'Warning, no trigger is linked to the action. It will not be active until it has at least 1.',
 	'Action:last_executions_tab' => 'Last executions',
-	'Action:last_executions_tab_panel_title' => 'Executions of this action in the past %1$s days',
+	'Action:last_executions_tab_panel_title' => 'Executions of this action (%1$s)',
+	'Action:last_executions_tab_limit_days' => 'past %1$s days',
+	'Action:last_executions_tab_limit_none' => 'no limit',
 ));
 
 //

--- a/dictionaries/en.dictionary.itop.core.php
+++ b/dictionaries/en.dictionary.itop.core.php
@@ -539,6 +539,8 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Class:Action/Attribute:finalclass' => 'Action sub-class',
 	'Class:Action/Attribute:finalclass+' => 'Name of the final class',
 	'Action:WarningNoTriggerLinked' => 'Warning, no trigger is linked to the action. It will not be active until it has at least 1.',
+	'Action:errors_tab' => 'Last errors',
+	'Action:errors_tab+' => 'Action errors since 2 months',
 ));
 
 //

--- a/dictionaries/en.dictionary.itop.core.php
+++ b/dictionaries/en.dictionary.itop.core.php
@@ -539,8 +539,8 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Class:Action/Attribute:finalclass' => 'Action sub-class',
 	'Class:Action/Attribute:finalclass+' => 'Name of the final class',
 	'Action:WarningNoTriggerLinked' => 'Warning, no trigger is linked to the action. It will not be active until it has at least 1.',
-	'Action:errors_tab' => 'Last errors',
-	'Action:errors_tab+' => 'Action errors since 2 months',
+	'Action:activity_tab' => 'Last executions',
+	'Action:activity_tab+' => 'Executions of this action in the past 2 months',
 ));
 
 //

--- a/lib/composer/autoload_classmap.php
+++ b/lib/composer/autoload_classmap.php
@@ -394,6 +394,7 @@ return array(
     'Combodo\\iTop\\Controller\\Base\\Layout\\ObjectController' => $baseDir . '/sources/Controller/Base/Layout/ObjectController.php',
     'Combodo\\iTop\\Controller\\Links\\LinkSetController' => $baseDir . '/sources/Controller/Links/LinkSetController.php',
     'Combodo\\iTop\\Controller\\Newsroom\\iTopNewsroomController' => $baseDir . '/sources/Controller/Newsroom/iTopNewsroomController.php',
+    'Combodo\\iTop\\Controller\\Notifications\\ActionController' => $baseDir . '/sources/Controller/Notifications/ActionController.php',
     'Combodo\\iTop\\Controller\\OAuth\\OAuthLandingController' => $baseDir . '/sources/Controller/OAuth/OAuthLandingController.php',
     'Combodo\\iTop\\Controller\\PreferencesController' => $baseDir . '/sources/Controller/PreferencesController.php',
     'Combodo\\iTop\\Controller\\TemporaryObjects\\TemporaryObjectController' => $baseDir . '/sources/Controller/TemporaryObjects/TemporaryObjectController.php',

--- a/lib/composer/autoload_static.php
+++ b/lib/composer/autoload_static.php
@@ -769,6 +769,7 @@ class ComposerStaticInit7f81b4a2a468a061c306af5e447a9a9f
         'Combodo\\iTop\\Controller\\Base\\Layout\\ObjectController' => __DIR__ . '/../..' . '/sources/Controller/Base/Layout/ObjectController.php',
         'Combodo\\iTop\\Controller\\Links\\LinkSetController' => __DIR__ . '/../..' . '/sources/Controller/Links/LinkSetController.php',
         'Combodo\\iTop\\Controller\\Newsroom\\iTopNewsroomController' => __DIR__ . '/../..' . '/sources/Controller/Newsroom/iTopNewsroomController.php',
+        'Combodo\\iTop\\Controller\\Notifications\\ActionController' => __DIR__ . '/../..' . '/sources/Controller/Notifications/ActionController.php',
         'Combodo\\iTop\\Controller\\OAuth\\OAuthLandingController' => __DIR__ . '/../..' . '/sources/Controller/OAuth/OAuthLandingController.php',
         'Combodo\\iTop\\Controller\\PreferencesController' => __DIR__ . '/../..' . '/sources/Controller/PreferencesController.php',
         'Combodo\\iTop\\Controller\\TemporaryObjects\\TemporaryObjectController' => __DIR__ . '/../..' . '/sources/Controller/TemporaryObjects/TemporaryObjectController.php',

--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -2569,6 +2569,23 @@ EOF
 				$oPage = $oController->OperationModify();
 				break;
 
+
+			case 'notification.action.last_execution_content':
+				$sActionId = utils::ReadParam('actionid', null, false);
+				$sCannotLoadActionErrorMessage = 'ajax.render route ' . $operation . ' invalid actionid parameter';
+				if (is_null($sActionId)) {
+					throw new CoreUnexpectedValue($sCannotLoadActionErrorMessage);
+				}
+
+				$oAction = MetaModel::GetObject(Action::class, $sActionId, false);
+				if (is_null($oAction)) {
+					throw new CoreException($sCannotLoadActionErrorMessage);
+				}
+
+				$oPage = new NiceWebPage(Dict::S('UI:BrowseInlineImages'));
+				$oAction->GetLastExecutionsTabContent($oPage);
+				break;
+
 			default:
 				$oPage->p("Invalid query.");
 		}

--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -2569,23 +2569,6 @@ EOF
 				$oPage = $oController->OperationModify();
 				break;
 
-
-			case 'notification.action.last_execution_content':
-				$sActionId = utils::ReadParam('actionid', null, false);
-				$sCannotLoadActionErrorMessage = 'ajax.render route ' . $operation . ' invalid actionid parameter';
-				if (is_null($sActionId)) {
-					throw new CoreUnexpectedValue($sCannotLoadActionErrorMessage);
-				}
-
-				$oAction = MetaModel::GetObject(Action::class, $sActionId, false);
-				if (is_null($oAction)) {
-					throw new CoreException($sCannotLoadActionErrorMessage);
-				}
-
-				$oPage = new NiceWebPage(Dict::S('UI:BrowseInlineImages'));
-				$oAction->GetLastExecutionsTabContent($oPage);
-				break;
-
 			default:
 				$oPage->p("Invalid query.");
 		}

--- a/sources/Controller/Notifications/ActionController.php
+++ b/sources/Controller/Notifications/ActionController.php
@@ -7,7 +7,7 @@
 namespace Combodo\iTop\Controller\Notifications;
 
 use Action;
-use Combodo\iTop\Application\WebPage\NiceWebPage;
+use Combodo\iTop\Application\WebPage\AjaxPage;
 use Combodo\iTop\Controller\AbstractController;
 use CoreException;
 use CoreUnexpectedValue;
@@ -40,7 +40,7 @@ class ActionController extends AbstractController {
 			throw new CoreException($sCannotLoadActionErrorMessage);
 		}
 
-		$oPage = new NiceWebPage(Dict::S('UI:BrowseInlineImages'));
+		$oPage = new AjaxPage(Dict::S('Action:last_executions_tab'));
 		$oAction->GetLastExecutionsTabContent($oPage);
 
 		return $oPage;

--- a/sources/Controller/Notifications/ActionController.php
+++ b/sources/Controller/Notifications/ActionController.php
@@ -29,9 +29,9 @@ class ActionController extends AbstractController {
 	 */
 	public function OperationLastExecutionsTab()
 	{
-		$sActionId = utils::ReadParam('actionid', null, false);
-		$sCannotLoadActionErrorMessage = __METHOD__ . ': invalid actionid parameter';
-		if (is_null($sActionId)) {
+		$sActionId = utils::ReadParam('action_id', null, false);
+		$sCannotLoadActionErrorMessage = __METHOD__ . ': invalid action_id parameter';
+		if (utils::IsNullOrEmptyString($sActionId)) {
 			throw new CoreUnexpectedValue($sCannotLoadActionErrorMessage);
 		}
 

--- a/sources/Controller/Notifications/ActionController.php
+++ b/sources/Controller/Notifications/ActionController.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * @copyright   Copyright (C) 2010-2024 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\Controller\Notifications;
+
+use Action;
+use Combodo\iTop\Application\WebPage\NiceWebPage;
+use Combodo\iTop\Controller\AbstractController;
+use CoreException;
+use CoreUnexpectedValue;
+use Dict;
+use MetaModel;
+use utils;
+
+/**
+ * @internal
+ * @since 3.2.0 N°5472 creation
+ */
+class ActionController extends AbstractController {
+	public const ROUTE_NAMESPACE = 'notifications.action';
+
+	/**
+	 * @throws CoreException if cannot load the Action object
+	 * @throws CoreUnexpectedValue if `actionid` parameter is invalid
+	 * @since 3.2.0 N°5472 creation
+	 */
+	public function OperationLastExecutionsTab()
+	{
+		$sActionId = utils::ReadParam('actionid', null, false);
+		$sCannotLoadActionErrorMessage = __METHOD__ . ': invalid actionid parameter';
+		if (is_null($sActionId)) {
+			throw new CoreUnexpectedValue($sCannotLoadActionErrorMessage);
+		}
+
+		$oAction = MetaModel::GetObject(Action::class, $sActionId, false);
+		if (is_null($oAction)) {
+			throw new CoreException($sCannotLoadActionErrorMessage);
+		}
+
+		$oPage = new NiceWebPage(Dict::S('UI:BrowseInlineImages'));
+		$oAction->GetLastExecutionsTabContent($oPage);
+
+		return $oPage;
+	}
+}


### PR DESCRIPTION
🧐 For now we have a "Notifications" (`UI:NotificationsTab` dict key) tab on each object that is used in triggers.
This is done in `\cmdbAbstractObject::DisplayBareRelations` by querying on `EventNotification` classes.

🤔 This is great for end users, to see which notifications were fired on their `UserRequest` for example.
But it would be nice to have the counterpart in `Action` objects for admin users !



✨ This PR adds a new "Last executions" (`Action:last_executions_tab` and `Action:last_executions_tab+` dict keys) ajax tab in `Action` objects.
This will display all the `EventNotification` saved for the current action in the past days (the limit is set in the `notifications.last_executions_days` config parameter, default is 61 days).

Having an ajax tab (not loaded by default) and being able to change the limit in the config are precaution for perf issues.
Note the list can still be be opened in a new window and filtered as wanted thanks to #222. 

![image](https://github.com/Combodo/iTop/assets/8947448/8b1c6693-0ad7-4f3f-81b1-ee7143056777)



⚙ Those `EventNotification` instances are created in each `Action::DoExecute` impl. On existing email sending actions impl we have : 
* ActionEmail::DoExecution : `new EventNotificationEmail()`
  - ActionEmailApprovalRequest : parent call
  - ActionEmailUnauthenticatedForm : parent call
* _ActionWebhook::DoExecute : `new EventWebhook();`

The created classes (`EventNotificationEmail`, `EventWebhook`) are children of `EventNotification`.
For now there are no attribute in this class, parent nor children, to tell whereas we have a success, warning or error :/

-----

🚧 TODO
- [x] replace DisplayBlock by `DataTableUIBlockFactory::MakeForResult`
- [x] ensure every notification events (success, errors, warnings) are traced as EventNotification objects => 24/11 description updated
- [x] replace the DisplayBareRelation by a dasboard attribute (asynchronous by default, customizable) => 24/11 `Action` class is defined in PHP, so having a DisplayBareRelation override would be clearer than a new attribute defined in the Init method I think ?
- [x] use an AjaxTab so that we won't have data load every time we open an Action
- [x] use iTop generic router for the endpoint (see ObjectController)
- [x] in the query, use a config parameter to set number of days (replace 2 months hardcoded value)
- [x] tech review
- [x] functional review
- [x] create bug
- [x] merge
- [x] document (config param, what's new)