### PR TITLE
N°7137 - DataSynchro: Remove "Organization" as default value for SynchroReplica->dest_class

### DIFF
--- a/synchro/synchrodatasource.class.inc.php
+++ b/synchro/synchrodatasource.class.inc.php
@@ -2077,7 +2077,6 @@ class SynchroReplica extends DBObject implements iDisplay
 			'class_category' => '',
 			'more_values' => '',
 			'sql' => 'dest_class',
-			'default_value' => 'Organization',
 			'is_null_allowed' => true,
 			'depends_on' => array(),
 		)));


### PR DESCRIPTION
It appears to be existing since commit f3f2eb5c797ec40d331798e134b3cd73b5bfd4ea and I never found this a logical value..
https://github.com/Combodo/iTop/blame/f3f2eb5c797ec40d331798e134b3cd73b5bfd4ea/synchro/synchrodatasource.class.inc.php#L1006