### PR TITLE
N°5775 - Allow configuration of OAuth client on MS Azure with single tenant

### DIFF
--- a/datamodels/2.x/itop-oauth-client/datamodel.itop-oauth-client.xml
+++ b/datamodels/2.x/itop-oauth-client/datamodel.itop-oauth-client.xml
@@ -339,6 +339,11 @@
           <default_value>no</default_value>
           <is_null_allowed>true</is_null_allowed>
         </field>
+        <field id="tenant" xsi:type="AttributeString">
+          <sql>tenant</sql>
+          <default_value>common</default_value>
+          <is_null_allowed>true</is_null_allowed>
+        </field>
       </fields>
       <presentation>
         <details>
@@ -364,14 +369,17 @@
                     <item id="redirect_url">
                       <rank>50</rank>
                     </item>
-                    <item id="client_id">
+                    <item id="tenant">
                       <rank>60</rank>
                     </item>
-                    <item id="client_secret">
+                    <item id="client_id">
                       <rank>70</rank>
                     </item>
-                    <item id="mailbox_list">
+                    <item id="client_secret">
                       <rank>80</rank>
+                    </item>
+                    <item id="mailbox_list">
+                      <rank>90</rank>
                     </item>
                   </items>
                 </item>

--- a/datamodels/2.x/itop-oauth-client/datamodel.itop-oauth-client.xml
+++ b/datamodels/2.x/itop-oauth-client/datamodel.itop-oauth-client.xml
@@ -342,7 +342,7 @@
         <field id="tenant" xsi:type="AttributeString">
           <sql>tenant</sql>
           <default_value>common</default_value>
-          <is_null_allowed>true</is_null_allowed>
+          <is_null_allowed>false</is_null_allowed>
         </field>
       </fields>
       <presentation>

--- a/datamodels/2.x/itop-oauth-client/en.dict.itop-oauth-client.php
+++ b/datamodels/2.x/itop-oauth-client/en.dict.itop-oauth-client.php
@@ -93,6 +93,7 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Class:OAuthClientAzure/Attribute:used_for_smtp+' => 'At least one OAuth client must have this flag to “Yes”, if you want iTop to use it for sending mails',
 	'Class:OAuthClientAzure/Attribute:used_for_smtp/Value:yes' => 'Yes',
 	'Class:OAuthClientAzure/Attribute:used_for_smtp/Value:no' => 'No',
+    'Class:OAuthClientAzure/Attribute:tenant' => 'Tenant',
 ));
 
 //

--- a/datamodels/2.x/itop-oauth-client/en.dict.itop-oauth-client.php
+++ b/datamodels/2.x/itop-oauth-client/en.dict.itop-oauth-client.php
@@ -94,6 +94,7 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Class:OAuthClientAzure/Attribute:used_for_smtp/Value:yes' => 'Yes',
 	'Class:OAuthClientAzure/Attribute:used_for_smtp/Value:no' => 'No',
     'Class:OAuthClientAzure/Attribute:tenant' => 'Tenant',
+    'Class:OAuthClientAzure/Attribute:tenant+' => 'Tenant ID of the configured application. For multi-tenant application, use common.',
 ));
 
 //

--- a/sources/Core/Authentication/Client/OAuth/OAuthClientProviderAzure.php
+++ b/sources/Core/Authentication/Client/OAuth/OAuthClientProviderAzure.php
@@ -20,6 +20,7 @@ class OAuthClientProviderAzure extends OAuthClientProviderAbstract
 			'clientId'               => $oOAuthClient->Get('client_id'),
 			'clientSecret'           => $oOAuthClient->Get('client_secret'),
 			'redirectUri'            => $oOAuthClient->Get('redirect_url'),
+            'tenant'                 => empty($oOAuthClient->Get('tenant')) ? 'common' : $oOAuthClient->Get('tenant'),
 		];
 
 		$this->oVendorProvider = new Azure($aOptions, $collaborators);

--- a/sources/Core/Authentication/Client/OAuth/OAuthClientProviderAzure.php
+++ b/sources/Core/Authentication/Client/OAuth/OAuthClientProviderAzure.php
@@ -20,7 +20,7 @@ class OAuthClientProviderAzure extends OAuthClientProviderAbstract
 			'clientId'               => $oOAuthClient->Get('client_id'),
 			'clientSecret'           => $oOAuthClient->Get('client_secret'),
 			'redirectUri'            => $oOAuthClient->Get('redirect_url'),
-            'tenant'                 => empty($oOAuthClient->Get('tenant')) ? 'common' : $oOAuthClient->Get('tenant'),
+            'tenant'                 => $oOAuthClient->Get('tenant'),
 		];
 
 		$this->oVendorProvider = new Azure($aOptions, $collaborators);


### PR DESCRIPTION
When using OAuth2 to authenticate to Microsoft Azure in order to access a mail account, currently only multi-tenant configurations are possible. This is often forbidden by company policy in large corporations.

I added a "tenant" field to the OAuth-Client, which defaults to "common", and pass it to the `OAuthClientProviderAzure`.