### PR TITLE
N°6648 - Use \utils::GetDataPath() instead of hard-coded paths

### DIFF
--- a/application/excelexporter.class.inc.php
+++ b/application/excelexporter.class.inc.php
@@ -299,7 +299,7 @@ class ExcelExporter
 	{
 		if ($this->sOutputFilePath == null)
 		{
-			return APPROOT.'data/bulk_export/'.$this->sToken.'.xlsx';
+			return utils::GetDataPath().'bulk_export/'.$this->sToken.'.xlsx';
 		}
 		else
 		{
@@ -309,14 +309,14 @@ class ExcelExporter
 	
 	public static function GetExcelFileFromToken($sToken)
 	{
-		return @file_get_contents(APPROOT.'data/bulk_export/'.$sToken.'.xlsx');
+		return @file_get_contents(utils::GetDataPath().'bulk_export/'.$sToken.'.xlsx');
 	}
 	
 	public static function CleanupFromToken($sToken)
 	{
-		@unlink(APPROOT.'data/bulk_export/'.$sToken.'.status');
-		@unlink(APPROOT.'data/bulk_export/'.$sToken.'.data');
-		@unlink(APPROOT.'data/bulk_export/'.$sToken.'.xlsx');
+		@unlink(utils::GetDataPath().'bulk_export/'.$sToken.'.status');
+		@unlink(utils::GetDataPath().'bulk_export/'.$sToken.'.data');
+		@unlink(utils::GetDataPath().'bulk_export/'.$sToken.'.xlsx');
 	}
 	
 	public function Cleanup()
@@ -330,7 +330,7 @@ class ExcelExporter
 	 */
 	public static function CleanupOldFiles()
 	{
-		$aFiles = glob(APPROOT.'data/bulk_export/*.*');
+		$aFiles = glob(utils::GetDataPath().'bulk_export/*.*');
 		$iDelay = MetaModel::GetConfig()->Get('xlsx_exporter_cleanup_old_files_delay');
 		
 		if($iDelay > 0)
@@ -412,14 +412,14 @@ class ExcelExporter
 	
 	protected function CheckDataDir()
 	{
-		if(!is_dir(APPROOT."data/bulk_export"))
+		if(!is_dir(utils::GetDataPath()."bulk_export"))
 		{
-			@mkdir(APPROOT."data/bulk_export", 0777, true /* recursive */);
+			@mkdir(utils::GetDataPath()."bulk_export", 0777, true /* recursive */);
 			clearstatcache();
 		}
-		if (!is_writable(APPROOT."data/bulk_export"))
+		if (!is_writable(utils::GetDataPath()."bulk_export"))
 		{
-			throw new Exception('Data directory "'.APPROOT.'data/bulk_export" could not be written.');
+			throw new Exception('Data directory "'.utils::GetDataPath().'bulk_export" could not be written.');
 		}
 	}
 	
@@ -429,12 +429,12 @@ class ExcelExporter
 		{
 			$sToken = $this->sToken;
 		}
-		return APPROOT."data/bulk_export/$sToken.status";
+		return utils::GetDataPath()."bulk_export/$sToken.status";
 	}
 	
 	protected function GetDataFile()
 	{
-		return APPROOT.'data/bulk_export/'.$this->sToken.'.data';
+		return utils::GetDataPath().'bulk_export/'.$this->sToken.'.data';
 	}
 	
 	protected function GetNewToken()

--- a/application/transaction.class.inc.php
+++ b/application/transaction.class.inc.php
@@ -228,7 +228,7 @@ class privUITransactionFile
 	 */
 	public static function GetNewTransactionId()
 	{
-		if (!is_dir(APPROOT.'data/transactions'))
+		if (!is_dir(utils::GetDataPath().'transactions'))
 		{
 			if (!is_writable(APPROOT.'data'))
 			{
@@ -236,22 +236,22 @@ class privUITransactionFile
 			}
 			// condition avoids race condition N°2345
 			// See https://github.com/kalessil/phpinspectionsea/blob/master/docs/probable-bugs.md#mkdir-race-condition
-			if (!mkdir($concurrentDirectory = APPROOT.'data/transactions') && !is_dir($concurrentDirectory))
+			if (!mkdir($concurrentDirectory = utils::GetDataPath().'transactions') && !is_dir($concurrentDirectory))
 			{
-				throw new Exception('Failed to create the directory "'.APPROOT.'data/transactions". Ajust the rights on the parent directory or let an administrator create the transactions directory and give the web sever enough rights to write into it.');
+				throw new Exception('Failed to create the directory "'.utils::GetDataPath().'transactions". Ajust the rights on the parent directory or let an administrator create the transactions directory and give the web sever enough rights to write into it.');
 			}
 		}
 
-		if (!is_writable(APPROOT.'data/transactions'))
+		if (!is_writable(utils::GetDataPath().'transactions'))
 		{
-			throw new Exception('The directory "'.APPROOT.'data/transactions" must be writable to the application.');
+			throw new Exception('The directory "'.utils::GetDataPath().'transactions" must be writable to the application.');
 		}
 
 		$iCurrentUserId = static::GetCurrentUserId();
 
 		self::CleanupOldTransactions();
 
-		$sTransactionIdFullPath = tempnam(APPROOT.'data/transactions', static::GetUserPrefix());
+		$sTransactionIdFullPath = tempnam(utils::GetDataPath().'transactions', static::GetUserPrefix());
 		file_put_contents($sTransactionIdFullPath, $iCurrentUserId, LOCK_EX);
 
 		$sTransactionIdFileName = basename($sTransactionIdFullPath);
@@ -274,8 +274,8 @@ class privUITransactionFile
 	 */
 	public static function IsTransactionValid($id, $bRemoveTransaction = true)
 	{
-		// Constraint the transaction file within APPROOT.'data/transactions'
-		$sTransactionDir = realpath(APPROOT.'data/transactions');
+		// Constraint the transaction file within utils::GetDataPath().'transactions'
+		$sTransactionDir = realpath(utils::GetDataPath().'transactions');
 		$sFilepath = utils::RealPath($sTransactionDir.'/'.$id, $sTransactionDir);
 		if (($sFilepath === false) || (strlen($sTransactionDir) == strlen($sFilepath)))
 		{
@@ -348,7 +348,7 @@ class privUITransactionFile
 
 		clearstatcache();
 		$iLimit = time() - 24*3600;
-		$sPattern = $sTransactionDir ? "$sTransactionDir/*" : APPROOT.'data/transactions/*';
+		$sPattern = $sTransactionDir ? "$sTransactionDir/*" : utils::GetDataPath().'transactions/*';
 		$aTransactions = glob($sPattern);
 		foreach($aTransactions as $sFileName)
 		{
@@ -368,7 +368,7 @@ class privUITransactionFile
 	{
 		clearstatcache();
 		$aResult = array();
-		$aTransactions = glob(APPROOT.'data/transactions/'.self::GetUserPrefix().'*');
+		$aTransactions = glob(utils::GetDataPath().'transactions/'.self::GetUserPrefix().'*');
 		foreach($aTransactions as $sFileName)
 		{
 			$aResult[] = date('Y-m-d H:i:s', filemtime($sFileName)).' - '.basename($sFileName);

--- a/core/bulkexport.class.inc.php
+++ b/core/bulkexport.class.inc.php
@@ -466,14 +466,14 @@ abstract class BulkExport
 	 */
 	protected function MakeTmpFile($sExtension)
 	{
-		if(!is_dir(APPROOT."data/bulk_export"))
+		if(!is_dir(utils::GetDataPath()."bulk_export"))
 		{
-			@mkdir(APPROOT."data/bulk_export", 0777, true /* recursive */);
+			@mkdir(utils::GetDataPath()."bulk_export", 0777, true /* recursive */);
 			clearstatcache();
 		}
-		if (!is_writable(APPROOT."data/bulk_export"))
+		if (!is_writable(utils::GetDataPath()."bulk_export"))
 		{
-			throw new Exception('Data directory "'.APPROOT.'data/bulk_export" could not be written.');
+			throw new Exception('Data directory "'.utils::GetDataPath().'bulk_export" could not be written.');
 		}
 
 		$iNum = rand();
@@ -481,7 +481,7 @@ abstract class BulkExport
 		{
 			$iNum++;
 			$sToken = sprintf("%08x", $iNum);
-			$sFileName = APPROOT."data/bulk_export/$sToken.".$sExtension;
+			$sFileName = utils::GetDataPath()."bulk_export/$sToken.".$sExtension;
 			$hFile = @fopen($sFileName, 'x');
 		}
 		while($hFile === false);

--- a/core/dbsearch.class.php
+++ b/core/dbsearch.class.php
@@ -1503,13 +1503,13 @@ abstract class DBSearch
 		}
 
 		$sLogFile = 'queries.latest';
-		file_put_contents(APPROOT.'data/'.$sLogFile.'.html', $sHtml);
+		file_put_contents(utils::GetDataPath().$sLogFile.'.html', $sHtml);
 
 		$sLog = "<?php\n\$aQueriesLog = ".var_export(self::$m_aQueriesLog, true).";";
-		file_put_contents(APPROOT.'data/'.$sLogFile.'.log', $sLog);
+		file_put_contents(utils::GetDataPath().$sLogFile.'.log', $sLog);
 
 		// Cumulate the queries
-		$sAllQueries = APPROOT.'data/queries.log';
+		$sAllQueries = utils::GetDataPath().'queries.log';
 		if (file_exists($sAllQueries))
 		{
 			// Merge the new queries into the existing log

--- a/core/simplegraph.class.inc.php
+++ b/core/simplegraph.class.inc.php
@@ -500,17 +500,17 @@ EOF
 		if (file_exists($sDotExecutable))
 		{
 			// create the file with Graphviz
-			if (!is_dir(APPROOT."data"))
+			if (!is_dir(utils::GetDataPath()))
 			{
-				@mkdir(APPROOT."data");
+				@mkdir(utils::GetDataPath());
 			}
-			if (!is_dir(APPROOT."data/tmp"))
+			if (!is_dir(utils::GetDataPath()."tmp"))
 			{
-				@mkdir(APPROOT."data/tmp");
+				@mkdir(utils::GetDataPath()."tmp");
 			}
-			$sImageFilePath = tempnam(APPROOT."data/tmp", 'png-');
+			$sImageFilePath = tempnam(utils::GetDataPath()."tmp", 'png-');
 			$sDotDescription = $this->GetDotDescription();
-			$sDotFilePath = tempnam(APPROOT."data/tmp", 'dot-');
+			$sDotFilePath = tempnam(utils::GetDataPath()."tmp", 'dot-');
 		
 			$rFile = @fopen($sDotFilePath, "w");
 			@fwrite($rFile, $sDotDescription);
@@ -556,17 +556,17 @@ EOF
 		if (file_exists($sDotExecutable))
 		{
 			// create the file with Graphviz
-			if (!is_dir(APPROOT."data"))
+			if (!is_dir(utils::GetDataPath()))
 			{
-				@mkdir(APPROOT."data");
+				@mkdir(utils::GetDataPath());
 			}
-			if (!is_dir(APPROOT."data/tmp"))
+			if (!is_dir(utils::GetDataPath()."tmp"))
 			{
-				@mkdir(APPROOT."data/tmp");
+				@mkdir(utils::GetDataPath()."tmp");
 			}
-			$sXdotFilePath = tempnam(APPROOT."data/tmp", 'xdot-');
+			$sXdotFilePath = tempnam(utils::GetDataPath()."tmp", 'xdot-');
 			$sDotDescription = $this->GetDotDescription(true); // true => don't put (localized) labels in the file, since it makes it harder to parse
-			$sDotFilePath = tempnam(APPROOT."data/tmp", 'dot-');
+			$sDotFilePath = tempnam(utils::GetDataPath()."tmp", 'dot-');
 	
 			$rFile = @fopen($sDotFilePath, "w");
 			@fwrite($rFile, $sDotDescription);

--- a/datamodels/2.x/itop-backup/ajax.backup.php
+++ b/datamodels/2.x/itop-backup/ajax.backup.php
@@ -116,7 +116,7 @@ try
 			try
 			{
 				set_time_limit(0);
-				$oBB = new BackupExec(APPROOT.'data/backups/manual/', 0 /*iRetentionCount*/);
+				$oBB = new BackupExec(utils::GetDataPath().'backups/manual/', 0 /*iRetentionCount*/);
 				$sRes = $oBB->Process(time() + 36000); // 10 hours to complete should be sufficient!
 			}
 			catch (Exception $e)
@@ -181,7 +181,7 @@ try
 				$oDBRS = new DBRestore($oItopConfig);
 				$oDBRS->SetMySQLBinDir($sMySQLBinDir);
 
-				$sBackupDir = APPROOT.'data/backups/';
+				$sBackupDir = utils::GetDataPath().'backups/';
 				$sBackupFile = $sBackupDir.$sFile;
 				$sRes = $oDBRS->RestoreFromCompressedBackup($sBackupFile, $sEnvironment);
 
@@ -206,7 +206,7 @@ try
 			}
 			$sFile = utils::ReadParam('file', '', false, 'raw_data');
 			$oBackup = new DBBackupScheduled();
-			$sBackupDir = APPROOT.'data/backups/';
+			$sBackupDir = utils::GetDataPath().'backups/';
 			$sBackupFilePath = utils::RealPath($sBackupDir.$sFile, $sBackupDir);
 			if ($sBackupFilePath === false)
 			{

--- a/datamodels/2.x/itop-backup/dbrestore.class.inc.php
+++ b/datamodels/2.x/itop-backup/dbrestore.class.inc.php
@@ -154,7 +154,7 @@ class DBRestore extends DBBackup
 
 				// Load the database
 				//
-				$sDataDir = APPROOT.'data/tmp-backup-'.rand(10000, getrandmax());
+				$sDataDir = utils::GetDataPath().'tmp-backup-'.rand(10000, getrandmax());
 
 				SetupUtils::builddir($sDataDir); // Here is the directory
 				$oArchive->extractTo($sDataDir);
@@ -164,7 +164,7 @@ class DBRestore extends DBBackup
 
 				// Update the code
 				//
-				$sDeltaFile = APPROOT.'data/'.$sEnvironment.'.delta.xml';
+				$sDeltaFile = utils::GetDataPath().$sEnvironment.'.delta.xml';
 
 				if (is_file($sDataDir.'/delta.xml')) {
 					// Extract and rename delta.xml => <env>.delta.xml;
@@ -172,15 +172,15 @@ class DBRestore extends DBBackup
 				} else {
 					@unlink($sDeltaFile);
 				}
-				if (is_dir(APPROOT.'data/production-modules/')) {
+				if (is_dir(utils::GetDataPath().'production-modules/')) {
 					try {
-						SetupUtils::rrmdir(APPROOT.'data/production-modules/');
+						SetupUtils::rrmdir(utils::GetDataPath().'production-modules/');
 					} catch (Exception $e) {
 						throw new BackupException("Can't remove production-modules dir", 0, $e);
 					}
 				}
 				if (is_dir($sDataDir.'/production-modules')) {
-					rename($sDataDir.'/production-modules', APPROOT.'data/production-modules/');
+					rename($sDataDir.'/production-modules', utils::GetDataPath().'production-modules/');
 				}
 
 				$sConfigFile = APPROOT.'conf/'.$sEnvironment.'/config-itop.php';

--- a/datamodels/2.x/itop-backup/main.itop-backup.php
+++ b/datamodels/2.x/itop-backup/main.itop-backup.php
@@ -109,7 +109,7 @@ class BackupExec extends AbstractWeeklyScheduledProcess
 	{
 		if (is_null($sBackupDir))
 		{
-			$this->sBackupDir = APPROOT.'data/backups/auto/';
+			$this->sBackupDir = utils::GetDataPath().'backups/auto/';
 		}
 		else
 		{

--- a/datamodels/2.x/itop-backup/status.php
+++ b/datamodels/2.x/itop-backup/status.php
@@ -130,7 +130,7 @@ try {
 	// Destination directory
 	//
 	// Make sure the target directory exists and is writeable
-	$sBackupDir = realpath(APPROOT.'data/backups/');
+	$sBackupDir = realpath(utils::GetDataPath().'backups/');
 	SetupUtils::builddir($sBackupDir);
 	if (!is_dir($sBackupDir)) {
 		$oBlockForChecks->AddSubBlock(

--- a/datamodels/2.x/itop-core-update/src/Service/CoreUpdater.php
+++ b/datamodels/2.x/itop-core-update/src/Service/CoreUpdater.php
@@ -486,7 +486,7 @@ final class CoreUpdater
 	 */
 	private static function GetItopArchiveName()
 	{
-		$sItopArchiveName = APPROOT.'data/backups/itop';
+		$sItopArchiveName = utils::GetDataPath().'backups/itop';
 		return $sItopArchiveName;
 	}
 
@@ -504,7 +504,7 @@ final class CoreUpdater
 	 */
 	private static function GetBackupName()
 	{
-		$sBackupName = APPROOT.'data/backups/manual/backup-core-update';
+		$sBackupName = utils::GetDataPath().'backups/manual/backup-core-update';
 		return $sBackupName;
 	}
 

--- a/datamodels/2.x/itop-hub-connector/ajax.php
+++ b/datamodels/2.x/itop-hub-connector/ajax.php
@@ -183,7 +183,7 @@ try
 			require_once (APPROOT.'/application/loginwebpage.class.inc.php');
 			LoginWebPage::DoLogin(true); // Check user rights and prompt if needed (must be admin)
 
-			$sDBBackupPath = APPROOT.'data/backups/manual';
+			$sDBBackupPath = utils::GetDataPath().'backups/manual';
 			$aChecks = SetupUtils::CheckBackupPrerequisites($sDBBackupPath);
 			$bFailed = false;
 			foreach ($aChecks as $oCheckResult)
@@ -256,7 +256,7 @@ try
 		case 'compile':
 			SetupLog::Info('Deployment starts...');
 			$sAuthent = utils::ReadParam('authent', '', false, 'raw_data');
-			if (!file_exists(APPROOT.'data/hub/compile_authent') || $sAuthent !== file_get_contents(APPROOT.'data/hub/compile_authent'))
+			if (!file_exists(utils::GetDataPath().'hub/compile_authent') || $sAuthent !== file_get_contents(utils::GetDataPath().'hub/compile_authent'))
 			{
 					throw new SecurityException(Dict::S('iTopHub:FailAuthent'));
 			}
@@ -299,11 +299,11 @@ try
 			{
 				SetupLog::Info('Move to production starts...');
 			    $sAuthent = utils::ReadParam('authent', '', false, 'raw_data');
-				if (!file_exists(APPROOT.'data/hub/compile_authent') || $sAuthent !== file_get_contents(APPROOT.'data/hub/compile_authent'))
+				if (!file_exists(utils::GetDataPath().'hub/compile_authent') || $sAuthent !== file_get_contents(utils::GetDataPath().'hub/compile_authent'))
 				{
 					throw new SecurityException(Dict::S('iTopHub:FailAuthent'));
 				}
-				unlink(APPROOT.'data/hub/compile_authent');
+				unlink(utils::GetDataPath().'hub/compile_authent');
 				// Load the "production" config file to clone & update it
 				$oConfig = new Config(APPCONF.'production/'.ITOP_CONFIG_FILE);
 				SetupUtils::EnterReadOnlyMode($oConfig);
@@ -368,9 +368,9 @@ try
 			}
 			catch (Exception $e)
 			{
-				if(file_exists(APPROOT.'data/hub/compile_authent'))
+				if(file_exists(utils::GetDataPath().'hub/compile_authent'))
 				{
-					unlink(APPROOT.'data/hub/compile_authent');
+					unlink(utils::GetDataPath().'hub/compile_authent');
 				}
 				// Note: at this point, the dictionnary is not necessarily loaded
 				SetupLog::Error(get_class($e).': '.Dict::S('iTopHub:ConfigurationSafelyReverted')."\n".$e->getMessage());

--- a/datamodels/2.x/itop-hub-connector/hubnewsroomprovider.class.inc.php
+++ b/datamodels/2.x/itop-hub-connector/hubnewsroomprovider.class.inc.php
@@ -78,7 +78,7 @@ class HubNewsroomProvider extends NewsroomProviderBase
 		$sBaseUrl = $this->oConfig->GetModuleSetting('itop-hub-connector', 'url').MetaModel::GetModuleSetting('itop-hub-connector', $sRouteCode);
 		
 		$sParameters = 'uuid[bdd]='.urlencode((string) trim(DBProperty::GetProperty('database_uuid', ''), '{}'));
-		$sParameters .= '&uuid[file]='.urlencode((string) trim(@file_get_contents(APPROOT."data/instance.txt"), "{} \n"));
+		$sParameters .= '&uuid[file]='.urlencode((string) trim(@file_get_contents(utils::GetDataPath()."instance.txt"), "{} \n"));
 		$sParameters .= '&uuid[user]='.urlencode(UserRights::GetUserId());
 		
 		return $sBaseUrl.'?'.$sParameters;

--- a/datamodels/2.x/itop-hub-connector/land.php
+++ b/datamodels/2.x/itop-hub-connector/land.php
@@ -11,7 +11,7 @@ function DisplayStatus(WebPage $oPage)
 
 	$oPage->add('<div class="module-selection-body">');
 	// Now scan the extensions and display a report of the extensions brought by the hub
-	$sPath = APPROOT.'data/downloaded-extensions/';
+	$sPath = utils::GetDataPath().'downloaded-extensions/';
 	$aExtraDirs = array();
 	if (is_dir($sPath)) {
 		$aExtraDirs[] = $sPath; // Also read the extra downloaded-modules directory
@@ -80,7 +80,7 @@ function DoLanding(WebPage $oPage)
 		throw new Exception("Inconsistent version '$sVersion', expecting ".ITOP_VERSION."'");
 	}
 
-	$sFileUUID = (string)trim(@file_get_contents(APPROOT."data/instance.txt"), "{} \n");
+	$sFileUUID = (string)trim(@file_get_contents(utils::GetDataPath()."instance.txt"), "{} \n");
 	if ($sInstanceUUID != $sFileUUID) {
 		throw new Exception("Inconsistent file UUID '$sInstanceUUID', expecting ".$sFileUUID."'");
 	}
@@ -93,7 +93,7 @@ function DoLanding(WebPage $oPage)
 	// Uncompression of extensions in data/downloaded-extensions
 	// only newly downloaded extensions reside in this folder
 	$i = 0;
-	$sPath = APPROOT.'data/downloaded-extensions/';
+	$sPath = utils::GetDataPath().'downloaded-extensions/';
 	if (!is_dir($sPath)) {
 		if (!mkdir($sPath)) {
 			throw new Exception("ERROR: Unable to create the directory '$sPath'. Cannot download any extension. Check the access rights on '".dirname('data/downloaded-extensions/')."'");
@@ -108,7 +108,7 @@ function DoLanding(WebPage $oPage)
 
 		$sZipArchiveFile = $sPath."/extension-{$i}.zip";
 		file_put_contents($sZipArchiveFile, $sArchive);
-		// Expand the content of extension-x.zip into  APPROOT.'data/downloaded-extensions/'
+		// Expand the content of extension-x.zip into  utils::GetDataPath().'downloaded-extensions/'
 		// where the installation will load the extension automatically
 		$oZip = new ZipArchive();
 		if (!$oZip->open($sZipArchiveFile)) {
@@ -132,7 +132,7 @@ function DoLanding(WebPage $oPage)
 function DoInstall(WebPage $oPage)
 {
 	$sUID = hash('sha256', rand());
-	file_put_contents(APPROOT.'data/hub/compile_authent', $sUID);
+	file_put_contents(utils::GetDataPath().'hub/compile_authent', $sUID);
 
 	$oPage->add_linked_stylesheet(utils::GetAbsoluteUrlModulesRoot().'itop-hub-connector/css/hub.css');
 	$oPage->add('<table class="module-selection-banner"><tr>');
@@ -147,7 +147,7 @@ function DoInstall(WebPage $oPage)
 
 	// Now scan the extensions and display a report of the extensions brought by the hub
 	// Now scan the extensions and display a report of the extensions brought by the hub
-	$sPath = APPROOT.'data/downloaded-extensions/';
+	$sPath = utils::GetDataPath().'downloaded-extensions/';
 	$aExtraDirs = array();
 	if (is_dir($sPath)) {
 		$aExtraDirs[] = $sPath; // Also read the extra downloaded-modules directory
@@ -279,8 +279,8 @@ CSS
 			break;
 
 		case 'install':
-			if (!file_exists(APPROOT.'data/hub')) {
-				mkdir(APPROOT.'data/hub');
+			if (!file_exists(utils::GetDataPath().'hub')) {
+				mkdir(utils::GetDataPath().'hub');
 			}
 			DoInstall($oPage);
 			break;

--- a/datamodels/2.x/itop-hub-connector/launch.php
+++ b/datamodels/2.x/itop-hub-connector/launch.php
@@ -228,7 +228,7 @@ function MakeDataToPost($sTargetRoute)
 			'itop_hub_target_route' => $sTargetRoute,
 			'itop_stack' => array(
 				"uuidBdd" => (string)trim(DBProperty::GetProperty('database_uuid', ''), '{}'), // TODO check if empty and... regenerate a new UUID ??
-				"uuidFile" => (string)trim(@file_get_contents(APPROOT."data/instance.txt"), "{} \n"), // TODO check if empty and... regenerate a new UUID ??
+				"uuidFile" => (string)trim(@file_get_contents(utils::GetDataPath()."instance.txt"), "{} \n"), // TODO check if empty and... regenerate a new UUID ??
 				'instance_friendly_name' => (string)$_SERVER['SERVER_NAME'],
 				'instance_host' => (string)utils::GetAbsoluteUrlAppRoot(),
 				'application_name' => (string)ITOP_APPLICATION,

--- a/pages/exec.php
+++ b/pages/exec.php
@@ -79,8 +79,8 @@ if (is_link($sPageEnvFullPath)) {
 	$aPossibleBasePaths = [
 		APPROOT.$sSourceDir,
 		APPROOT.'extensions',
-		APPROOT.'data/'.$sEnvironment.'-modules',
-		APPROOT.'data/downloaded-extensions', // Hub connector
+		utils::GetDataPath().$sEnvironment.'-modules',
+		utils::GetDataPath().'downloaded-extensions', // Hub connector
 	];
 } else {
 	$aPossibleBasePaths = [$sEnvFullPath];

--- a/pages/graphviz.php
+++ b/pages/graphviz.php
@@ -111,17 +111,17 @@ $sDotExecutable = MetaModel::GetConfig()->Get('graphviz_path');
 if (file_exists($sDotExecutable))
 {
 	// create the file with Graphviz
-	$sImageFilePath = APPROOT."data/lifecycle/".$sClass.".svg";
-	if (!is_dir(APPROOT."data"))
+	$sImageFilePath = utils::GetDataPath()."lifecycle/".$sClass.".svg";
+	if (!is_dir(utils::GetDataPath()))
 	{
-		@mkdir(APPROOT."data");
+		@mkdir(utils::GetDataPath());
 	}
-	if (!is_dir(APPROOT."data/lifecycle"))
+	if (!is_dir(utils::GetDataPath()."lifecycle"))
 	{
-		@mkdir(APPROOT."data/lifecycle");
+		@mkdir(utils::GetDataPath()."lifecycle");
 	}
 	$sDotDescription = GraphvizLifecycle($sClass);
-	$sDotFilePath = APPROOT."data/lifecycle/{$sClass}.dot";
+	$sDotFilePath = utils::GetDataPath()."lifecycle/{$sClass}.dot";
 	
 	$rFile = @fopen($sDotFilePath, "w");
 	@fwrite($rFile, $sDotDescription);

--- a/setup/applicationinstaller.class.inc.php
+++ b/setup/applicationinstaller.class.inc.php
@@ -659,7 +659,7 @@ class ApplicationInstaller
 		
 		// Set an "Instance UUID" identifying this machine based on a file located in the data directory
 		$sInstanceUUIDFile = utils::GetDataPath().'instance.txt';
-		SetupUtils::builddir(APPROOT.'data');
+		SetupUtils::builddir(utils::GetDataPath());
 		if (!file_exists($sInstanceUUIDFile))
 		{
 			$sIntanceUUID = utils::CreateUUID('filesystem');

--- a/setup/applicationinstaller.class.inc.php
+++ b/setup/applicationinstaller.class.inc.php
@@ -626,14 +626,14 @@ class ApplicationInstaller
 			}
 		}
 		// Dump the "reference" model, just before loading any actual delta
-		$oFactory->SaveToFile(APPROOT.'data/datamodel-'.$sEnvironment.'.xml');
+		$oFactory->SaveToFile(utils::GetDataPath().'datamodel-'.$sEnvironment.'.xml');
 		
-		$sDeltaFile = APPROOT.'data/'.$sEnvironment.'.delta.xml';
+		$sDeltaFile = utils::GetDataPath().$sEnvironment.'.delta.xml';
 		if (file_exists($sDeltaFile))
 		{
 			$oDelta = new MFDeltaModule($sDeltaFile);
 			$oFactory->LoadModule($oDelta);
-			$oFactory->SaveToFile(APPROOT.'data/datamodel-'.$sEnvironment.'-with-delta.xml');
+			$oFactory->SaveToFile(utils::GetDataPath().'datamodel-'.$sEnvironment.'-with-delta.xml');
 		}
 
 		$oMFCompiler = new MFCompiler($oFactory, $sEnvironment);
@@ -658,7 +658,7 @@ class ApplicationInstaller
 		}
 		
 		// Set an "Instance UUID" identifying this machine based on a file located in the data directory
-		$sInstanceUUIDFile = APPROOT.'data/instance.txt';
+		$sInstanceUUIDFile = utils::GetDataPath().'instance.txt';
 		SetupUtils::builddir(APPROOT.'data');
 		if (!file_exists($sInstanceUUIDFile))
 		{

--- a/setup/backup.class.inc.php
+++ b/setup/backup.class.inc.php
@@ -201,7 +201,7 @@ class DBBackup
 
 		$oArchive = new ITopArchiveTar($sTargetFile.'.tar.gz');
 
-		$sTmpFolder = APPROOT.'data/tmp-backup-'.rand(10000, getrandmax());
+		$sTmpFolder = utils::GetDataPath().'tmp-backup-'.rand(10000, getrandmax());
 		$aFiles = $this->PrepareFilesToBackup($sSourceConfigFile, $sTmpFolder);
 
 		$sFilesList = var_export($aFiles, true);
@@ -248,7 +248,7 @@ class DBBackup
 			$aRet[] = $sFile;
 		}
 
-		$sDeltaFile = APPROOT.'data/'.utils::GetCurrentEnvironment().'.delta.xml';
+		$sDeltaFile = utils::GetDataPath().utils::GetCurrentEnvironment().'.delta.xml';
 		if (file_exists($sDeltaFile))
 		{
 			$sFile = $sTmpFolder.'/delta.xml';
@@ -256,7 +256,7 @@ class DBBackup
 			copy($sDeltaFile, $sFile);
 			$aRet[] = $sFile;
 		}
-		$sExtraDir = APPROOT.'data/'.utils::GetCurrentEnvironment().'-modules/';
+		$sExtraDir = utils::GetDataPath().utils::GetCurrentEnvironment().'-modules/';
 		if (is_dir($sExtraDir))
 		{
 			$sModules = utils::GetCurrentEnvironment().'-modules';

--- a/setup/runtimeenv.class.inc.php
+++ b/setup/runtimeenv.class.inc.php
@@ -380,7 +380,7 @@ class RunTimeEnvironment
 		{
 			$aDirsToCompile[] = APPROOT.'extensions';
 		}
-		$sExtraDir = APPROOT.'data/'.$this->sTargetEnv.'-modules/';
+		$sExtraDir = utils::GetDataPath().$this->sTargetEnv.'-modules/';
 		if (is_dir($sExtraDir))
 		{
 			$aDirsToCompile[] = $sExtraDir;
@@ -475,7 +475,7 @@ class RunTimeEnvironment
 		}
 		while($bModuleAdded);
 
-		$sDeltaFile = APPROOT.'data/'.$this->sTargetEnv.'.delta.xml';
+		$sDeltaFile = utils::GetDataPath().$this->sTargetEnv.'.delta.xml';
 		if (file_exists($sDeltaFile))
 		{
 			$oDelta = new MFDeltaModule($sDeltaFile);
@@ -512,7 +512,7 @@ class RunTimeEnvironment
 			{
 				// Just before loading the delta, let's save an image of the datamodel
 				// in case there is no delta the operation will be done after the end of the loop
-				$oFactory->SaveToFile(APPROOT.'data/datamodel-'.$this->sTargetEnv.'.xml');
+				$oFactory->SaveToFile(utils::GetDataPath().'datamodel-'.$this->sTargetEnv.'.xml');
 			}
 			$oFactory->LoadModule($oModule);
 		}
@@ -520,10 +520,10 @@ class RunTimeEnvironment
 
 		if ($oModule instanceof MFDeltaModule) {
 			// A delta was loaded, let's save a second copy of the datamodel
-			$oFactory->SaveToFile(APPROOT.'data/datamodel-'.$this->sTargetEnv.'-with-delta.xml');
+			$oFactory->SaveToFile(utils::GetDataPath().'datamodel-'.$this->sTargetEnv.'-with-delta.xml');
 		} else {
 			// No delta was loaded, let's save the datamodel now
-			$oFactory->SaveToFile(APPROOT.'data/datamodel-'.$this->sTargetEnv.'.xml');
+			$oFactory->SaveToFile(utils::GetDataPath().'datamodel-'.$this->sTargetEnv.'.xml');
 		}
 
 		$sTargetDir = APPROOT.'env-'.$this->sTargetEnv;
@@ -532,7 +532,7 @@ class RunTimeEnvironment
 		$oMFCompiler = new MFCompiler($oFactory, $this->sFinalEnv);
 		$oMFCompiler->Compile($sTargetDir, null, $bUseSymLinks, $bSkipTempDir);
 
-		$sCacheDir = APPROOT.'data/cache-'.$this->sTargetEnv;
+		$sCacheDir = utils::GetDataPath().'cache-'.$this->sTargetEnv;
 		SetupUtils::builddir($sCacheDir);
 		SetupUtils::tidydir($sCacheDir);
 
@@ -942,38 +942,38 @@ class RunTimeEnvironment
 	{
 		if ($this->sFinalEnv != $this->sTargetEnv)
 		{
-			if (file_exists(APPROOT.'data/'.$this->sTargetEnv.'.delta.xml'))
+			if (file_exists(utils::GetDataPath().$this->sTargetEnv.'.delta.xml'))
 			{
-				if (file_exists(APPROOT.'data/'.$this->sFinalEnv.'.delta.xml'))
+				if (file_exists(utils::GetDataPath().$this->sFinalEnv.'.delta.xml'))
 				{
 					// Make a "previous" file
 					copy(
-						APPROOT.'data/'.$this->sFinalEnv.'.delta.xml',
-						APPROOT.'data/'.$this->sFinalEnv.'.delta.prev.xml'
+						utils::GetDataPath().$this->sFinalEnv.'.delta.xml',
+						utils::GetDataPath().$this->sFinalEnv.'.delta.prev.xml'
 					);
 				}
 				$this->CommitFile(
-					APPROOT.'data/'.$this->sTargetEnv.'.delta.xml',
-					APPROOT.'data/'.$this->sFinalEnv.'.delta.xml'
+					utils::GetDataPath().$this->sTargetEnv.'.delta.xml',
+					utils::GetDataPath().$this->sFinalEnv.'.delta.xml'
 				);
 			}
 			$this->CommitFile(
-				APPROOT.'data/datamodel-'.$this->sTargetEnv.'.xml',
-				APPROOT.'data/datamodel-'.$this->sFinalEnv.'.xml'
+				utils::GetDataPath().'datamodel-'.$this->sTargetEnv.'.xml',
+				utils::GetDataPath().'datamodel-'.$this->sFinalEnv.'.xml'
 			);
 			$this->CommitFile(
-				APPROOT.'data/datamodel-'.$this->sTargetEnv.'-with-delta.xml',
-				APPROOT.'data/datamodel-'.$this->sFinalEnv.'-with-delta.xml',
+				utils::GetDataPath().'datamodel-'.$this->sTargetEnv.'-with-delta.xml',
+				utils::GetDataPath().'datamodel-'.$this->sFinalEnv.'-with-delta.xml',
 				false
 			);
 			$this->CommitDir(
-				APPROOT.'data/'.$this->sTargetEnv.'-modules/',
-				APPROOT.'data/'.$this->sFinalEnv.'-modules/',
+				utils::GetDataPath().$this->sTargetEnv.'-modules/',
+				utils::GetDataPath().$this->sFinalEnv.'-modules/',
 				false
 			);
 			$this->CommitDir(
-				APPROOT.'data/cache-'.$this->sTargetEnv,
-				APPROOT.'data/cache-'.$this->sFinalEnv,
+				utils::GetDataPath().'cache-'.$this->sTargetEnv,
+				utils::GetDataPath().'cache-'.$this->sFinalEnv,
 				false
 			);
 			$this->CommitDir(

--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -1579,7 +1579,7 @@ JS
 		if (is_dir($oWizard->GetParameter('copy_extensions_from'))) {
 			$aDirsToScan[] = $oWizard->GetParameter('copy_extensions_from');
 		}
-		$sExtraDir = APPROOT.'data/production-modules/';
+		$sExtraDir = utils::GetDataPath().'production-modules/';
 		if (is_dir($sExtraDir))
 		{
 			$aDirsToScan[] = $sExtraDir;
@@ -1933,7 +1933,7 @@ JS
 		if (empty($sEnv)) {
 			$aLicenceFiles = array_merge($aLicenceFiles, glob(APPROOT.'datamodels/*/*/license.*.xml'));
 			$aLicenceFiles = array_merge($aLicenceFiles, glob(APPROOT.'extensions/{*,*/*}/license.*.xml', GLOB_BRACE));
-			$aLicenceFiles = array_merge($aLicenceFiles, glob(APPROOT.'data/*-modules/{*,*/*}/license.*.xml', GLOB_BRACE));
+			$aLicenceFiles = array_merge($aLicenceFiles, glob(utils::GetDataPath().'*-modules/{*,*/*}/license.*.xml', GLOB_BRACE));
 		}
 		else
 		{
@@ -2065,11 +2065,11 @@ JS
 		if (!is_dir(APPROOT.'data')) {
 			mkdir(APPROOT.'data');
 		}
-		if (!is_dir(APPROOT.'data/setup')) {
-			mkdir(APPROOT.'data/setup');
+		if (!is_dir(utils::GetDataPath().'setup')) {
+			mkdir(utils::GetDataPath().'setup');
 		}
 		$sUID = hash('sha256', rand());
-		file_put_contents(APPROOT.'data/setup/authent', $sUID);
+		file_put_contents(utils::GetDataPath().'setup/authent', $sUID);
 		Session::Set('setup_token', $sUID);
 		return $sUID;
 	}
@@ -2085,7 +2085,7 @@ JS
 	final public static function CheckSetupToken($bRemoveToken = false)
 	{
 		$sAuthent = utils::ReadParam('authent', '', false, 'raw_data');
-		$sTokenFile = APPROOT.'data/setup/authent';
+		$sTokenFile = utils::GetDataPath().'setup/authent';
 		if (!file_exists($sTokenFile) || $sAuthent !== file_get_contents($sTokenFile)) {
 			throw new SecurityException('Setup operations are not allowed outside of the setup');
 		}
@@ -2104,7 +2104,7 @@ JS
 	{
 		if (Session::IsSet('setup_token')) {
 			$sAuth = Session::Get('setup_token');
-			$sTokenFile = APPROOT.'data/setup/authent';
+			$sTokenFile = utils::GetDataPath().'setup/authent';
 			if (file_exists($sTokenFile) && $sAuth === file_get_contents($sTokenFile)) {
 				return true;
 			}
@@ -2118,7 +2118,7 @@ JS
 	 */
 	public static function EraseSetupToken()
 	{
-		$sTokenFile = APPROOT.'data/setup/authent';
+		$sTokenFile = utils::GetDataPath().'setup/authent';
 		if (is_file($sTokenFile)) {
 			unlink($sTokenFile);
 		}

--- a/setup/wizardsteps.class.inc.php
+++ b/setup/wizardsteps.class.inc.php
@@ -238,7 +238,7 @@ class WizStepInstallOrUpgrade extends WizardStep
 		$sPreviousVersionDir = '';
 		if ($sInstallMode == '')
 		{
-			$sDBBackupPath = APPROOT.'data/backups/manual/setup-'.date('Y-m-d_H_i');
+			$sDBBackupPath = utils::GetDataPath().'backups/manual/setup-'.date('Y-m-d_H_i');
 			$bDBBackup = true;
 			$aPreviousInstance = SetupUtils::GetPreviousInstance(APPROOT);
 			if ($aPreviousInstance['found']) {

--- a/setup/xmldataloader.class.inc.php
+++ b/setup/xmldataloader.class.inc.php
@@ -24,7 +24,7 @@
  * @license     http://opensource.org/licenses/AGPL-3.0
  */
 
-define ('KEYS_CACHE_FILE', APPROOT.'data/keyscache.tmp');
+define ('KEYS_CACHE_FILE', utils::GetDataPath().'keyscache.tmp');
 /**
  * Class to load sets of objects from XML files into the database
  * XML files can be produced by the 'export' web service or by any other means

--- a/sources/Controller/AjaxRenderController.php
+++ b/sources/Controller/AjaxRenderController.php
@@ -898,7 +898,7 @@ EOF
 		if (file_exists(APPROOT.'extensions')) {
 			$aSearchDirs[] = APPROOT.'extensions';
 		}
-		$sExtraDir = APPROOT.'data/'.$sCurrEnv.'-modules/';
+		$sExtraDir = utils::GetDataPath().$sCurrEnv.'-modules/';
 		if (file_exists($sExtraDir)) {
 			$aSearchDirs[] = $sExtraDir;
 		}

--- a/tests/php-unit-tests/legacy-tests/replay_query_log.php
+++ b/tests/php-unit-tests/legacy-tests/replay_query_log.php
@@ -19,7 +19,7 @@
 
 function LogResult($sString)
 {
-	file_put_contents(APPROOT.'data/queries.results.log', "\n".$sString, FILE_APPEND);
+	file_put_contents(utils::GetDataPath().'queries.results.log', "\n".$sString, FILE_APPEND);
 }
 
 function LogBenchmarkCSV()
@@ -37,7 +37,7 @@ function LogBenchmarkCSV()
 		}
 	}
 	$sLine = implode(';', $aValues); // the preferred for MS Excel
-	file_put_contents(APPROOT.'data/queries.benchmark.csv', "\n".$sLine, FILE_APPEND);
+	file_put_contents(utils::GetDataPath().'queries.benchmark.csv', "\n".$sLine, FILE_APPEND);
 }
 
 class QueryLogEntry
@@ -308,8 +308,8 @@ case 'check':
 case 'benchmark':
 	$oP->add("<h2>Create data/queries.xxx reports</h2>\n");
 	// Reset the log contents
-	file_put_contents(APPROOT.'data/queries.results.log', date('Y-m-d H:i:s')."\n");
-	file_put_contents(APPROOT.'data/queries.benchmark.csv', '');
+	file_put_contents(utils::GetDataPath().'queries.results.log', date('Y-m-d H:i:s')."\n");
+	file_put_contents(utils::GetDataPath().'queries.benchmark.csv', '');
 	LogBenchmarkCSV('type', 'properties', 'make duration', 'class', 'tables', 'query length', 'exec duration', 'rows', 'oql');
 
 	$iErrors = 0;

--- a/tests/php-unit-tests/src/Hook/TestsRunStartHook.php
+++ b/tests/php-unit-tests/src/Hook/TestsRunStartHook.php
@@ -36,7 +36,7 @@ class TestsRunStartHook implements BeforeFirstTestHook, AfterLastTestHook
 	{
 		// Note: This can't be put in the cache-<ENV> folder as we have multiple <ENV> running across the test cases
 		//       We also don't want to put it in the unit tests folder as it is not supposed to be writable
-		return APPROOT.'data/.php-unit-tests-run-started';
+		return utils::GetDataPath().'.php-unit-tests-run-started';
 	}
 
 	/**


### PR DESCRIPTION
**Objective**
Stop duplicating an hard-coded path to the "<ITOP>/data" folder (the "writable" folder for caches, extensions needs, ...) by using a helper function `\utils::GetDataCache()` similar to what as been done for other folders.

Note that the helper was introduced a while back, this PR just makes a bit of cleanup by using it everywhere it can.