### PR TITLE
N°6816 - Search: Fix JS "me._onACSearchContainsSuccess is not a function" error

### DIFF
--- a/js/search/search_form_criteria_enum.js
+++ b/js/search/search_form_criteria_enum.js
@@ -439,8 +439,6 @@ $(function()
 
 									return;
 								}
-
-								me._onACSearchContainsSuccess(oResponse);
 							})
 							.fail(function(oResponse, sStatus, oXHR){  me._onACSearchFail(oResponse, sStatus); })
 							.always(function(oResponse, sStatus, oXHR){


### PR DESCRIPTION
**Symptom**
JS error in the browser console when searching on an external key criteria : "me._onACSearchContainsSuccess is not a function"
![image](https://github.com/Combodo/iTop/assets/5130468/b6152f94-1880-4b42-a489-da5cc9248101)


**Reproduction**
- iTop 3.1
- Open a search form with an object with an external key
- Open the dev. tools of the browser
- The external key criteria must be in "auto complete" (change "max_combo_length" conf. param. if necessary)
- Type a NONE existing value in the criteria
- See the error in the JS console

**Cause**
With [47becb3b](https://github.com/Combodo/iTop/commit/47becb3be802220a338d8060dd15c9d2ce933fdd#diff-3ed3308f842d345fc38af7bdc22337a85c03a8ff8f23ddef9e37fd414253c273L707) a JS function was removed but not it's call ([47becb3b](https://github.com/Combodo/iTop/commit/47becb3be802220a338d8060dd15c9d2ce933fdd#diff-3ed3308f842d345fc38af7bdc22337a85c03a8ff8f23ddef9e37fd414253c273R443)).

**Proposed solution**
Remove the remaining call as the search form is working well besides that.