### PR TITLE
 N°6385 - Allow to disable LinkedSet (1:n & n:n) edition by XML

### DIFF
--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -91,6 +91,12 @@ define('LINKSET_EDITMODE_ACTIONS', 2); // Show the usual 'Actions' popup menu
 define('LINKSET_EDITMODE_INPLACE', 3); // The "linked" objects can be created/modified/deleted in place
 define('LINKSET_EDITMODE_ADDREMOVE', 4); // The "linked" objects can be added/removed in place
 
+define('LINKSET_WHEN_NEVER', 0); // The linkset cannot be edited at all from inside this object
+define('LINKSET_WHEN_ON_HOST_EDITION', 1); // The only possible action is to open a new window to create a new object
+define('LINKSET_WHEN_ON_HOST_DISPLAY', 2); // Show the usual 'Actions' popup menu
+define('LINKSET_WHEN_ALWAYS', 3); // Show the usual 'Actions' popup menu
+
+
 define('LINKSET_DISPLAY_STYLE_PROPERTY', 'property');
 define('LINKSET_DISPLAY_STYLE_TAB', 'tab');
 
@@ -1703,6 +1709,14 @@ class AttributeLinkedSet extends AttributeDefinition
 	public function GetEditMode()
 	{
 		return $this->GetOptional('edit_mode', LINKSET_EDITMODE_ACTIONS);
+	}	
+	
+	/**
+	 * @return int see LINKSET_WHEN_* constants
+	 */
+	public function GetEditWhen()
+	{
+		return $this->GetOptional('edit_when', LINKSET_WHEN_ALWAYS);
 	}
 
 	/**

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -1712,12 +1712,12 @@ class AttributeLinkedSet extends AttributeDefinition
 	}	
 	
 	/**
-	 * @return int see LINKSET_WHEN_* constants
+	 * @return int see LINKSET_EDITWHEN_* constants
 	 * @since 3.1.1 3.2.0 N°6385
 	 */
 	public function GetEditWhen(): int
 	{
-		return $this->GetOptional('edit_when', LINKSET_WHEN_ALWAYS);
+		return $this->GetOptional('edit_when', LINKSET_EDITWHEN_ALWAYS);
 	}
 
 	/**

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -1715,7 +1715,7 @@ class AttributeLinkedSet extends AttributeDefinition
 	 * @return int see LINKSET_WHEN_* constants
 	 * @since 3.1.1 3.2.0 N°6385
 	 */
-	public function GetEditWhen()
+	public function GetEditWhen(): int
 	{
 		return $this->GetOptional('edit_when', LINKSET_WHEN_ALWAYS);
 	}

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -91,10 +91,10 @@ define('LINKSET_EDITMODE_ACTIONS', 2); // Show the usual 'Actions' popup menu
 define('LINKSET_EDITMODE_INPLACE', 3); // The "linked" objects can be created/modified/deleted in place
 define('LINKSET_EDITMODE_ADDREMOVE', 4); // The "linked" objects can be added/removed in place
 
-define('LINKSET_WHEN_NEVER', 0); // The linkset cannot be edited at all from inside this object
-define('LINKSET_WHEN_ON_HOST_EDITION', 1); // The only possible action is to open a new window to create a new object
-define('LINKSET_WHEN_ON_HOST_DISPLAY', 2); // Show the usual 'Actions' popup menu
-define('LINKSET_WHEN_ALWAYS', 3); // Show the usual 'Actions' popup menu
+define('LINKSET_EDITWHEN_NEVER', 0); // The linkset cannot be edited at all from inside this object
+define('LINKSET_EDITWHEN_ON_HOST_EDITION', 1); // The only possible action is to open a new window to create a new object
+define('LINKSET_EDITWHEN_ON_HOST_DISPLAY', 2); // Show the usual 'Actions' popup menu
+define('LINKSET_EDITWHEN_ALWAYS', 3); // Show the usual 'Actions' popup menu
 
 
 define('LINKSET_DISPLAY_STYLE_PROPERTY', 'property');

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -1713,6 +1713,7 @@ class AttributeLinkedSet extends AttributeDefinition
 	
 	/**
 	 * @return int see LINKSET_WHEN_* constants
+	 * @since 3.1.1 3.2.0 N°6385
 	 */
 	public function GetEditWhen()
 	{

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -950,10 +950,10 @@ EOF
 	protected function EditWhenToPHP($sEditWhen): string
 	{
 		static $aXmlToPHP = array(
-			'never' => 'LINKSET_WHEN_NEVER',
-			'on_host_edition' => 'LINKSET_WHEN_ON_HOST_EDITION',
-			'on_host_display' => 'LINKSET_WHEN_ON_HOST_DISPLAY',
-			'always' => 'LINKSET_WHEN_ALWAYS',
+			'never' => 'LINKSET_EDITWHEN_NEVER',
+			'on_host_edition' => 'LINKSET_EDITWHEN_ON_HOST_EDITION',
+			'on_host_display' => 'LINKSET_EDITWHEN_ON_HOST_DISPLAY',
+			'always' => 'LINKSET_EDITWHEN_ALWAYS',
 		);
 
 		if (!array_key_exists($sEditWhen, $aXmlToPHP))

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -943,11 +943,11 @@ EOF
 	 * Helper to format the edit-when for direct linkset
 	 *
 	 * @param string $sEditWhen Value set from within the XML
-	 * Returns string PHP flag
+	 * @return string PHP flag
 	 *
 	 * @throws \DOMFormatException
 	 */
-	protected function EditWhenToPHP($sEditWhen)
+	protected function EditWhenToPHP($sEditWhen): string
 	{
 		static $aXmlToPHP = array(
 			'never' => 'LINKSET_WHEN_NEVER',

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -938,6 +938,30 @@ EOF
 		return $aXmlToPHP[$sEditMode];
 	}
 
+
+	/**
+	 * Helper to format the edit-when for direct linkset
+	 *
+	 * @param string $sEditWhen Value set from within the XML
+	 * Returns string PHP flag
+	 *
+	 * @throws \DOMFormatException
+	 */
+	protected function EditWhenToPHP($sEditWhen)
+	{
+		static $aXmlToPHP = array(
+			'never' => 'LINKSET_WHEN_NEVER',
+			'on_host_edition' => 'LINKSET_WHEN_ON_HOST_EDITION',
+			'on_host_display' => 'LINKSET_WHEN_ON_HOST_DISPLAY',
+			'always' => 'LINKSET_WHEN_ALWAYS',
+		);
+
+		if (!array_key_exists($sEditWhen, $aXmlToPHP))
+		{
+			throw new DOMFormatException("Edit mode: unknown value '$sEditWhen'");
+		}
+		return $aXmlToPHP[$sEditWhen];
+	}
 	
 	/**
 	 * Format a path (file or url) as an absolute path or relative to the module or the app
@@ -2054,6 +2078,7 @@ EOF
 			$this->CompileCommonProperty('duplicates', $oField, $aParameters, $sModuleRelativeDir, false);
 			$this->CompileCommonProperty('display_style', $oField, $aParameters, $sModuleRelativeDir);
 			$this->CompileCommonProperty('edit_mode', $oField, $aParameters, $sModuleRelativeDir);
+			$this->CompileCommonProperty('edit_when', $oField, $aParameters, $sModuleRelativeDir);
 			$this->CompileCommonProperty('filter', $oField, $aParameters, $sModuleRelativeDir);
 			$this->CompileCommonProperty('with_php_constraint', $oField, $aParameters, $sModuleRelativeDir, false);
 			$aParameters['depends_on'] = $sDependencies;
@@ -2064,6 +2089,7 @@ EOF
 			$this->CompileCommonProperty('count_max', $oField, $aParameters, $sModuleRelativeDir, 0);
 			$this->CompileCommonProperty('display_style', $oField, $aParameters, $sModuleRelativeDir);
 			$this->CompileCommonProperty('edit_mode', $oField, $aParameters, $sModuleRelativeDir);
+			$this->CompileCommonProperty('edit_when', $oField, $aParameters, $sModuleRelativeDir);
 			$this->CompileCommonProperty('filter', $oField, $aParameters, $sModuleRelativeDir);
 			$this->CompileCommonProperty('with_php_constraint', $oField, $aParameters, $sModuleRelativeDir, false);
 			$aParameters['depends_on'] = $sDependencies;
@@ -2287,6 +2313,12 @@ EOF
 					$sEditMode = $oField->GetChildText('edit_mode');
 					if (!is_null($sEditMode)) {
 						$aParameters['edit_mode'] = $this->EditModeToPHP($sEditMode);
+					}
+					break;
+				case 'edit_when':
+					$sEditWhen = $oField->GetChildText('edit_when');
+					if(!is_null($sEditWhen)){
+						$aParameters['edit_when'] = $this->EditWhenToPHP($sEditWhen);
 					}
 					break;
 				case 'mappings':

--- a/sources/Application/UI/Links/AbstractBlockLinkSetViewTable.php
+++ b/sources/Application/UI/Links/AbstractBlockLinkSetViewTable.php
@@ -226,6 +226,7 @@ abstract class AbstractBlockLinkSetViewTable extends UIContentBlock
 	 * Compares Linkset attribute edit_when values with its usage requirements
 	 * 
 	 * @return bool
+	 * @since 3.1.1 3.2.0 N°6385
 	 */
 	protected function IsEditableBasedOnEditWhen(): bool{
 		return true;

--- a/sources/Application/UI/Links/AbstractBlockLinkSetViewTable.php
+++ b/sources/Application/UI/Links/AbstractBlockLinkSetViewTable.php
@@ -216,8 +216,19 @@ abstract class AbstractBlockLinkSetViewTable extends UIContentBlock
 		{
 			$iFlags = $this->oDbObject->GetAttributeFlags($this->sAttCode);
 		}
+		
+		$bEditWhen = $this->IsEditableBasedOnEditWhen();
 
-		$this->bIsAttEditable = !($iFlags & (OPT_ATT_READONLY | OPT_ATT_SLAVE | OPT_ATT_HIDDEN));
+		$this->bIsAttEditable = !($iFlags & (OPT_ATT_READONLY | OPT_ATT_SLAVE | OPT_ATT_HIDDEN)) && $bEditWhen;
+	}
+
+	/**
+	 * Compares Linkset attribute edit_when values with its usage requirements
+	 * 
+	 * @return bool
+	 */
+	protected function IsEditableBasedOnEditWhen(): bool{
+		return true;
 	}
 	
 	/**

--- a/sources/Application/UI/Links/Direct/BlockDirectLinkSetEditTable.php
+++ b/sources/Application/UI/Links/Direct/BlockDirectLinkSetEditTable.php
@@ -121,10 +121,13 @@ class BlockDirectLinkSetEditTable extends UIContentBlock
 	{
 		$this->oAttributeLinkedSet = MetaModel::GetAttributeDef($this->oUILinksDirectWidget->GetClass(), $this->oUILinksDirectWidget->GetAttCode());
 
+		$sEditWhen = $this->oAttributeLinkedSet->GetEditWhen();
+		$bIsEditableBasedOnEditWhen = ($sEditWhen === LINKSET_WHEN_ALWAYS || $sEditWhen === LINKSET_WHEN_ON_HOST_EDITION);
+
 		// User rights
-		$this->bIsAllowCreate = UserRights::IsActionAllowed($this->oAttributeLinkedSet->GetLinkedClass(), UR_ACTION_CREATE) == UR_ALLOWED_YES;
-		$this->bIsAllowModify = UserRights::IsActionAllowed($this->oAttributeLinkedSet->GetLinkedClass(), UR_ACTION_MODIFY) == UR_ALLOWED_YES;
-		$this->bIsAllowDelete = UserRights::IsActionAllowed($this->oAttributeLinkedSet->GetLinkedClass(), UR_ACTION_DELETE) == UR_ALLOWED_YES;
+		$this->bIsAllowCreate = UserRights::IsActionAllowed($this->oAttributeLinkedSet->GetLinkedClass(), UR_ACTION_CREATE) == UR_ALLOWED_YES && $bIsEditableBasedOnEditWhen;
+		$this->bIsAllowModify = UserRights::IsActionAllowed($this->oAttributeLinkedSet->GetLinkedClass(), UR_ACTION_MODIFY) == UR_ALLOWED_YES && $bIsEditableBasedOnEditWhen;
+		$this->bIsAllowDelete = UserRights::IsActionAllowed($this->oAttributeLinkedSet->GetLinkedClass(), UR_ACTION_DELETE) == UR_ALLOWED_YES && $bIsEditableBasedOnEditWhen;
 	}
 
 	/**

--- a/sources/Application/UI/Links/Direct/BlockDirectLinkSetEditTable.php
+++ b/sources/Application/UI/Links/Direct/BlockDirectLinkSetEditTable.php
@@ -122,7 +122,7 @@ class BlockDirectLinkSetEditTable extends UIContentBlock
 		$this->oAttributeLinkedSet = MetaModel::GetAttributeDef($this->oUILinksDirectWidget->GetClass(), $this->oUILinksDirectWidget->GetAttCode());
 
 		$sEditWhen = $this->oAttributeLinkedSet->GetEditWhen();
-		$bIsEditableBasedOnEditWhen = ($sEditWhen === LINKSET_WHEN_ALWAYS || $sEditWhen === LINKSET_WHEN_ON_HOST_EDITION);
+		$bIsEditableBasedOnEditWhen = ($sEditWhen === LINKSET_EDITWHEN_ALWAYS || $sEditWhen === LINKSET_EDITWHEN_ON_HOST_EDITION);
 
 		// User rights
 		$this->bIsAllowCreate = UserRights::IsActionAllowed($this->oAttributeLinkedSet->GetLinkedClass(), UR_ACTION_CREATE) == UR_ALLOWED_YES && $bIsEditableBasedOnEditWhen;

--- a/sources/Application/UI/Links/Direct/BlockDirectLinkSetViewTable.php
+++ b/sources/Application/UI/Links/Direct/BlockDirectLinkSetViewTable.php
@@ -186,6 +186,6 @@ class BlockDirectLinkSetViewTable extends AbstractBlockLinkSetViewTable
 	protected function IsEditableBasedOnEditWhen(): bool
 	{
 		$sEditWhen = $this->oAttDef->GetEditWhen();
-		return $sEditWhen === LINKSET_WHEN_ALWAYS || $sEditWhen === LINKSET_WHEN_ON_HOST_DISPLAY;
+		return $sEditWhen === LINKSET_EDITWHEN_ALWAYS || $sEditWhen === LINKSET_EDITWHEN_ON_HOST_DISPLAY;
 	}
 }

--- a/sources/Application/UI/Links/Direct/BlockDirectLinkSetViewTable.php
+++ b/sources/Application/UI/Links/Direct/BlockDirectLinkSetViewTable.php
@@ -179,4 +179,15 @@ class BlockDirectLinkSetViewTable extends AbstractBlockLinkSetViewTable
 
 		return $aDefaults;
 	}
+
+	/**
+	 * @inheritDoc
+	 * 
+	 * @return bool
+	 */
+	protected function IsEditableBasedOnEditWhen(): bool
+	{
+		$sEditWhen = $this->oAttDef->GetEditWhen();
+		return $sEditWhen === LINKSET_WHEN_ALWAYS || $sEditWhen === LINKSET_WHEN_ON_HOST_DISPLAY;
+	}
 }

--- a/sources/Application/UI/Links/Direct/BlockDirectLinkSetViewTable.php
+++ b/sources/Application/UI/Links/Direct/BlockDirectLinkSetViewTable.php
@@ -182,8 +182,6 @@ class BlockDirectLinkSetViewTable extends AbstractBlockLinkSetViewTable
 
 	/**
 	 * @inheritDoc
-	 * 
-	 * @return bool
 	 */
 	protected function IsEditableBasedOnEditWhen(): bool
 	{

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinkSetEditTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinkSetEditTable.php
@@ -108,7 +108,7 @@ class BlockIndirectLinkSetEditTable extends UIContentBlock
 		$this->oAttributeLinkedSetIndirect = MetaModel::GetAttributeDef($this->oUILinksWidget->GetClass(), $this->oUILinksWidget->GetAttCode());
 
 		$sEditWhen = $this->oAttributeLinkedSetIndirect->GetEditWhen();
-		$bIsEditableBasedOnEditWhen = ($sEditWhen === LINKSET_WHEN_ALWAYS || $sEditWhen === LINKSET_WHEN_ON_HOST_EDITION);
+		$bIsEditableBasedOnEditWhen = ($sEditWhen === LINKSET_EDITWHEN_ALWAYS || $sEditWhen === LINKSET_EDITWHEN_ON_HOST_EDITION);
 
 		// User rights
 		$this->bIsAllowCreate = UserRights::IsActionAllowed($this->oAttributeLinkedSetIndirect->GetLinkedClass(), UR_ACTION_CREATE) == UR_ALLOWED_YES && $bIsEditableBasedOnEditWhen;

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinkSetEditTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinkSetEditTable.php
@@ -107,10 +107,13 @@ class BlockIndirectLinkSetEditTable extends UIContentBlock
 	{
 		$this->oAttributeLinkedSetIndirect = MetaModel::GetAttributeDef($this->oUILinksWidget->GetClass(), $this->oUILinksWidget->GetAttCode());
 
+		$sEditWhen = $this->oAttributeLinkedSetIndirect->GetEditWhen();
+		$bIsEditableBasedOnEditWhen = ($sEditWhen === LINKSET_WHEN_ALWAYS || $sEditWhen === LINKSET_WHEN_ON_HOST_EDITION);
+
 		// User rights
-		$this->bIsAllowCreate = UserRights::IsActionAllowed($this->oAttributeLinkedSetIndirect->GetLinkedClass(), UR_ACTION_CREATE) == UR_ALLOWED_YES;
-		$this->bIsAllowModify = UserRights::IsActionAllowed($this->oAttributeLinkedSetIndirect->GetLinkedClass(), UR_ACTION_MODIFY) == UR_ALLOWED_YES;
-		$this->bIsAllowDelete = UserRights::IsActionAllowed($this->oAttributeLinkedSetIndirect->GetLinkedClass(), UR_ACTION_DELETE) == UR_ALLOWED_YES;
+		$this->bIsAllowCreate = UserRights::IsActionAllowed($this->oAttributeLinkedSetIndirect->GetLinkedClass(), UR_ACTION_CREATE) == UR_ALLOWED_YES && $bIsEditableBasedOnEditWhen;
+		$this->bIsAllowModify = UserRights::IsActionAllowed($this->oAttributeLinkedSetIndirect->GetLinkedClass(), UR_ACTION_MODIFY) == UR_ALLOWED_YES && $bIsEditableBasedOnEditWhen;
+		$this->bIsAllowDelete = UserRights::IsActionAllowed($this->oAttributeLinkedSetIndirect->GetLinkedClass(), UR_ACTION_DELETE) == UR_ALLOWED_YES && $bIsEditableBasedOnEditWhen;
 	}
 
 	/**

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinkSetViewTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinkSetViewTable.php
@@ -129,8 +129,6 @@ class BlockIndirectLinkSetViewTable extends AbstractBlockLinkSetViewTable
 	
 	/**
 	 * @inheritDoc
-	 * 
-	 * @return bool
 	 */
 	protected function IsEditableBasedOnEditWhen(): bool
 	{

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinkSetViewTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinkSetViewTable.php
@@ -126,4 +126,15 @@ class BlockIndirectLinkSetViewTable extends AbstractBlockLinkSetViewTable
 
 		return $sAttCodesToDisplay;
 	}
+	
+	/**
+	 * @inheritDoc
+	 * 
+	 * @return bool
+	 */
+	protected function IsEditableBasedOnEditWhen(): bool
+	{
+		$sEditWhen = $this->oAttDef->GetEditWhen();
+		return $sEditWhen === LINKSET_WHEN_ALWAYS || $sEditWhen === LINKSET_WHEN_ON_HOST_DISPLAY; 
+	}
 }

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinkSetViewTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinkSetViewTable.php
@@ -133,6 +133,6 @@ class BlockIndirectLinkSetViewTable extends AbstractBlockLinkSetViewTable
 	protected function IsEditableBasedOnEditWhen(): bool
 	{
 		$sEditWhen = $this->oAttDef->GetEditWhen();
-		return $sEditWhen === LINKSET_WHEN_ALWAYS || $sEditWhen === LINKSET_WHEN_ON_HOST_DISPLAY; 
+		return $sEditWhen === LINKSET_EDITWHEN_ALWAYS || $sEditWhen === LINKSET_EDITWHEN_ON_HOST_DISPLAY; 
 	}
 }


### PR DESCRIPTION
**Objective**
Forbid editing of an n:n relationship on either side of the relationship, if the host object is in read or edit mode, or in both cases, while still displaying it.