### PR TITLE
N°6866 - Fix issue when creating new fields in Request Template in French

### DIFF
--- a/sources/application/UI/Base/Component/DataTable/DataTableUIBlockFactory.php
+++ b/sources/application/UI/Base/Component/DataTable/DataTableUIBlockFactory.php
@@ -791,14 +791,14 @@ class DataTableUIBlockFactory extends AbstractUIBlockFactory
 					$aColumnDefinition["type"] = "html";
 
 					if ($sAttCode == '_key_') {
-						$sAttrLabel = $aData['alias'];
+						$sAttLabel = $aData['alias'];
 						$aColumnDefinition["title"] = $aData['alias'];
 						$aColumnDefinition['metadata'] = [
 							'object_class'    => $sClassName,
 							'class_alias'     => $sClassAlias,
 							'attribute_code'  => $sAttCode,
 							'attribute_type'  => '_key_',
-							'attribute_label' => $sAttrLabel,
+							'attribute_label' => $sAttLabel,
 						];
 						$aColumnDefinition["data"] = $sClassAlias."/".$sAttCode;
 						$aColumnDefinition["render"] = [
@@ -806,8 +806,8 @@ class DataTableUIBlockFactory extends AbstractUIBlockFactory
 							"_"       => $sClassAlias."/".$sAttCode,
 						];
 						$aColumnDefinition["createdCell"] = <<<JS
-						$(td).attr('data-object-class', '$sClassName');
-						$(td).attr('data-attribute-label', '$sAttrLabel');
+						$(td).attr('data-object-class', `$sClassName`);
+						$(td).attr('data-attribute-label', `$sAttLabel`);
 						if (rowData["$sClassAlias/$sAttCode/raw"]) {
 							$(td).attr('data-value-raw', rowData["$sClassAlias/$sAttCode/raw"]);
 		                }
@@ -836,10 +836,10 @@ JS;
 							"_"       => $sClassAlias."/".$sAttCode,
 						];
 						$aColumnDefinition["createdCell"] = <<<JS
-						$(td).attr('data-object-class', '$sClassName');
-						$(td).attr('data-attribute-label', '$sAttrLabel');
-						$(td).attr('data-attribute-code', '$sAttCode');
-						$(td).attr('data-attribute-type', '$sAttDefClass');
+						$(td).attr('data-object-class', `$sClassName`);
+						$(td).attr('data-attribute-label', `$sAttLabel`);
+						$(td).attr('data-attribute-code', `$sAttCode`);
+						$(td).attr('data-attribute-type', `$sAttDefClass`);
 						if (rowData["$sClassAlias/$sAttCode/raw"]) {
 							$(td).attr('data-value-raw', rowData["$sClassAlias/$sAttCode/raw"]);
 		                }


### PR DESCRIPTION
_Internal_

Use backticks to avoid escaping simple/double quotes as these parts are not in TWIG yet.
Another approach could have been to "json_encode" variables first, but I find the backticks easier to read.