### PR TITLE
N°6852 - Missing configuration forgot_password_from

### DIFF
--- a/application/loginwebpage.class.inc.php
+++ b/application/loginwebpage.class.inc.php
@@ -248,6 +248,7 @@ class LoginWebPage extends NiceWebPage
 				$oEmail = new Email();
 				$oEmail->SetRecipientTO($sTo);
 				$sFrom = MetaModel::GetConfig()->Get('forgot_password_from');
+				$sFrom = utils::IsNullOrEmptyString($sFrom) ? MetaModel::GetConfig()->Get('email_default_sender_address') : $sFrom;
 				$oEmail->SetRecipientFrom($sFrom);
 				$oEmail->SetSubject(Dict::S('UI:ResetPwd-EmailSubject', $oUser->Get('login')));
 				$sResetUrl = utils::GetAbsoluteUrlAppRoot().'pages/UI.php?loginop=reset_pwd&auth_user='.urlencode($oUser->Get('login')).'&token='.urlencode($sToken);


### PR DESCRIPTION
Fix for the ticket https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=6852&

Forgot password emails are sent using "email_default_sender_address" if the "forgot_password_from" field is empty.