### PR TITLE
N°6975 ItopCustomDatamodelTestCase VS symlinks flag

### DIFF
--- a/tests/php-unit-tests/src/BaseTestCase/ItopCustomDatamodelTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopCustomDatamodelTestCase.php
@@ -11,8 +11,8 @@ use Combodo\iTop\Test\UnitTest\Hook\TestsRunStartHook;
 use Combodo\iTop\Test\UnitTest\Service\UnitTestRunTimeEnvironment;
 use Config;
 use Exception;
-use IssueLog;
 use MetaModel;
+use MFCompiler;
 use SetupUtils;
 use utils;
 
@@ -181,7 +181,7 @@ abstract class ItopCustomDatamodelTestCase extends ItopDataTestCase
 			// - Compile env. based on the existing 'production' env.
 			$oEnvironment = new UnitTestRunTimeEnvironment($sTestEnv);
 			$oEnvironment->WriteConfigFileSafe($oTestConfig);
-			$oEnvironment->CompileFrom($sSourceEnv, false);
+			$oEnvironment->CompileFrom($sSourceEnv, MFCompiler::IsUseSymbolicLinksFlagPresent());
 
 			// - Force re-creating a fresh DB
 			CMDBSource::InitFromConfig($oTestConfig);

--- a/tests/php-unit-tests/src/BaseTestCase/ItopCustomDatamodelTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopCustomDatamodelTestCase.php
@@ -12,7 +12,6 @@ use Combodo\iTop\Test\UnitTest\Service\UnitTestRunTimeEnvironment;
 use Config;
 use Exception;
 use MetaModel;
-use MFCompiler;
 use SetupUtils;
 use utils;
 
@@ -181,7 +180,7 @@ abstract class ItopCustomDatamodelTestCase extends ItopDataTestCase
 			// - Compile env. based on the existing 'production' env.
 			$oEnvironment = new UnitTestRunTimeEnvironment($sTestEnv);
 			$oEnvironment->WriteConfigFileSafe($oTestConfig);
-			$oEnvironment->CompileFrom($sSourceEnv, MFCompiler::IsUseSymbolicLinksFlagPresent());
+			$oEnvironment->CompileFrom($sSourceEnv);
 
 			// - Force re-creating a fresh DB
 			CMDBSource::InitFromConfig($oTestConfig);


### PR DESCRIPTION
ItopCustomDatamodelTestCase was added in 2.7.9 / 3.0.3 / 3.1.0
When preparing the test env the compilation is made with the symlink param always set to false. 
Since iTop 3.0.0 we have a symlink flag persisted on disk (N°4092), that is present by default in the iTop repo.
When working with the repo, executing a ItopCustomDatamodelTestCase  leads to removing this flag :(

This is now fixed.