### PR TITLE
N°6976 Fix DeprecatedCallsLog error handler never set

### DIFF
--- a/approot.inc.php
+++ b/approot.inc.php
@@ -26,8 +26,10 @@ define('ITOP_DESIGN_LATEST_VERSION', '3.0');
 define('ITOP_CORE_VERSION', '3.0.3');
 
 /**
- * @since 3.0.4 N°6274 Allow to test if PHPUnit is currently running. Starting with PHPUnit 9.5 we'll be able to replace it with $GLOBALS['phpunit_version']
+ * @var string
+ * @since 3.0.4 3.1.0 3.2.0 N°6274 Allow to test if PHPUnit is currently running. Starting with PHPUnit 9.5 we'll be able to replace it with $GLOBALS['phpunit_version']
+ * @since 3.0.4 3.1.1 3.2.0 N°6976 Fix constant name (DeprecatedCallsLog error handler was never set)
  */
-define('ITOP_PHPUNIT_RUNNING_CONSTANT_NAME', 'ITOP_PHPUNIT_RUNNING');
+const ITOP_PHPUNIT_RUNNING_CONSTANT_NAME = 'ITOP_PHPUNIT_RUNNING';
 
 require_once APPROOT.'bootstrap.inc.php';

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -1080,7 +1080,7 @@ class DeprecatedCallsLog extends LogAPI
 		parent::Enable($sTargetFile);
 
 		if (
-			(false === defined('ITOP_PHPUNIT_RUNNING_CONSTANT_NAME'))
+			(false === defined(ITOP_PHPUNIT_RUNNING_CONSTANT_NAME))
 			&& static::IsLogLevelEnabledSafe(self::LEVEL_WARNING, self::ENUM_CHANNEL_PHP_LIBMETHOD)
 		) {
 			set_error_handler([static::class, 'DeprecatedNoticesErrorHandler'], E_DEPRECATED | E_USER_DEPRECATED);

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -1086,7 +1086,10 @@ class DeprecatedCallsLog extends LogAPI
 		parent::Enable($sTargetFile);
 
 		if (
-			(false === defined(ITOP_PHPUNIT_RUNNING_CONSTANT_NAME))
+			(
+				(false === defined(ITOP_PHPUNIT_RUNNING_CONSTANT_NAME))
+				|| (defined(ITOP_PHPUNIT_RUNNING_CONSTANT_NAME) && (constant(ITOP_PHPUNIT_RUNNING_CONSTANT_NAME) !== true))
+			)
 			&& static::IsLogLevelEnabledSafe(self::LEVEL_WARNING, self::ENUM_CHANNEL_PHP_LIBMETHOD)
 		) {
 			IssueLog::Trace('Setting '.static::class.' error handler to catch DEPRECATED', static::ENUM_CHANNEL_PHP_LIBMETHOD);

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -1037,6 +1037,12 @@ class DeprecatedCallsLog extends LogAPI
 	public const ENUM_CHANNEL_FILE = 'deprecated-file';
 	public const CHANNEL_DEFAULT = self::ENUM_CHANNEL_PHP_METHOD;
 
+	/**
+	 * @var string
+	 * @since 3.0.4 3.1.1 3.2.0 N°6976
+	 */
+	public const LOG_DEPRECATED_CALLS_LOG_FILENAME = 'log/deprecated-calls.log';
+
 	/** @var string Warning this constant won't be used directly ! To see the real default level check {@see GetLevelDefault()} */
 	public const LEVEL_DEFAULT = self::LEVEL_ERROR;
 
@@ -1075,7 +1081,7 @@ class DeprecatedCallsLog extends LogAPI
 	 */
 	public static function Enable($sTargetFile = null): void {
 		if (empty($sTargetFile)) {
-			$sTargetFile = APPROOT.'log/deprecated-calls.log';
+			$sTargetFile = APPROOT. self::LOG_DEPRECATED_CALLS_LOG_FILENAME;
 		}
 		parent::Enable($sTargetFile);
 

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -1089,6 +1089,7 @@ class DeprecatedCallsLog extends LogAPI
 			(false === defined(ITOP_PHPUNIT_RUNNING_CONSTANT_NAME))
 			&& static::IsLogLevelEnabledSafe(self::LEVEL_WARNING, self::ENUM_CHANNEL_PHP_LIBMETHOD)
 		) {
+			IssueLog::Trace('Setting '.static::class.' error handler to catch DEPRECATED', static::ENUM_CHANNEL_PHP_LIBMETHOD);
 			set_error_handler([static::class, 'DeprecatedNoticesErrorHandler'], E_DEPRECATED | E_USER_DEPRECATED);
 		}
 	}

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -1037,12 +1037,6 @@ class DeprecatedCallsLog extends LogAPI
 	public const ENUM_CHANNEL_FILE = 'deprecated-file';
 	public const CHANNEL_DEFAULT = self::ENUM_CHANNEL_PHP_METHOD;
 
-	/**
-	 * @var string
-	 * @since 3.0.4 3.1.1 3.2.0 N°6976
-	 */
-	public const LOG_DEPRECATED_CALLS_LOG_FILENAME = 'log/deprecated-calls.log';
-
 	/** @var string Warning this constant won't be used directly ! To see the real default level check {@see GetLevelDefault()} */
 	public const LEVEL_DEFAULT = self::LEVEL_ERROR;
 
@@ -1081,7 +1075,7 @@ class DeprecatedCallsLog extends LogAPI
 	 */
 	public static function Enable($sTargetFile = null): void {
 		if (empty($sTargetFile)) {
-			$sTargetFile = APPROOT. self::LOG_DEPRECATED_CALLS_LOG_FILENAME;
+			$sTargetFile = APPROOT.'log/deprecated-calls.log';
 		}
 		parent::Enable($sTargetFile);
 

--- a/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
@@ -7,6 +7,7 @@
 namespace Combodo\iTop\Test\UnitTest;
 
 use CMDBSource;
+use DeprecatedCallsLog;
 use MySQLTransactionNotClosedException;
 use PHPUnit\Framework\TestCase;
 use SetupUtils;
@@ -24,6 +25,12 @@ define('DEBUG_UNIT_TEST', true);
 abstract class ItopTestCase extends TestCase
 {
 	public const TEST_LOG_DIR = 'test';
+
+	/**
+	 * @var bool
+	 * @since 3.0.4 3.1.1 3.2.0 N°6976 Allow to enable/disable {@see DeprecatedCallsLog} error handler
+	 */
+	public const DISABLE_DEPRECATEDCALLSLOG_ERRORHANDLER = true;
 	public static $DEBUG_UNIT_TEST = false;
 	protected static $aBackupStaticProperties = [];
 
@@ -46,7 +53,8 @@ abstract class ItopTestCase extends TestCase
 
 		require_once static::GetAppRoot() . 'approot.inc.php';
 
-		if (false === defined(ITOP_PHPUNIT_RUNNING_CONSTANT_NAME)) {
+		if ((static::DISABLE_DEPRECATEDCALLSLOG_ERRORHANDLER)
+			&& (false === defined(ITOP_PHPUNIT_RUNNING_CONSTANT_NAME))) {
 			// setUp might be called multiple times, so protecting the define() call !
 			define(ITOP_PHPUNIT_RUNNING_CONSTANT_NAME, true);
 		}

--- a/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
@@ -46,9 +46,9 @@ abstract class ItopTestCase extends TestCase
 
 		require_once static::GetAppRoot() . 'approot.inc.php';
 
-		if (false === defined('ITOP_PHPUNIT_RUNNING_CONSTANT_NAME')) {
+		if (false === defined(ITOP_PHPUNIT_RUNNING_CONSTANT_NAME)) {
 			// setUp might be called multiple times, so protecting the define() call !
-			define('ITOP_PHPUNIT_RUNNING_CONSTANT_NAME', true);
+			define(ITOP_PHPUNIT_RUNNING_CONSTANT_NAME, true);
 		}
 	}
 

--- a/tests/php-unit-tests/unitary-tests/core/Log/DeprecatedCallsLogErrorHandlerTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/Log/DeprecatedCallsLogErrorHandlerTest.php
@@ -15,6 +15,7 @@ use IssueLog;
 use LogAPI;
 use utils;
 use const E_USER_DEPRECATED;
+use const ITOP_PHPUNIT_RUNNING_CONSTANT_NAME;
 
 class DeprecatedCallsLogErrorHandlerTest extends ItopTestCase {
 	public const DISABLE_DEPRECATEDCALLSLOG_ERRORHANDLER = false;
@@ -22,8 +23,15 @@ class DeprecatedCallsLogErrorHandlerTest extends ItopTestCase {
 	/**
 	 * @covers DeprecatedCallsLog::DeprecatedNoticesErrorHandler
 	 * @since 3.0.4 3.1.1 3.2.0 N°6976
+	 *
+	 * @runInSeparateProcess so that other tests won't set the constant !
 	 */
 	public function testPhpLibMethodNoticeCatched():void {
+		if (defined(ITOP_PHPUNIT_RUNNING_CONSTANT_NAME)) {
+			// Should not happen thanks to the process isolation !
+			$this->fail('Constant to disable error handler is set, so we cannot test :(');
+		}
+
 		$sNoticeMessage = __METHOD__.uniqid(' @trigger_error unique message - ', true);
 
 		// to check that error handler is really set

--- a/tests/php-unit-tests/unitary-tests/core/Log/DeprecatedCallsLogErrorHandlerTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/Log/DeprecatedCallsLogErrorHandlerTest.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * @copyright   Copyright (C) 2010-2023 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\Test\UnitTest\Core\Log;
+
+
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+use DeprecatedCallsLog;
+use LogAPI;
+use utils;
+use const APPROOT;
+use const E_USER_DEPRECATED;
+
+class DeprecatedCallsLogErrorHandlerTest extends ItopTestCase {
+	public const DISABLE_DEPRECATEDCALLSLOG_ERRORHANDLER = false;
+
+	/**
+	 * @covers DeprecatedCallsLog::DeprecatedNoticesErrorHandler
+	 * @since 3.0.4 3.1.1 3.2.0 N°6976
+	 */
+	public function testPhpLibMethodNoticeCatched():void {
+		$oConfig = utils::GetConfig(true);
+		$oConfig->Set('log_level_min', [\DeprecatedCallsLog::ENUM_CHANNEL_PHP_LIBMETHOD => LogAPI::LEVEL_WARNING]);
+
+		$this->RequireOnceItopFile('core/log.class.inc.php');
+		DeprecatedCallsLog::Enable(); // will set error handler
+
+		$sNoticeMessage = __METHOD__.uniqid(' @trigger_error unique message - ', true);
+		@trigger_error($sNoticeMessage, E_USER_DEPRECATED);
+
+		// no notice when running in PHPUnit
+		$sDeprecatedCallsLogFileContent = file_get_contents(APPROOT.DeprecatedCallsLog::LOG_DEPRECATED_CALLS_LOG_FILENAME);
+		$this->assertStringContainsString($sNoticeMessage, $sDeprecatedCallsLogFileContent);
+	}
+}


### PR DESCRIPTION
With N°6274 we added a constant to be able to remove the DeprecatedCallsLog error handler when running tests, because this error handler was removing PHPUnit's one.
The code was disfunctional : DeprecatedCallsLog error handler was never set anymore :(

This PR restores the expected behavior : 
- when running PHPUnit, DeprecatedCallsLog won't set an error handler
- but it will on any other case 