### PR TITLE
N°7021 - Fix error log and useless compilation time due to SCSS file unnecessary compilation

### DIFF
--- a/sources/Application/WebPage/NiceWebPage.php
+++ b/sources/Application/WebPage/NiceWebPage.php
@@ -242,13 +242,6 @@ JS
 		// TODO 3.0.0: Reuse theming mechanism for Full Moon
 		$sCssThemeUrl = ThemeHandler::GetCurrentThemeUrl();
 		$this->add_linked_stylesheet($sCssThemeUrl);
-
-		$sCssRelPath = utils::GetCSSFromSASS(
-			'css/backoffice/main.scss',
-			array(
-				APPROOT.'css/backoffice/',
-			)
-		);
 	}
 
 	protected function GetReadyScriptsStartedTrigger(): ?string


### PR DESCRIPTION
Removed useless call to GetCSSFromSASS that creates troubles (log error + unecessary compiling time every time user visits a new page on iTop) if iTop can't write in css/backoffice/ directory