### PR TITLE
 N°7055 - Apply better default value for portal copy object link

### DIFF
--- a/datamodels/2.x/itop-portal-base/dictionaries/cs.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/cs.dict.itop-portal-base.php
@@ -135,7 +135,7 @@ Dict::Add('CS CZ', 'Czech', 'Čeština', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s uloženo',
 	'Brick:Portal:Object:Search:Regular:Title' => 'Vybrat %1$s (%2$s)',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => 'Vybrat %1$s (%2$s)',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Zkopíruj odkaz na objekt',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Zkopírováno'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/da.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/da.dict.itop-portal-base.php
@@ -135,7 +135,7 @@ Dict::Add('DA DA', 'Danish', 'Dansk', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s saved~~',
 	'Brick:Portal:Object:Search:Regular:Title' => 'Select %1$s (%2$s)~~',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => 'Select %1$s (%2$s)~~',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s~~',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Copy object link~~',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Copied~~'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/de.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/de.dict.itop-portal-base.php
@@ -135,7 +135,7 @@ Dict::Add('DE DE', 'German', 'Deutsch', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s gespeichert',
 	'Brick:Portal:Object:Search:Regular:Title' => 'Select %1$s (%2$s)',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => 'Select %1$s (%2$s)',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Objektverknüpfung kopieren',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Kopiert'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/en.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/en.dict.itop-portal-base.php
@@ -136,7 +136,7 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s saved',
 	'Brick:Portal:Object:Search:Regular:Title' => 'Select %1$s (%2$s)',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => 'Select %1$s (%2$s)',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Copy object link',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Copied'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/es_cr.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/es_cr.dict.itop-portal-base.php
@@ -139,7 +139,7 @@ Dict::Add('ES CR', 'Spanish', 'Español, Castellano', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s guardado',
 	'Brick:Portal:Object:Search:Regular:Title' => 'Selección %1$s (%2$s)',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => 'Selección %1$s (%2$s)',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Copiar liga al objeto',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Copiado'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/fr.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/fr.dict.itop-portal-base.php
@@ -135,7 +135,7 @@ Dict::Add('FR FR', 'French', 'Français', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s enregistré(e)',
 	'Brick:Portal:Object:Search:Regular:Title' => 'Sélection de %1$s (%2$s)',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => 'Sélection de %1$s (%2$s)',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Copier l\'url de l\'objet',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Copié'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/hu.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/hu.dict.itop-portal-base.php
@@ -135,7 +135,7 @@ Dict::Add('HU HU', 'Hungarian', 'Magyar', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s mentve',
 	'Brick:Portal:Object:Search:Regular:Title' => '%1$s kiválasztása (%2$s)',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => '%1$s kiválasztása (%2$s)',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Objektum hivatkozás másolása',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Másolva'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/it.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/it.dict.itop-portal-base.php
@@ -135,7 +135,7 @@ Dict::Add('IT IT', 'Italian', 'Italiano', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s saved~~',
 	'Brick:Portal:Object:Search:Regular:Title' => 'Select %1$s (%2$s)~~',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => 'Select %1$s (%2$s)~~',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s~~',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Copy object link~~',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Copied~~'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/ja.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/ja.dict.itop-portal-base.php
@@ -135,7 +135,7 @@ Dict::Add('JA JP', 'Japanese', '日本語', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s saved~~',
 	'Brick:Portal:Object:Search:Regular:Title' => 'Select %1$s (%2$s)~~',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => 'Select %1$s (%2$s)~~',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s~~',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Copy object link~~',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Copied~~'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/nl.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/nl.dict.itop-portal-base.php
@@ -138,7 +138,7 @@ Dict::Add('NL NL', 'Dutch', 'Nederlands', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s opgeslagen',
 	'Brick:Portal:Object:Search:Regular:Title' => 'Geselecteerd %1$s (%2$s)',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => 'Selecteer %1$s (%2$s)',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Kopieer link naar object',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Gekopieerd'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/pl.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/pl.dict.itop-portal-base.php
@@ -135,7 +135,7 @@ Dict::Add('PL PL', 'Polish', 'Polski', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s zapisany',
 	'Brick:Portal:Object:Search:Regular:Title' => 'Wybierz %1$s (%2$s)',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => 'Wybierz %1$s (%2$s)',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Skopiuj obiekt',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Skopiowano'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/pt_br.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/pt_br.dict.itop-portal-base.php
@@ -135,7 +135,7 @@ Dict::Add('PT BR', 'Brazilian', 'Brazilian', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s salvo',
 	'Brick:Portal:Object:Search:Regular:Title' => 'Selecionar %1$s (%2$s)',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => 'Selecinar %1$s (%2$s)',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Copiar',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Copiado'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/ru.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/ru.dict.itop-portal-base.php
@@ -144,7 +144,7 @@ Dict::Add('RU RU', 'Russian', 'Русский', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s сохранено',
 	'Brick:Portal:Object:Search:Regular:Title' => 'Выбрать %1$s (%2$s)',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => 'Выбрать %1$s (%2$s)',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Скопировать ссылку на объект',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Ссылка скопирована'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/sk.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/sk.dict.itop-portal-base.php
@@ -135,7 +135,7 @@ Dict::Add('SK SK', 'Slovak', 'Slovenčina', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s saved~~',
 	'Brick:Portal:Object:Search:Regular:Title' => 'Select %1$s (%2$s)~~',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => 'Select %1$s (%2$s)~~',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s~~',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Copy object link~~',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Copied~~'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/tr.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/tr.dict.itop-portal-base.php
@@ -135,7 +135,7 @@ Dict::Add('TR TR', 'Turkish', 'Türkçe', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '%1$s saved~~',
 	'Brick:Portal:Object:Search:Regular:Title' => 'Select %1$s (%2$s)~~',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => 'Select %1$s (%2$s)~~',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s~~',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => 'Copy object link~~',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => 'Copied~~'
 ));

--- a/datamodels/2.x/itop-portal-base/dictionaries/zh_cn.dict.itop-portal-base.php
+++ b/datamodels/2.x/itop-portal-base/dictionaries/zh_cn.dict.itop-portal-base.php
@@ -135,7 +135,7 @@ Dict::Add('ZH CN', 'Chinese', '简体中文', array(
 	'Brick:Portal:Object:Form:Message:ObjectSaved' => '已保存%1$s~~',
 	'Brick:Portal:Object:Search:Regular:Title' => '选择%1$s (%2$s)',
 	'Brick:Portal:Object:Search:Hierarchy:Title' => '选择%1$s (%2$s)',
-	'Brick:Portal:Object:Copy:TextToCopy' => '%1$s: %2$s',
+	'Brick:Portal:Object:Copy:TextToCopy' => '%2$s',
 	'Brick:Portal:Object:Copy:Tooltip' => '复制对象链接',
 	'Brick:Portal:Object:Copy:CopiedTooltip' => '已复制'
 ));


### PR DESCRIPTION
The default text added to the clipboard when clicking "Copy object link" on the portal is `<object friendlyname>: <object portal URL>`. This seems not useful in most cases, so this is my proposal to change that to simply `<object portal URL>`.

In the scenario users still want the old text, they can adapt the dictionary item in the designer or with an extension.