### PR TITLE
N°7052 synchro_import.php: fix undefined offset notices

### DIFF
--- a/synchro/synchro_import.php
+++ b/synchro/synchro_import.php
@@ -469,6 +469,8 @@ try
 	$aIsBinaryToTransform = array();
 	foreach ($aInputColumns as $iFieldId => $sInputColumn)
 	{
+		$aIsBinaryToTransform[$iFieldId] = false;
+
 		if (array_key_exists($sInputColumn, $aDateColumns))
 		{
 			$aIsDateToTransform[$iFieldId] = $aDateColumns[$sInputColumn]; // either DATE or DATETIME
@@ -488,7 +490,8 @@ try
 		{
 			throw new ExchangeException("Unknown column '$sInputColumn' (class: '$sClass')");
 		}
-		$aIsBinaryToTransform[$iFieldId] = $aColumns[$sInputColumn] === 'LONGBLOB';
+
+		$aIsBinaryToTransform[$iFieldId] = ($aColumns[$sInputColumn] === 'LONGBLOB');
 	}
 	if (!isset($iPrimaryKeyCol))
 	{


### PR DESCRIPTION
With #269 was added in 3.0.1 iTop version, in the `/synchro/synchro_import.php` script the `$aIsBinaryToTransform` variable. But :
- when reading the header columns, the array is set only for certain columns
- whereas when reading data the array is accessed on all columns indexes

The fix is to set the array for every columns indexes.