### PR TITLE
N°7085 - Fix infinite loop in login page until fatal error occurs

### DIFF
--- a/application/logindefault.class.inc.php
+++ b/application/logindefault.class.inc.php
@@ -119,8 +119,8 @@ class LoginDefaultAfter extends AbstractLoginFSMExtension implements iLogoutExte
 		unset($_SESSION['login_temp_auth_user']);
 		if (is_null(UserRights::GetUserObject())){
 			//N°7085 avoid infinite loop
-			IssueLog::Error("No user logged on. exit");
-			exit;
+			IssueLog::Error("No user logged in. exit");
+			exit(-1);
 		}
 		return LoginWebPage::LOGIN_FSM_CONTINUE;
 	}

--- a/application/logindefault.class.inc.php
+++ b/application/logindefault.class.inc.php
@@ -117,6 +117,11 @@ class LoginDefaultAfter extends AbstractLoginFSMExtension implements iLogoutExte
 	protected function OnConnected(&$iErrorCode)
 	{
 		unset($_SESSION['login_temp_auth_user']);
+		if (is_null(UserRights::GetUserObject())){
+			//N°7085 avoid infinite loop
+			IssueLog::Error("No user logged on. exit");
+			exit;
+		}
 		return LoginWebPage::LOGIN_FSM_CONTINUE;
 	}
 

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1911,10 +1911,12 @@ class Config
 	public function AddAllowedLoginTypes($sLoginMode)
 	{
 		$aAllowedLoginTypes = $this->GetAllowedLoginTypes();
-		if (! in_array($sLoginMode, $aAllowedLoginTypes)){
-			$aAllowedLoginTypes[] = $sLoginMode;
-			$this->SetAllowedLoginTypes($aAllowedLoginTypes);
+		if (in_array($sLoginMode, $aAllowedLoginTypes)){
+			return;
 		}
+
+		$aAllowedLoginTypes[] = $sLoginMode;
+		$this->SetAllowedLoginTypes($aAllowedLoginTypes);
 	}
 
 	public function SetExternalAuthenticationVariable($sExtAuthVariable)

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1626,7 +1626,7 @@ class Config
 		}
 		if (strlen($sNoise) > 0)
 		{
-			// Note: sNoise is an html output, but so far it was ok for me (e.g. showing the entire call stack) 
+			// Note: sNoise is an html output, but so far it was ok for me (e.g. showing the entire call stack)
 			throw new ConfigException('Syntax error in configuration file',
 				array('file' => $sConfigFile, 'error' => '<tt>'.htmlentities($sNoise, ENT_QUOTES, 'UTF-8').'</tt>'));
 		}
@@ -1899,6 +1899,22 @@ class Config
 	public function SetAllowedLoginTypes($aAllowedLoginTypes)
 	{
 		$this->m_sAllowedLoginTypes = implode('|', $aAllowedLoginTypes);
+	}
+
+	/**
+	 * @since 2.7.11 N°7085
+	 * Add login mode if not configured already
+	 * @param string $sLoginMode
+	 *
+	 * @return void
+	 */
+	public function AddAllowedLoginTypes($sLoginMode)
+	{
+		$aAllowedLoginTypes = $this->GetAllowedLoginTypes();
+		if (! in_array($sLoginMode, $aAllowedLoginTypes)){
+			$aAllowedLoginTypes[] = $sLoginMode;
+			$this->SetAllowedLoginTypes($aAllowedLoginTypes);
+		}
 	}
 
 	public function SetExternalAuthenticationVariable($sExtAuthVariable)
@@ -2420,7 +2436,7 @@ class ConfigPlaceholdersResolver
 		}
 
 		$sPattern = '/\%(env|server)\((\w+)\)(?:\?:(\w*))?\%/'; //3 capturing groups, ie `%env(HTTP_PORT)?:8080%` produce: `env` `HTTP_PORT` and `8080`.
-		
+
 		if (! preg_match_all($sPattern, $rawValue, $aMatchesCollection, PREG_SET_ORDER))
 		{
 			return $rawValue;

--- a/tests/php-unit-tests/unitary-tests/application/LoginTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/LoginTest.php
@@ -22,9 +22,9 @@ class LoginTest extends ItopDataTestCase {
 		$this->sLoginMode = "unimplemented_loginmode";
 		$oConfig->AddAllowedLoginTypes($this->sLoginMode);
 
-		@chmod($oConfig->GetLoadedFile(), 0770);
+		@chmod($sConfigPath, 0770);
 		$oConfig->WriteToFile();
-		@chmod($oConfig->GetLoadedFile(), 0440);
+		@chmod($sConfigPath, 0440);
 	}
 
 	protected function tearDown(): void {
@@ -34,7 +34,7 @@ class LoginTest extends ItopDataTestCase {
 			//put config back
 			$sConfigPath = MetaModel::GetConfig()->GetLoadedFile();
 			$oConfig = new \Config($this->sConfigTmpBackupFile);
-			@chmod($oConfig->GetLoadedFile(), 0770);
+			@chmod($sConfigPath, 0770);
 			$oConfig->WriteToFile($sConfigPath);
 			@chmod($sConfigPath, 0440);
 		}

--- a/tests/php-unit-tests/unitary-tests/application/LoginTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/LoginTest.php
@@ -6,6 +6,7 @@ use MetaModel;
 
 class LoginTest extends ItopDataTestCase {
 	protected $sConfigTmpBackupFile;
+	protected $sConfigPath;
 	protected $sLoginMode;
 
 	protected function setUp(): void {
@@ -14,30 +15,28 @@ class LoginTest extends ItopDataTestCase {
 		clearstatcache();
 
 		//backup config file
-		$sConfigPath = MetaModel::GetConfig()->GetLoadedFile();
+		$this->sConfigPath = MetaModel::GetConfig()->GetLoadedFile();
 		$this->sConfigTmpBackupFile = tempnam(sys_get_temp_dir(), "config_");
-		MetaModel::GetConfig()->WriteToFile($this->sConfigTmpBackupFile);
+		file_put_contents($this->sConfigTmpBackupFile, file_get_contents($this->sConfigPath));
 
-		$oConfig = new \Config($sConfigPath);
+		$oConfig = new \Config($this->sConfigPath);
 		$this->sLoginMode = "unimplemented_loginmode";
 		$oConfig->AddAllowedLoginTypes($this->sLoginMode);
 
-		@chmod($sConfigPath, 0770);
+		@chmod($this->sConfigPath, 0770);
 		$oConfig->WriteToFile();
-		@chmod($sConfigPath, 0440);
+		@chmod($this->sConfigPath, 0440);
 	}
 
 	protected function tearDown(): void {
-		parent::tearDown();
-
 		if (! is_null($this->sConfigTmpBackupFile) && is_file($this->sConfigTmpBackupFile)){
 			//put config back
-			$sConfigPath = MetaModel::GetConfig()->GetLoadedFile();
-			$oConfig = new \Config($this->sConfigTmpBackupFile);
-			@chmod($sConfigPath, 0770);
-			$oConfig->WriteToFile($sConfigPath);
-			@chmod($sConfigPath, 0440);
+			@chmod($this->sConfigPath, 0770);
+			file_put_contents($this->sConfigPath, file_get_contents($this->sConfigTmpBackupFile));
+			@chmod($this->sConfigPath, 0440);
+			@unlink($this->sConfigTmpBackupFile);
 		}
+		parent::tearDown();
 	}
 
 	public function testLoginInfiniteLoopFix() {

--- a/tests/php-unit-tests/unitary-tests/application/LoginTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/LoginTest.php
@@ -4,13 +4,6 @@ namespace Combodo\iTop\Test\UnitTest\Application;
 use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
 use MetaModel;
 
-/**
- *
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
- * @backupGlobals disabled
- *
- */
 class LoginTest extends ItopDataTestCase {
 	protected $sConfigTmpBackupFile;
 	protected $sConfigPath;
@@ -21,7 +14,8 @@ class LoginTest extends ItopDataTestCase {
 
 		clearstatcache();
 
-		//backup config file
+		// The test consists in requesting UI.php from outside iTop with a specific configuration
+		// Hence the configuration file must be tweaked on disk (and restored)
 		$this->sConfigPath = MetaModel::GetConfig()->GetLoadedFile();
 		$this->sConfigTmpBackupFile = tempnam(sys_get_temp_dir(), "config_");
 		file_put_contents($this->sConfigTmpBackupFile, file_get_contents($this->sConfigPath));

--- a/tests/php-unit-tests/unitary-tests/application/LoginTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/LoginTest.php
@@ -34,6 +34,7 @@ class LoginTest extends ItopDataTestCase {
 			//put config back
 			$sConfigPath = MetaModel::GetConfig()->GetLoadedFile();
 			$oConfig = new \Config($this->sConfigTmpBackupFile);
+			@chmod($oConfig->GetLoadedFile(), 0770);
 			$oConfig->WriteToFile($sConfigPath);
 			@chmod($sConfigPath, 0440);
 		}

--- a/tests/php-unit-tests/unitary-tests/application/LoginTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/LoginTest.php
@@ -1,0 +1,66 @@
+<?php
+namespace Combodo\iTop\Test\UnitTest\Application;
+
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use MetaModel;
+
+class LoginTest extends ItopDataTestCase {
+	protected $sConfigTmpBackupFile;
+	protected $sLoginMode;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		clearstatcache();
+
+		//backup config file
+		$sConfigPath = MetaModel::GetConfig()->GetLoadedFile();
+		$this->sConfigTmpBackupFile = tempnam(sys_get_temp_dir(), "config_");
+		MetaModel::GetConfig()->WriteToFile($this->sConfigTmpBackupFile);
+
+		$oConfig = new \Config($sConfigPath);
+		$this->sLoginMode = "unimplemented_loginmode";
+		$oConfig->AddAllowedLoginTypes($this->sLoginMode);
+
+		@chmod($oConfig->GetLoadedFile(), 0770);
+		$oConfig->WriteToFile();
+		@chmod($oConfig->GetLoadedFile(), 0440);
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		if (! is_null($this->sConfigTmpBackupFile) && is_file($this->sConfigTmpBackupFile)){
+			//put config back
+			$sConfigPath = MetaModel::GetConfig()->GetLoadedFile();
+			$oConfig = new \Config($this->sConfigTmpBackupFile);
+			$oConfig->WriteToFile($sConfigPath);
+			@chmod($sConfigPath, 0440);
+		}
+	}
+
+	public function testLoginInfiniteLoopFix() {
+		$iTimeStamp = microtime(true);
+		$sOutput = $this->CallItopUrlByCurl(sprintf("/pages/UI.php?login_mode=%s", $this->sLoginMode));
+		$iElapsedInMs =  (microtime(true) - $iTimeStamp) * 1000;
+		$sMaxExecutionInS = 1;
+		$this->assertTrue($iElapsedInMs < $sMaxExecutionInS * 1000, "iTop answered in $iElapsedInMs ms. it should do it in less than $sMaxExecutionInS seconds (max_execution_time)");
+		$this->assertFalse(strpos($sOutput, "Fatal error"), "no fatal error due to max execution time should be returned" . $sOutput);
+	}
+
+	protected function CallItopUrlByCurl($sUri, ?array $aPostFields=[]){
+		$ch = curl_init();
+
+		$sUrl = MetaModel::GetConfig()->Get('app_root_url') . "/$sUri";
+		curl_setopt($ch, CURLOPT_URL, $sUrl);
+		if (0 !== sizeof($aPostFields)){
+			curl_setopt($ch, CURLOPT_POST, 1);// set post data to true
+			curl_setopt($ch, CURLOPT_POSTFIELDS, $aPostFields);
+		}
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		$sOutput = curl_exec($ch);
+		curl_close ($ch);
+
+		return $sOutput;
+	}
+}

--- a/tests/php-unit-tests/unitary-tests/application/LoginTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/LoginTest.php
@@ -4,6 +4,13 @@ namespace Combodo\iTop\Test\UnitTest\Application;
 use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
 use MetaModel;
 
+/**
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ * @backupGlobals disabled
+ *
+ */
 class LoginTest extends ItopDataTestCase {
 	protected $sConfigTmpBackupFile;
 	protected $sConfigPath;


### PR DESCRIPTION
When iTop authentication is badly configured, login page can lead to a fatal error page (after loading for a while).
![image](https://github.com/Combodo/iTop/assets/56586767/70c150d1-d3c9-491e-8775-b5c3c9bf624c)



Current PR avoids iTop to be trapped in an infinite loop. the application will answer immediately instead (white page).

To reproduce:
- configure a dummy login mode in iTop configuration
`'allowed_login_types' => 'form|external|dummy_login_mode|basic',`

- call iTop/pages/UI.php?login_mode=dummy_login_mode URL

