### PR TITLE
N°7122 - Portal: Hide log off button when user can't actually log off (eg. SSO using SAML or other providers)

### DIFF
--- a/datamodels/2.x/itop-portal-base/portal/src/EventListener/UserProvider.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/EventListener/UserProvider.php
@@ -93,7 +93,7 @@ class UserProvider implements ContainerAwareInterface
 		$this->oContainer->set('combodo.current_user', $oUser);
 
         // User allowed to log off or not
-        $this->oContainer->set('combodo.current_user.can_logff', utils::CanLogOff());
+        $this->oContainer->set('combodo.current_user.can_logoff', utils::CanLogOff());
 
 		// Allowed portals
 		$aAllowedPortals = UserRights::GetAllowedPortals();

--- a/datamodels/2.x/itop-portal-base/portal/src/EventListener/UserProvider.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/EventListener/UserProvider.php
@@ -29,6 +29,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use UserRights;
+use utils;
 
 /**
  * Class UserProvider
@@ -90,6 +91,9 @@ class UserProvider implements ContainerAwareInterface
 			throw new Exception('Could not load connected user.');
 		}
 		$this->oContainer->set('combodo.current_user', $oUser);
+
+        // User allowed to log off or not
+        $this->oContainer->set('combodo.current_user.can_logff', utils::CanLogOff());
 
 		// Allowed portals
 		$aAllowedPortals = UserRights::GetAllowedPortals();

--- a/datamodels/2.x/itop-portal-base/portal/templates/layout.html.twig
+++ b/datamodels/2.x/itop-portal-base/portal/templates/layout.html.twig
@@ -3,7 +3,7 @@
 
 {% if app['combodo.current_user'] is defined and app['combodo.current_user'] is not null %}
 	{% set bUserConnected = true %}
-    {% set bUserCanLogOff = app['combodo.current_user.can_logff'] %}
+    {% set bUserCanLogOff = app['combodo.current_user.can_logoff'] %}
 	{% set sUserFullname = app['combodo.current_user'].Get('first_name') ~ ' ' ~ app['combodo.current_user'].Get('last_name') %}
 	{% set sUserEmail = app['combodo.current_user'].Get('email') %}
 	{% set sUserPhotoUrl = app['combodo.current_contact.photo_url'] %}

--- a/datamodels/2.x/itop-portal-base/portal/templates/layout.html.twig
+++ b/datamodels/2.x/itop-portal-base/portal/templates/layout.html.twig
@@ -3,11 +3,13 @@
 
 {% if app['combodo.current_user'] is defined and app['combodo.current_user'] is not null %}
 	{% set bUserConnected = true %}
+    {% set bUserCanLogOff = app['combodo.current_user.can_logff'] %}
 	{% set sUserFullname = app['combodo.current_user'].Get('first_name') ~ ' ' ~ app['combodo.current_user'].Get('last_name') %}
 	{% set sUserEmail = app['combodo.current_user'].Get('email') %}
 	{% set sUserPhotoUrl = app['combodo.current_contact.photo_url'] %}
 {% else %}
 	{% set bUserConnected = false %}
+    {% set bUserCanLogOff = false %}
 	{% set sUserFullname = '' %}
 	{% set sUserEmail = '' %}
 	{% set sUserPhotoUrl = app['combodo.portal.base.absolute_url'] ~ 'img/user-profile-default-256px.png' %}
@@ -230,11 +232,13 @@
 											<li><a href="{{ aPortal.url }}" target="_blank"><span class="brick_icon {{ sIconClass }} fa-2x fa-fw"></span>{{ aPortal.label|dict_s }}</a></li>
 										{% endif %}
 									{% endfor %}
-									{# We display the separator only if the user has more then 1 portal. Meaning default portal + console or several portal at least #}
-									{% if app['combodo.current_user.allowed_portals']|length > 1 %}
-										<li role="separator" class="divider"></li>
-									{% endif %}
-									<li><a href="{{ app['combodo.absolute_url'] }}pages/logoff.php"><span class="brick_icon fas fa-sign-out-alt fa-2x fa-fw"></span>{{ 'Brick:Portal:UserProfile:Navigation:Dropdown:Logout'|dict_s }}</a></li>
+                                    {% if bUserCanLogOff %}
+                                        {# We display the separator only if the user has more then 1 portal. Meaning default portal + console or several portal at least #}
+                                        {% if app['combodo.current_user.allowed_portals']|length > 1 %}
+                                            <li role="separator" class="divider"></li>
+                                        {% endif %}
+									    <li><a href="{{ app['combodo.absolute_url'] }}pages/logoff.php"><span class="brick_icon fas fa-sign-out-alt fa-2x fa-fw"></span>{{ 'Brick:Portal:UserProfile:Navigation:Dropdown:Logout'|dict_s }}</a></li>
+                                    {% endif %}
 								{% endif %}
 							</ul>
 						</div>
@@ -269,11 +273,13 @@
 											<li><a href="{{ aPortal.url }}" {% if app['combodo.portal.instance.conf'].properties.allowed_portals.opening_mode == 'tab' %}target="_blank"{% endif %} title="{{ aPortal.label|dict_s }}"><span class="brick_icon {{ sGlyphiconClass }} fa-lg fa-fw"></span>{{ aPortal.label|dict_s }}</a></li>
 										{% endif %}
 									{% endfor %}
-									{# We display the separator only if the user has more then 1 portal. Meaning default portal + console or several portal at least #}
-									{% if app['combodo.current_user.allowed_portals']|length > 1 %}
-										<li role="separator" class="divider"></li>
-									{% endif %}
-									<li><a href="{{ app['combodo.absolute_url'] }}pages/logoff.php"><span class="brick_icon fas fa-sign-out-alt fa-lg fa-fw"></span>{{ 'Brick:Portal:UserProfile:Navigation:Dropdown:Logout'|dict_s }}</a></li>
+                                    {% if bUserCanLogOff %}
+                                        {# We display the separator only if the user has more then 1 portal. Meaning default portal + console or several portal at least #}
+                                        {% if app['combodo.current_user.allowed_portals']|length > 1 %}
+                                            <li role="separator" class="divider"></li>
+                                        {% endif %}
+									    <li><a href="{{ app['combodo.absolute_url'] }}pages/logoff.php"><span class="brick_icon fas fa-sign-out-alt fa-lg fa-fw"></span>{{ 'Brick:Portal:UserProfile:Navigation:Dropdown:Logout'|dict_s }}</a></li>
+                                    {% endif %}
 								</ul>
 							</div>
 						</div>


### PR DESCRIPTION
**Symptom**
For some users using SSO (eg. SAML), they can't log off through iTop as it will show them an error page.

**Proposed solution**
Do exactly as in the backoffice, only show the "log off" button is the user can actually log off, which is based on a session variable that can be retrieved through `\utils::CanLogOff()`

_**Important:** Careful when merging in support/3.1 branch as the `UserProvider` part changed a lot when migrating to Symfony 5.4_

_Desktop_
![image](https://github.com/Combodo/iTop/assets/5130468/e64b708d-6826-42db-8151-192c5aded11e)

_Mobile_
![image](https://github.com/Combodo/iTop/assets/5130468/aa84c99d-e443-427b-9d58-f0ce1678f179)
