### PR TITLE
N°7645 - PHP 8.1: Fix usage of strpos() & str_replace() with null value when compiling empty dictionary

### DIFF
--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -1165,6 +1165,7 @@ EOF
 	 */	 	
 	protected function QuoteForPHP($sStr, $bSimpleQuotes = false)
 	{
+		$sStr = $sStr ?? '';
 		if ($bSimpleQuotes)
 		{
 			$sEscaped = str_replace(array('\\', "'"), array('\\\\', "\\'"), $sStr);
@@ -3260,7 +3261,7 @@ EOF;
 		file_put_contents($sLanguagesFile, $sLanguagesFileContent);
 	}
 
-	protected static function FilterDictString($s)
+	protected static function FilterDictString(string $s): string
 	{
 		if (strpos($s, '~') !== false)
 		{

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -3221,10 +3221,11 @@ EOF;
 
 			$aEntriesPHP = array();
 			$oEntries = $oDictionaryNode->GetUniqueElement('entries');
+			/** @var MFElement $oEntry */
 			foreach ($oEntries->getElementsByTagName('entry') as $oEntry)
 			{
 				$sStringCode = $oEntry->getAttribute('id');
-				$sValue = $oEntry->GetText();
+				$sValue = $oEntry->GetText('');
 				$aEntriesPHP[] = "\t'$sStringCode' => ".self::QuoteForPHP(self::FilterDictString($sValue), true).",";
 			}
 			$sEntriesPHP = implode("\n", $aEntriesPHP);


### PR DESCRIPTION
## To reproduce

Having : 
- an iTop 3.1 clone
- PHP 8.1+ 
- php notices enabled

Deploy this XML, that is redefining a dict key to an empty value : 

```xml
<?xml version="1.0" encoding="UTF-8"?>
<itop_design version="1.7">
  <dictionaries>
    <dictionary id="EN US" _delta="must_exist">
      <entries>
        <entry id="Class:UserRequest/Attribute:urgency" _delta="force"></entry>
      </entries>
    </dictionary>
  </dictionaries>
</itop_design>
```

Upon compilation (either by the setup or the toolkit) you'll get the following notices : 

```
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in C:\Dev\wamp64\www\itop-31\setup\compiler.class.inc.php on line 3272

Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in C:\Dev\wamp64\www\itop-31\setup\compiler.class.inc.php on line 1170
```

They are blocking during setup.


## Analysis

The methods `FilterDictString` and `QuoteForPHP` both use `strpos` or `str_replace` who give a deprecation notice when the argument is `null`:

```
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/html/setup/compiler.class.inc.php on line 3231
Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/html/setup/compiler.class.inc.php on line 1146
```

This message is repeated for each empty dictionary item, which seems to happen on a Professional instance connected to the Designer.

Logs taken from a iTop Professional 3.1.0-3. The null argument gives a deprecation notice since [PHP 8.1](https://3v4l.org/W5mRs), which is supported for this iTop version.