### PR TITLE
N°7179 Remove unused var in ActionEmail::PrepareMessageContent

### DIFF
--- a/core/action.class.inc.php
+++ b/core/action.class.inc.php
@@ -629,9 +629,7 @@ class ActionEmail extends ActionNotification
 				$oLog->Set('body', HTMLSanitizer::Sanitize($aMessageContent['body']));
 			}
 		}
-		$sStyles = file_get_contents(APPROOT.'css/email.css');
-		$sStyles .= MetaModel::GetConfig()->Get('email_css');
-		
+
 		if ($this->IsBeingTested()) {
 			$sTestBody = $aMessageContent['body'];
 			$sTestBody .= "<div style=\"border: dashed;\">\n";


### PR DESCRIPTION
This var was introduced in fed149dc in 3.1.0, but is not used in the method.
The same var exists and is used in ActionEmail::_DoExecute.
This was certainly forgotten during the refactoring.