### PR TITLE
N°7245 Add details on exceptions in RunTimeEnvironment::CallInstallerHandlers

### DIFF
--- a/setup/runtimeenv.class.inc.php
+++ b/setup/runtimeenv.class.inc.php
@@ -1079,13 +1079,14 @@ class RunTimeEnvironment
 			SetupUtils::tidydir(APPROOT.'env-'.$this->sTargetEnv);
 		}
 	}
-	
-	/**
-	 * Call the given handler method for all selected modules having an installation handler
-	 * @param array[] $aAvailableModules
-	 * @param string[] $aSelectedModules
-	 * @param string $sHandlerName
-	 */
+
+    /**
+     * Call the given handler method for all selected modules having an installation handler
+     * @param array[] $aAvailableModules
+     * @param string[] $aSelectedModules
+     * @param string $sHandlerName
+     * @throws CoreException
+     */
 	public function CallInstallerHandlers($aAvailableModules, $aSelectedModules, $sHandlerName)
 	{
 	    foreach($aAvailableModules as $sModuleId => $aModule)
@@ -1098,8 +1099,20 @@ class RunTimeEnvironment
 	            $aCallSpec = array($sModuleInstallerClass, $sHandlerName);
 	            if (is_callable($aCallSpec))
 	            {
-	               call_user_func_array($aCallSpec, array(MetaModel::GetConfig(), $aModule['version_db'], $aModule['version_code']));
-	            }
+                    try {
+                        call_user_func_array($aCallSpec, array(MetaModel::GetConfig(), $aModule['version_db'], $aModule['version_code']));
+                    } catch (Exception $e) {
+                        $sErrorMessage = "Module $sModuleId : error when calling module installer class $sModuleInstallerClass for $sHandlerName handler";
+                        $aExceptionContextData = [
+                                'ModulelId' => $sModuleId,
+                                'ModuleInstallerClass' => $sModuleInstallerClass,
+                                'ModuleInstallerHandler' => $sHandlerName,
+                                'ExceptionClass' => get_class($e),
+                                'ExceptionMessage' => $e->getMessage(),
+                        ];
+                        throw new CoreException($sErrorMessage, $aExceptionContextData, '', $e);
+                    }
+                }
 	        }
 	    }
 	}


### PR DESCRIPTION
If a crash occurs in a ModuleInstaller impl callback, for now we did have no details on the concerned code.

On screen the exception message : 

> test exception

And in setup.log : 
```
2024-01-31 17:42:22 | Info    |       | Calling Module Handler: AttachmentInstaller::BeforeDatabaseCreation(oConfig, 2.7.10, 2.7.10) | SetupLog
2024-01-31 17:41:04 | Error   |       | An exception occurred: test exception at line 116 in file C:\Dev\wamp64\www\itop-27\setup\modulediscovery.class.inc.php(497) : eval()'d code | SetupLog
2024-01-31 17:41:04 | Ok      |       | Call stack: | SetupLog
2024-01-31 17:41:04 | Ok      |       | #0 C:\Dev\wamp64\www\itop-27\setup\runtimeenv.class.inc.php(1101): AttachmentInstaller::BeforeDatabaseCreation(...) | SetupLog
2024-01-31 17:41:04 | Ok      |       | #1 C:\Dev\wamp64\www\itop-27\setup\applicationinstaller.class.inc.php(756): RunTimeEnvironment->CallInstallerHandlers(...) | SetupLog
2024-01-31 17:41:04 | Ok      |       | #2 C:\Dev\wamp64\www\itop-27\setup\applicationinstaller.class.inc.php(312): ApplicationInstaller::DoUpdateDBSchema(...) | SetupLog
2024-01-31 17:41:04 | Ok      |       | #3 C:\Dev\wamp64\www\itop-27\setup\wizardsteps.class.inc.php(2463): ApplicationInstaller->ExecuteStep(...) | SetupLog
2024-01-31 17:41:04 | Ok      |       | #4 C:\Dev\wamp64\www\itop-27\setup\ajax.dataloader.php(177): WizStepSummary->AsyncAction(...) | SetupLog
```

With this fix the concerned module is added.
We are now getting : 

On screen : 
> Module itop-attachments : error when calling module installer class AttachmentInstaller for BeforeDatabaseCreation handler: ModulelId = itop-attachments, ModuleInstallerClass = AttachmentInstaller, ModuleInstallerHandler = BeforeDatabaseCreation, ExceptionClass = Exception, ExceptionMessage = test exception

In setup.log : 
```
2024-01-31 17:42:22 | Info    |       | Calling Module Handler: AttachmentInstaller::BeforeDatabaseCreation(oConfig, 2.7.10, 2.7.10) | SetupLog
2024-01-31 17:42:22 | Error   |       | An exception occurred: Module itop-attachments : error when calling module installer class AttachmentInstaller for BeforeDatabaseCreation handler: ModulelId = itop-attachments, ModuleInstallerClass = AttachmentInstaller, ModuleInstallerHandler = BeforeDatabaseCreation, ExceptionClass = Exception, ExceptionMessage = test exception at line 1113 in file C:\Dev\wamp64\www\itop-27\setup\runtimeenv.class.inc.php | SetupLog
2024-01-31 17:42:22 | Ok      |       | Call stack: | SetupLog
2024-01-31 17:42:22 | Ok      |       | #0 C:\Dev\wamp64\www\itop-27\setup\applicationinstaller.class.inc.php(756): RunTimeEnvironment->CallInstallerHandlers(...) | SetupLog
2024-01-31 17:42:22 | Ok      |       | #1 C:\Dev\wamp64\www\itop-27\setup\applicationinstaller.class.inc.php(312): ApplicationInstaller::DoUpdateDBSchema(...) | SetupLog
2024-01-31 17:42:22 | Ok      |       | #2 C:\Dev\wamp64\www\itop-27\setup\wizardsteps.class.inc.php(2463): ApplicationInstaller->ExecuteStep(...) | SetupLog
2024-01-31 17:42:22 | Ok      |       | #3 C:\Dev\wamp64\www\itop-27\setup\ajax.dataloader.php(177): WizStepSummary->AsyncAction(...) | SetupLog
```

To reproduce simply throw an exception for example in \AttachmentInstaller::BeforeDatabaseCreation