### PR TITLE
N°7212 - PHP 8.1: Migrate remaining usages of strlen() with null value

### DIFF
--- a/core/ormcaselog.class.inc.php
+++ b/core/ormcaselog.class.inc.php
@@ -169,7 +169,7 @@ class ormCaseLog {
 		}
 
 		// Process the case of an eventual remainder (quick migration of AttributeText fields)
-		if ($iPos < (strlen($this->m_sLog) - 1))
+		if ($iPos < (utils::StrLen($this->m_sLog) - 1))
 		{
 			$sTextEntry = substr($this->m_sLog, $iPos);
 
@@ -292,7 +292,7 @@ class ormCaseLog {
 		}
 
 		// Process the case of an eventual remainder (quick migration of AttributeText fields)
-		if ($iPos < (strlen($this->m_sLog) - 1)) {
+		if ($iPos < (utils::StrLen($this->m_sLog) - 1)) {
 			$sTextEntry = substr($this->m_sLog, $iPos);
 			$sTextEntry = str_replace(array("\r\n", "\n", "\r"), "<br/>", utils::EscapeHtml($sTextEntry));
 
@@ -373,7 +373,7 @@ class ormCaseLog {
 		}
 
 		// Process the case of an eventual remainder (quick migration of AttributeText fields)
-		if ($iPos < (strlen($this->m_sLog) - 1)) {
+		if ($iPos < (utils::StrLen($this->m_sLog) - 1)) {
 			$sTextEntry = substr($this->m_sLog, $iPos);
 			$sTextEntry = str_replace(array("\r\n", "\n", "\r"), "<br/>", utils::EscapeHtml($sTextEntry));
 
@@ -467,7 +467,7 @@ class ormCaseLog {
 			$oBlock->AddSubBlock($oCollapsibleBlock);
 		}
 		// Process the case of an eventual remainder (quick migration of AttributeText fields)
-		if ($iPos < (strlen($this->m_sLog) - 1)) {
+		if ($iPos < (utils::StrLen($this->m_sLog) - 1)) {
 			// In this case the format is always "text"
 			$sTextEntry = substr($this->m_sLog, $iPos);
 			$sTextEntry = str_replace(array("\r\n", "\n", "\r"), "<br/>", utils::EscapeHtml($sTextEntry));


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | Combodo N°7212, mentioned in [#600](https://github.com/Combodo/iTop/pull/600#issuecomment-1923311355)
| Type of change?                                               | Bug fix


## Symptom (bug)
Deprecation notice in the logs
```
Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/core/ormcaselog.class.inc.php on line 172
```


## Reproduction procedure (bug)
No real use case so far, only programatically with the following delta.

1. On iTop 3.1.0
2. With PHP 8.1.0
2. Apply following delta
2. Create new User Request
3. Change urgency to trigger a ComputeValues
4. Check that notice is present either in iTop logs or the network panel of the browser

```xml
<?xml version="1.0" encoding="UTF-8"?>
<itop_design xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0">
  <classes>
    <class id="UserRequest" _delta="must_exist">
      <methods>
        <method id="ComputeValues" _delta="force">
          <static>false</static>
          <access>public</access>
          <type>Overload-DBObject</type>
          <code>
<![CDATA[
public function ComputeValues()
{
  $oLog = new ormCaseLog(null);
  $oLog->GetAsArray();
  $oLog->GetAsEmailHtml();
  $oLog->GetAsSimpleHtml();
  $oLog->GetAsHTML();

  $oDoc = new ormDocument();
  $oDoc->GetSignature();

  parent::ComputeValues();
}
]]>
          </code>
        </method>
      </methods>
    </class>
  </classes>
</itop_design>

```


## Cause (bug)
In some cases, the `$m_sLog` part of the `\ormCaseLog` can be null and cause this. But how it can be null is not clear yet.


## Proposed solution (bug and enhancement)
Protect code by using `\utils::StrLen()` instead which was done with that exact purpose in mind.


## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [X] Would a unit test be relevant and have I added it?
- [X] Is the PR clear and detailled enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge
None