### PR TITLE
N°7244 Fix setup ContextTag init

### DIFF
--- a/setup/applicationinstaller.class.inc.php
+++ b/setup/applicationinstaller.class.inc.php
@@ -685,6 +685,8 @@ class ApplicationInstaller
 	 */
 	protected static function DoUpdateDBSchema($aSelectedModules, $sModulesDir, $aParamValues, $sTargetEnvironment = '', $bOldAddon = false, $sAppRootUrl = '')
 	{
+		/** @noinspection PhpUnusedLocalVariableInspection */
+		$oContextTag = new ContextTag(ContextTag::TAG_SETUP);
 		SetupLog::Info("Update Database Schema for environment '$sTargetEnvironment'.");
 		$sMode = $aParamValues['mode'];
 		$sDBPrefix = $aParamValues['db_prefix'];
@@ -703,7 +705,6 @@ class ApplicationInstaller
 
 		$oProductionEnv = new RunTimeEnvironment($sTargetEnvironment);
 		$oProductionEnv->InitDataModel($oConfig, true);  // load data model only
-		$oContextTag = new ContextTag(ContextTag::TAG_SETUP);
 
 		// Migrate columns
 		self::MoveColumns($sDBPrefix);
@@ -886,6 +887,8 @@ class ApplicationInstaller
 		$bOldAddon
 	)
 	{
+		/** @noinspection PhpUnusedLocalVariableInspection */
+		$oContextTag = new ContextTag(ContextTag::TAG_SETUP);
 		SetupLog::Info('After Database Creation');
 
 		$sMode = $aParamValues['mode'];
@@ -902,8 +905,7 @@ class ApplicationInstaller
 
 		$oProductionEnv = new RunTimeEnvironment($sTargetEnvironment);
 		$oProductionEnv->InitDataModel($oConfig, true);  // load data model and connect to the database
-		$oContextTag = new ContextTag(ContextTag::TAG_SETUP);
-		self::$bMetaModelStarted = true; // No need to reload the final MetaModel in case the installer runs synchronously 
+		self::$bMetaModelStarted = true; // No need to reload the final MetaModel in case the installer runs synchronously
 		
 		// Perform here additional DB setup... profiles, etc...
 		//
@@ -952,6 +954,9 @@ class ApplicationInstaller
 		$bSampleData = false
 	)
 	{
+		/** @noinspection PhpUnusedLocalVariableInspection */
+		$oContextTag = new ContextTag(ContextTag::TAG_SETUP);
+
 		$oConfig = new Config();
 		$oConfig->UpdateFromParams($aParamValues, $sModulesDir);
 
@@ -969,7 +974,6 @@ class ApplicationInstaller
 		if (!self::$bMetaModelStarted)
 		{
 			$oProductionEnv->InitDataModel($oConfig, false);  // load data model and connect to the database
-			$oContextTag = new ContextTag(ContextTag::TAG_SETUP);
 
 			self::$bMetaModelStarted = true; // No need to reload the final MetaModel in case the installer runs synchronously
 		} 
@@ -1002,6 +1006,8 @@ class ApplicationInstaller
 		$sModulesDir, $sPreviousConfigFile, $sTargetEnvironment, $sDataModelVersion, $bOldAddon, $aSelectedModuleCodes,
 		$aSelectedExtensionCodes, $aParamValues, $sInstallComment = null
 	) {
+		$oContextTag = new ContextTag(ContextTag::TAG_SETUP);
+
 		$aParamValues['selected_modules'] = implode(',', $aSelectedModuleCodes);
 		$sMode = $aParamValues['mode'];
 
@@ -1042,7 +1048,6 @@ class ApplicationInstaller
 		// Record which modules are installed...
 		$oProductionEnv = new RunTimeEnvironment($sTargetEnvironment);
 		$oProductionEnv->InitDataModel($oConfig, true);  // load data model and connect to the database
-		$oContextTag = new ContextTag(ContextTag::TAG_SETUP);
 
 		if (!$oProductionEnv->RecordInstallation($oConfig, $sDataModelVersion, $aSelectedModuleCodes, $aSelectedExtensionCodes, $sInstallComment))
 		{

--- a/setup/applicationinstaller.class.inc.php
+++ b/setup/applicationinstaller.class.inc.php
@@ -685,7 +685,10 @@ class ApplicationInstaller
 	 */
 	protected static function DoUpdateDBSchema($aSelectedModules, $sModulesDir, $aParamValues, $sTargetEnvironment = '', $bOldAddon = false, $sAppRootUrl = '')
 	{
-		/** @noinspection PhpUnusedLocalVariableInspection */
+		/**
+		 * @since 3.2.0 move the ContextTag init at the very beginning of the method
+		 * @noinspection PhpUnusedLocalVariableInspection
+		 */
 		$oContextTag = new ContextTag(ContextTag::TAG_SETUP);
 		SetupLog::Info("Update Database Schema for environment '$sTargetEnvironment'.");
 		$sMode = $aParamValues['mode'];
@@ -887,7 +890,10 @@ class ApplicationInstaller
 		$bOldAddon
 	)
 	{
-		/** @noinspection PhpUnusedLocalVariableInspection */
+		/**
+		 * @since 3.2.0 move the ContextTag init at the very beginning of the method
+		 * @noinspection PhpUnusedLocalVariableInspection
+		 */
 		$oContextTag = new ContextTag(ContextTag::TAG_SETUP);
 		SetupLog::Info('After Database Creation');
 
@@ -954,7 +960,10 @@ class ApplicationInstaller
 		$bSampleData = false
 	)
 	{
-		/** @noinspection PhpUnusedLocalVariableInspection */
+		/**
+		 * @since 3.2.0 move the ContextTag init at the very beginning of the method
+		 * @noinspection PhpUnusedLocalVariableInspection
+		 */
 		$oContextTag = new ContextTag(ContextTag::TAG_SETUP);
 
 		$oConfig = new Config();
@@ -1006,6 +1015,10 @@ class ApplicationInstaller
 		$sModulesDir, $sPreviousConfigFile, $sTargetEnvironment, $sDataModelVersion, $bOldAddon, $aSelectedModuleCodes,
 		$aSelectedExtensionCodes, $aParamValues, $sInstallComment = null
 	) {
+		/**
+		 * @since 3.2.0 move the ContextTag init at the very beginning of the method
+		 * @noinspection PhpUnusedLocalVariableInspection
+		 */
 		$oContextTag = new ContextTag(ContextTag::TAG_SETUP);
 
 		$aParamValues['selected_modules'] = implode(',', $aSelectedModuleCodes);

--- a/setup/wizardcontroller.class.inc.php
+++ b/setup/wizardcontroller.class.inc.php
@@ -285,6 +285,9 @@ on the page's parameters
 	 */
 	public function Run()
 	{
+		/** @noinspection PhpUnusedLocalVariableInspection */
+		$oContextTag = new ContextTag(ContextTag::TAG_SETUP);
+
 		$sOperation = utils::ReadParam('operation');
 		$this->aParameters = utils::ReadParam('_params', array(), false, 'raw_data');
 		$this->aSteps  = json_decode(utils::ReadParam('_steps', '[]', false, 'raw_data'), true /* bAssoc */);

--- a/setup/wizardcontroller.class.inc.php
+++ b/setup/wizardcontroller.class.inc.php
@@ -285,7 +285,10 @@ on the page's parameters
 	 */
 	public function Run()
 	{
-		/** @noinspection PhpUnusedLocalVariableInspection */
+		/**
+		 * @since 3.2.0 Add the ContextTag init
+		 * @noinspection PhpUnusedLocalVariableInspection
+		 */
 		$oContextTag = new ContextTag(ContextTag::TAG_SETUP);
 
 		$sOperation = utils::ReadParam('operation');


### PR DESCRIPTION
Initial use case was an implementation of iEventServiceSetup::RegisterEventsAndListeners where we wanted to exclude based on \ContextTag::TAG_SETUP (EventService::RegisterListener has a context parameter for inclusion, but don't have one for exclusions)
We saw that the setup context wasn't present, especially during the call made in \ApplicationInstaller::DoUpdateDBSchema (call is made when initializing the data model)

With this PR the context init is moved on top of the methods.

Also, a context init is now done in the \WizardController::Run method.

Sample impl to reproduce : 

```php
class LoggingEventServiceSetup implements \Combodo\iTop\Service\Events\iEventServiceSetup
{
    public function RegisterEventsAndListeners()
    {
      IssueLog::Info(__CLASS__.'::'.__METHOD__.' call !', null, [
        'ContextTag_stack' => ContextTag::GetStack(),
        'stack' => debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS),
      ]);
    }
}
```