### PR TITLE
N°7343 Catch ParseError when loading dict files in setup

### DIFF
--- a/setup/modelfactory.class.inc.php
+++ b/setup/modelfactory.class.inc.php
@@ -872,11 +872,7 @@ class ModelFactory
 					$sDictFileContents = file_get_contents($sPHPFile);
 					$sDictFileContents = str_replace(array('<'.'?'.'php', '?'.'>'), '', $sDictFileContents);
 					$sDictFileContents = str_replace('Dict::Add', '$this->AddToTempDictionary', $sDictFileContents);
-                    try {
-                        eval($sDictFileContents);
-                    } catch (Error $e) {
-                        throw new DictException("Error when loading dict file $sPHPFile: " . $e->getMessage());
-                    }
+                    eval($sDictFileContents);
 				}
 
 				foreach ($this->aDict as $sLanguageCode => $aDictDefinition)
@@ -936,10 +932,12 @@ class ModelFactory
 						$this->aDictKeys[$sLanguageCode][$sCode] = $oXmlEntry;
 					}
 				}
-			}
-			catch (Exception $e)
+            } catch (Exception|Error $e) // Error can occurs on eval() calls
 			{
-				throw new Exception('Failed to load dictionary file "'.$sPHPFile.'", reason: '.$e->getMessage());
+                throw new DictException('Failed to load dictionary file "' . $sPHPFile . '"', [
+                        'exception_class' => get_class($e),
+                        'exception_msg' => $e->getMessage(),
+                ]);
 			}
 
 		}

--- a/setup/modelfactory.class.inc.php
+++ b/setup/modelfactory.class.inc.php
@@ -872,7 +872,7 @@ class ModelFactory
 					$sDictFileContents = file_get_contents($sPHPFile);
 					$sDictFileContents = str_replace(array('<'.'?'.'php', '?'.'>'), '', $sDictFileContents);
 					$sDictFileContents = str_replace('Dict::Add', '$this->AddToTempDictionary', $sDictFileContents);
-                    eval($sDictFileContents);
+					eval($sDictFileContents);
 				}
 
 				foreach ($this->aDict as $sLanguageCode => $aDictDefinition)

--- a/setup/modelfactory.class.inc.php
+++ b/setup/modelfactory.class.inc.php
@@ -872,7 +872,11 @@ class ModelFactory
 					$sDictFileContents = file_get_contents($sPHPFile);
 					$sDictFileContents = str_replace(array('<'.'?'.'php', '?'.'>'), '', $sDictFileContents);
 					$sDictFileContents = str_replace('Dict::Add', '$this->AddToTempDictionary', $sDictFileContents);
-					eval($sDictFileContents);
+                    try {
+                        eval($sDictFileContents);
+                    } catch (Error $e) {
+                        throw new DictException("Error when loading dict file $sPHPFile: " . $e->getMessage());
+                    }
 				}
 
 				foreach ($this->aDict as $sLanguageCode => $aDictDefinition)


### PR DESCRIPTION
Message before PR : 

> Setup error: PHP error occured : msg=Unclosed '[' on line 23, no=4, file=C:\Dev\wamp64\www\itop-dev\setup\modelfactory.class.inc.php(926) : eval()'d code, line=26

=> no information on which dict file caused the problem !

And after PR : 

> Error loading module "dictionaries": Failed to load dictionary file "C:\Dev\wamp64\www\itop-27/dictionaries/cs.dictionary.itop.ui.php": exception_class = ParseError, exception_msg = syntax error, unexpected end of file, expecting ')' - Loaded modules: dictionaries:1.0

There was an existing try/catch block but it wasn't catching Error...