### PR TITLE
N°7163 - Avoid having an empty list when "items per page" is set to 0 as it makes no sense

### DIFF
--- a/css/backoffice/components/datatable/_datatableconfig.scss
+++ b/css/backoffice/components/datatable/_datatableconfig.scss
@@ -23,7 +23,8 @@ $ibo-datatableconfig--settings-panel--option--margin-right: $ibo-spacing-200 !de
 .ibo-datatableconfig--attributes-panel--per-page--input{
   margin: $ibo-datatableconfig--attributes-panel--per-page--input--margin-y $ibo-datatableconfig--attributes-panel--per-page--input--margin-x;
   max-width: 4em;
-  border: 1px solid $ibo-color-grey-500;
+  @extend .ibo-input;
+  display: unset;
 }
 
 .ibo-datatableconfig--settings-panel .ibo-panel--body{

--- a/css/backoffice/components/datatable/_datatableconfig.scss
+++ b/css/backoffice/components/datatable/_datatableconfig.scss
@@ -22,6 +22,8 @@ $ibo-datatableconfig--settings-panel--option--margin-right: $ibo-spacing-200 !de
 }
 .ibo-datatableconfig--attributes-panel--per-page--input{
   margin: $ibo-datatableconfig--attributes-panel--per-page--input--margin-y $ibo-datatableconfig--attributes-panel--per-page--input--margin-x;
+  max-width: 4em;
+  border: 1px solid $ibo-color-grey-500;
 }
 
 .ibo-datatableconfig--settings-panel .ibo-panel--body{

--- a/css/backoffice/components/datatable/_datatableconfig.scss
+++ b/css/backoffice/components/datatable/_datatableconfig.scss
@@ -24,7 +24,7 @@ $ibo-datatableconfig--settings-panel--option--margin-right: $ibo-spacing-200 !de
   margin: $ibo-datatableconfig--attributes-panel--per-page--input--margin-y $ibo-datatableconfig--attributes-panel--per-page--input--margin-x;
   max-width: 4em;
   @extend .ibo-input;
-  display: unset;
+  display: initial;
 }
 
 .ibo-datatableconfig--settings-panel .ibo-panel--body{

--- a/js/dataTables.settings.js
+++ b/js/dataTables.settings.js
@@ -186,6 +186,7 @@ $(function () {
 					var sSortDirection = 'asc';
 					var oColumns = $('#datatable_dlg_'+this.options.sListId).find(':itop-fieldsorter').fieldsorter('get_params');
 					var iPageSize = parseInt($('#datatable_dlg_'+this.options.sListId+' input[name="page_size"]').val(), 10);
+					// Fallback to default page size in case of invalid number
 					if (isNaN(iPageSize) || iPageSize <= 0) {
 						iPageSize = this.options.oDefaultSettings.iDefaultPageSize;
 						$('#datatable_dlg_'+this.options.sListId+' input[name="page_size"]').val(iPageSize);

--- a/js/dataTables.settings.js
+++ b/js/dataTables.settings.js
@@ -186,6 +186,10 @@ $(function () {
 					var sSortDirection = 'asc';
 					var oColumns = $('#datatable_dlg_'+this.options.sListId).find(':itop-fieldsorter').fieldsorter('get_params');
 					var iPageSize = parseInt($('#datatable_dlg_'+this.options.sListId+' input[name="page_size"]').val(), 10);
+					if (isNaN(iPageSize) || iPageSize <= 0) {
+						iPageSize = this.options.oDefaultSettings.iDefaultPageSize;
+						$('#datatable_dlg_'+this.options.sListId+' input[name="page_size"]').val(iPageSize);
+					}
 
 					oOptions = {oColumns: oColumns, iPageSize: iPageSize, iDefaultPageSize: iPageSize };
 				}

--- a/sources/Controller/AjaxRenderController.php
+++ b/sources/Controller/AjaxRenderController.php
@@ -278,7 +278,7 @@ class AjaxRenderController
 		}
 
 		$sTableId = utils::ReadParam('list_id', '');
-		$iLength = utils::ReadParam('end', 10);
+		$iLength = utils::ReadParam('end', 10, false, utils::ENUM_SANITIZATION_FILTER_INTEGER);
 		$aColumns = utils::ReadParam('columns', array(), false, 'raw_data');
 		$sSelectMode = utils::ReadParam('select_mode', '');
 		$aClassAliases = utils::ReadParam('class_aliases', array());
@@ -499,7 +499,7 @@ class AjaxRenderController
 	 */
 	public static function DatatableSaveSettings(): bool
 	{
-		$iPageSize = utils::ReadParam('page_size', 10);
+		$iPageSize = utils::ReadParam('page_size', 10, false, utils::ENUM_SANITIZATION_FILTER_INTEGER);
 		$sTableId = utils::ReadParam('table_id', null, false, 'raw_data');
 		$bSaveAsDefaults = (utils::ReadParam('defaults', 'true') == 'true');
 		$aClassAliases = utils::ReadParam('class_aliases', array(), false, 'raw_data');

--- a/templates/base/components/datatable/config/layout.html.twig
+++ b/templates/base/components/datatable/config/layout.html.twig
@@ -20,7 +20,7 @@
                         </ul>
                     </div>
                 </div>
-                <p> {{ 'UI:Display_X_ItemsPerPage_prefix'|dict_s }}<input class="ibo-datatableconfig--attributes-panel--per-page--input" type="text" size="4" name="page_size" value="{{ oUIBlock.GetOption("iPageSize") }}">{{ 'UI:Display_X_ItemsPerPage_suffix'|dict_s }}</p>
+                <p> {{ 'UI:Display_X_ItemsPerPage_prefix'|dict_s }}<input class="ibo-datatableconfig--attributes-panel--per-page--input" type="number" min="1" size="4" name="page_size" value="{{ oUIBlock.GetOption("iPageSize") }}">{{ 'UI:Display_X_ItemsPerPage_suffix'|dict_s }}</p>
             </div>
         </div>
         <div class="ibo-datatableconfig--settings-panel ibo-panel ibo-is-neutral ibo-is-opened" data-role="ibo-panel">


### PR DESCRIPTION
New protections.
If the "items per page" value is not correct, it reverts to the default value