### PR TITLE
N°7288 - Fix page crash due to unescaped characters in relations row actions

### DIFF
--- a/templates/base/components/datatable/row-actions/handler.js.twig
+++ b/templates/base/components/datatable/row-actions/handler.js.twig
@@ -23,16 +23,16 @@
         {% if aAction.confirmation is defined %}
 
             // Prepare confirmation title
-            let sTitle = '{{ 'UI:Datatables:RowActions:ConfirmationDialog'|dict_s  }}';
+            let sTitle = `{{ 'UI:Datatables:RowActions:ConfirmationDialog'|dict_s|escape('js') }}`;
             {% if aAction.confirmation.title is defined %}
-                sTitle = '{{ aAction.confirmation.title|dict_s }}';
+                sTitle = `{{ aAction.confirmation.title|dict_s|escape('js') }}`;
             {% endif %}
             sTitle = sTitle.replaceAll('{item}', aRowData['{{ aAction.confirmation.row_data }}']);
 
             // Prepare confirmation message
-            let sMessage = '{{ 'UI:Datatables:RowActions:ConfirmationMessage'|dict_s  }}';
+            let sMessage = `{{ 'UI:Datatables:RowActions:ConfirmationMessage'|dict_s|escape('js') }}`;
             {% if aAction.confirmation.message is defined %}
-                sMessage = '{{ aAction.confirmation.message|dict_s }}';
+                sMessage = `{{ aAction.confirmation.message|dict_s|escape('js') }}`;
             {% endif %}
             sMessage = sMessage.replaceAll('{item}', aRowData['{{ aAction.confirmation.row_data }}']);
 


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | N°7288
| Type of change?                                               | Bug fix


## Symptom (bug) / Objective (enhancement)

The page hangs, javascript related actions can't be performed anymore (e.g.: changing an object's tab)
The following error message appears in the JS console:
```
Uncaught SyntaxError: Invalid Unicode escape sequence (at
```

## Reproduction procedure (bug)

1. On iTop 3.1.1
2. With PHP 8.1.0
3. Edit a Person and append "\utils" to their name or surname (it's very important that the backslash and 'u' come consecutively)
4. Save the object
5. See the error message in the JS console and the inability to change tabs

![image](https://support.combodo.com/pages/ajax.document.php?operation=download_inlineimage&id=38047&s=0068aa)


## Cause (bug)

This is a continuation of the parent bug (N°6560), when "\u" is put in a string, JavaScript expects it to be a unicode character (e.g., "\u0020" for a space), but that might not always be the case.


## Proposed solution (bug and enhancement)

- Add the TWIG filter | escape ('js') to strings so that all characters are correctly escaped
- Optionally, use backticks (`) instead of apostrophes (') to delimit strings. This allows for multi-line dictionary entries.


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [X] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailled enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge
