### PR TITLE
N°7344 rest.php core/get : add try/catch around query execution

### DIFF
--- a/application/applicationextension.inc.php
+++ b/application/applicationextension.inc.php
@@ -1712,7 +1712,7 @@ class RestUtils
             try {
                 $oSearch = DBObjectSearch::FromOQL($key);
             } catch (Exception $e) {
-                throw new CoreOqlException('json_data key parameter: query failed to execute', [
+                throw new CoreOqlException('Query failed to execute', [
                         'query' => $key,
                         'exception_class' => get_class($e),
                         'exception_message' => $e->getMessage(),

--- a/application/applicationextension.inc.php
+++ b/application/applicationextension.inc.php
@@ -1709,8 +1709,16 @@ class RestUtils
 		elseif (is_string($key))
 		{
 			// OQL
-			$oSearch = DBObjectSearch::FromOQL($key);
-		}
+            try {
+                $oSearch = DBObjectSearch::FromOQL($key);
+            } catch (Exception $e) {
+                throw new CoreOqlException('json_data key parameter: query failed to execute', [
+                        'query' => $key,
+                        'exception_class' => get_class($e),
+                        'exception_message' => $e->getMessage(),
+                ]);
+            }
+        }
 		else
 		{
 			throw new Exception("Wrong format for key");


### PR DESCRIPTION
For example with this json_data containing an invalid OQL (single quote after class name) : 

```json
{
   "operation": "core/get",
   "class": "Person",
   "key": "SELECT Person'", "limit": "10", "page": "1",
   "output_fields":"friendlyname"
}
```

Before PR you would get as a result : 

```json
{
    "code": 100,
    "message": "Error: Unexpected input at line 1: '"
}
```

And after PR : 

```json
{
    "code": 100,
    "message": "Error: Query failed to execute: query = SELECT Person', exception_class = Exception, exception_message = Unexpected input at line 1: '"
}
```
