### PR TITLE
N°7697 - Add method to rename DB table during setup

### DIFF
--- a/tests/php-unit-tests/unitary-tests/setup/ModuleInstallerAPITest.php
+++ b/tests/php-unit-tests/unitary-tests/setup/ModuleInstallerAPITest.php
@@ -241,4 +241,30 @@ SQL
 		$this->assertEquals('from table 2', $sFromTable2Data, "Data was not moved as expected");
 	}
 
+	/**
+	 * Test that the table has been renamed
+	 *
+	 * @covers ModuleInstallerAPI::RenameTableInDB
+	 *
+	 * @return void
+	 * @throws \CoreException
+	 * @throws \MySQLException
+	 */
+	public function testRenameTableInDB()
+	{
+		$sOrigTable = MetaModel::DBGetTable('Person');
+		$aOrigTableInfo = CMDBSource::GetTableInfo($sOrigTable);
+		$this->assertNotEmpty($aOrigTableInfo, 'Origin table does not exist');
+
+		$sDstTable = static::$sWorkTable;
+		$this->assertFalse(CMDBSource::IsTable($sDstTable), 'Work table already exists');
+
+		ModuleInstallerAPI::RenameTableInDB($sOrigTable, $sDstTable);
+
+		$this->assertEquals($aOrigTableInfo, CMDBSource::GetTableInfo($sDstTable), 'Table was not renamed');
+
+		// Revert
+		ModuleInstallerAPI::RenameTableInDB($sDstTable, $sOrigTable);
+		$this->assertEquals($aOrigTableInfo, CMDBSource::GetTableInfo($sOrigTable));
+	}
 }


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Enhancement


## Objective

To have a helper method that can rename a table in DB during setup.

~~The helper method can silently ignore the renaming if the origin table doesn't exist or the destination table already exists. This to avoid errors when running the setup again after the migration has ben done before.~~
EDIT: This part has been rejected by Combodo technical review..

## Proposed solution

Creation of `ModuleInstallerAPI::RenameTableInDB`.


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailled enough so anyone can understand digging in the code?
