### PR TITLE
N°7302 Fix unit name in \SetupUtils::HumanReadableSize

### DIFF
--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -899,14 +899,14 @@ class SetupUtils
 
     /**
      * @param float $fBytes size in raw bytes, for example 162594750464.0
-     * @return string formatted string, for example "161.62 Gb"
+     * @return string formatted string, for example "161.62 GB"
      *
      * @link https://en.wiktionary.org/wiki/petabyte petabyte PB
      * @link https://en.wiktionary.org/wiki/exabyte#English exabyte EB
      */
 	public static function HumanReadableSize($fBytes)
 	{
-        $aSizes = array('Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB');
+		$aSizes = array('Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB');
 		$index = 0;
 		while (($fBytes > 1000) && ($index < count($aSizes)))
 		{

--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -898,12 +898,15 @@ class SetupUtils
 	}
 
     /**
+     * @param float $fBytes size in raw bytes, for example 162594750464.0
+     * @return string formatted string, for example "161.62 Gb"
+     *
      * @link https://en.wiktionary.org/wiki/petabyte petabyte PB
      * @link https://en.wiktionary.org/wiki/exabyte#English exabyte EB
      */
 	public static function HumanReadableSize($fBytes)
 	{
-        $aSizes = array('bytes', 'Kb', 'Mb', 'Gb', 'Tb', 'Pb', 'Eb');
+        $aSizes = array('Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB');
 		$index = 0;
 		while (($fBytes > 1000) && ($index < count($aSizes)))
 		{

--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -897,9 +897,13 @@ class SetupUtils
 		return $f;
 	}
 
+    /**
+     * @link https://en.wiktionary.org/wiki/petabyte petabyte PB
+     * @link https://en.wiktionary.org/wiki/exabyte#English exabyte EB
+     */
 	public static function HumanReadableSize($fBytes)
 	{
-		$aSizes = array('bytes', 'Kb', 'Mb', 'Gb', 'Tb', 'Pb', 'Hb');
+        $aSizes = array('bytes', 'Kb', 'Mb', 'Gb', 'Tb', 'Pb', 'Eb');
 		$index = 0;
 		while (($fBytes > 1000) && ($index < count($aSizes)))
 		{

--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -901,12 +901,14 @@ class SetupUtils
      * @param float $fBytes size in raw bytes, for example 162594750464.0
      * @return string formatted string, for example "161.62 GB"
      *
+     * @link https://en.wiktionary.org/wiki/byte byte and not Byte
+     * @link https://en.wikipedia.org/wiki/Kilobyte kB and not KB (IEC 80000-13)
      * @link https://en.wiktionary.org/wiki/petabyte petabyte PB
      * @link https://en.wiktionary.org/wiki/exabyte#English exabyte EB
      */
 	public static function HumanReadableSize($fBytes)
 	{
-		$aSizes = array('Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB');
+        $aSizes = array('bytes', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB');
 		$index = 0;
 		while (($fBytes > 1000) && ($index < count($aSizes)))
 		{

--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -904,11 +904,11 @@ class SetupUtils
      * @link https://en.wiktionary.org/wiki/byte byte and not Byte
      * @link https://en.wikipedia.org/wiki/Kilobyte kB and not KB (IEC 80000-13)
      * @link https://en.wiktionary.org/wiki/petabyte petabyte PB
-     * @link https://en.wiktionary.org/wiki/exabyte#English exabyte EB
+     * @link https://en.wiktionary.org/wiki/exabyte exabyte EB
      */
 	public static function HumanReadableSize($fBytes)
 	{
-        $aSizes = array('bytes', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB');
+		$aSizes = array('bytes', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB');
 		$index = 0;
 		while (($fBytes > 1000) && ($index < count($aSizes)))
 		{


### PR DESCRIPTION
Multiple errors in the units sent in the returned value : 
- "b" (bit) instead of "B" (byte)
- Kb instead of kB (IEC 80000-13)
- Hb instead of EB (exabyte)

Also added some phpdoc as reference for the choices made + type hinting