### PR TITLE
N°7336 DeprecatedCallsLog robustness

### DIFF
--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -3,7 +3,7 @@
 //
 //   This file is part of iTop.
 //
-//   iTop is free software; you can redistribute it and/or modify	
+//   iTop is free software; you can redistribute it and/or modify
 //   it under the terms of the GNU Affero General Public License as published by
 //   the Free Software Foundation, either version 3 of the License, or
 //   (at your option) any later version.
@@ -1254,36 +1254,32 @@ class DeprecatedCallsLog extends LogAPI
 	private static function GetMessageFromStack(array $aDebugBacktrace): string
 	{
 		// level 0 = current method
-		/** @noinspection PhpUnusedLocalVariableInspection */
-		$iStackLevelCurrentMethod = 0;
 		// level 1 = deprecated method, containing the `NotifyDeprecatedPhpMethod` call
-		$iStackLevelMethodWithCallToNotifyDeprecated = 1;
+		$sMessage = 'Call' . self::GetMessageForCurrentStackLevel($aDebugBacktrace[1], " to ");
+
 		// level 2 = caller of the deprecated method
-		$iStackLevelDeprecatedMethodCaller = 2;
-
-		$sMessage = 'Call';
-
-		if (array_key_exists('class', $aDebugBacktrace[$iStackLevelMethodWithCallToNotifyDeprecated])) {
-			$sDeprecatedObject = $aDebugBacktrace[$iStackLevelMethodWithCallToNotifyDeprecated]['class'];
-			$sDeprecatedMethod = $aDebugBacktrace[$iStackLevelMethodWithCallToNotifyDeprecated]['function'];
-			$sMessage .= " to {$sDeprecatedObject}::{$sDeprecatedMethod}";
-		}
-		$sCallerFile = $aDebugBacktrace[$iStackLevelMethodWithCallToNotifyDeprecated]['file'];
-		$sCallerLine = $aDebugBacktrace[$iStackLevelMethodWithCallToNotifyDeprecated]['line'];
-		$sMessage .= " in {$sCallerFile}#L{$sCallerLine}";
-
-		if (array_key_exists($iStackLevelDeprecatedMethodCaller, $aDebugBacktrace)) {
+		if (array_key_exists(2, $aDebugBacktrace)) {
 			$sMessage .= ' (from ';
-			if (array_key_exists('class', $aDebugBacktrace[$iStackLevelDeprecatedMethodCaller])) {
-				$sCallerObject = $aDebugBacktrace[$iStackLevelDeprecatedMethodCaller]['class'];
-				$sCallerMethod = $aDebugBacktrace[$iStackLevelDeprecatedMethodCaller]['function'];
-				$sMessage .= "{$sCallerObject}::{$sCallerMethod}";
-			} else {
-				$sCallerFile = $aDebugBacktrace[$iStackLevelDeprecatedMethodCaller]['file'];
-				$sCallerLine = $aDebugBacktrace[$iStackLevelDeprecatedMethodCaller]['line'];
-				$sMessage .= "{$sCallerFile}#L{$sCallerLine}";
-			}
+			$sMessage .= self::GetMessageForCurrentStackLevel($aDebugBacktrace[2]);
 			$sMessage .= ')';
+		}
+
+		return $sMessage;
+	}
+
+	private static function GetMessageForCurrentStackLevel(array $aCurrentLevelDebugTrace, ?string $sPrefix=""): string
+	{
+		$sMessage = "";
+		if (array_key_exists('class', $aCurrentLevelDebugTrace)) {
+			$sDeprecatedObject = $aCurrentLevelDebugTrace['class'];
+			$sDeprecatedMethod = $aCurrentLevelDebugTrace['function'] ?? "";
+			$sMessage = "{$sPrefix}{$sDeprecatedObject}::{$sDeprecatedMethod} in ";
+		}
+
+		if (array_key_exists('file', $aCurrentLevelDebugTrace)) {
+			$sCallerFile = $aCurrentLevelDebugTrace['file'];
+			$sCallerLine = $aCurrentLevelDebugTrace['line'] ?? "";
+			$sMessage .= "{$sCallerFile}#L{$sCallerLine}";
 		}
 
 		return $sMessage;

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -1238,25 +1238,32 @@ class DeprecatedCallsLog extends LogAPI
 		}
 
 		$aStack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 3);
-		$iStackDeprecatedMethodLevel = 1; // level 0 = current method, level 1 = method containing the `NotifyDeprecatedPhpMethod` call
-		$sDeprecatedObject = $aStack[$iStackDeprecatedMethodLevel]['class'];
-		$sDeprecatedMethod = $aStack[$iStackDeprecatedMethodLevel]['function'];
-		$sCallerFile = $aStack[$iStackDeprecatedMethodLevel]['file'];
-		$sCallerLine = $aStack[$iStackDeprecatedMethodLevel]['line'];
-		$sMessage = "Call to {$sDeprecatedObject}::{$sDeprecatedMethod} in {$sCallerFile}#L{$sCallerLine}";
-
-		$iStackCallerMethodLevel = $iStackDeprecatedMethodLevel + 1; // level 2 = caller of the deprecated method
-		if (array_key_exists($iStackCallerMethodLevel, $aStack)) {
-			$sCallerObject = $aStack[$iStackCallerMethodLevel]['class'];
-			$sCallerMethod = $aStack[$iStackCallerMethodLevel]['function'];
-			$sMessage .= " ({$sCallerObject}::{$sCallerMethod})";
-		}
+		$sMessage = self::GetMessageFromStack($aStack);
 
 		if (!is_null($sAdditionalMessage)) {
 			$sMessage .= ' : '.$sAdditionalMessage;
 		}
 
 		static::Warning($sMessage, self::ENUM_CHANNEL_PHP_METHOD);
+	}
+
+	private static function GetMessageFromStack(array $aDebugBacktrace): string
+	{
+		$iStackDeprecatedMethodLevel = 1; // level 0 = current method, level 1 = method containing the `NotifyDeprecatedPhpMethod` call
+		$sDeprecatedObject = $aDebugBacktrace[$iStackDeprecatedMethodLevel]['class'];
+		$sDeprecatedMethod = $aDebugBacktrace[$iStackDeprecatedMethodLevel]['function'];
+		$sCallerFile = $aDebugBacktrace[$iStackDeprecatedMethodLevel]['file'];
+		$sCallerLine = $aDebugBacktrace[$iStackDeprecatedMethodLevel]['line'];
+		$sMessage = "Call to {$sDeprecatedObject}::{$sDeprecatedMethod} in {$sCallerFile}#L{$sCallerLine}";
+
+		$iStackCallerMethodLevel = $iStackDeprecatedMethodLevel + 1; // level 2 = caller of the deprecated method
+		if (array_key_exists($iStackCallerMethodLevel, $aDebugBacktrace)) {
+			$sCallerObject = $aDebugBacktrace[$iStackCallerMethodLevel]['class'];
+			$sCallerMethod = $aDebugBacktrace[$iStackCallerMethodLevel]['function'];
+			$sMessage .= " ({$sCallerObject}::{$sCallerMethod})";
+		}
+
+		return $sMessage;
 	}
 
 	public static function Log($sLevel, $sMessage, $sChannel = null, $aContext = array()): void

--- a/core/log.class.inc.php
+++ b/core/log.class.inc.php
@@ -1258,9 +1258,17 @@ class DeprecatedCallsLog extends LogAPI
 
 		$iStackCallerMethodLevel = $iStackDeprecatedMethodLevel + 1; // level 2 = caller of the deprecated method
 		if (array_key_exists($iStackCallerMethodLevel, $aDebugBacktrace)) {
-			$sCallerObject = $aDebugBacktrace[$iStackCallerMethodLevel]['class'];
-			$sCallerMethod = $aDebugBacktrace[$iStackCallerMethodLevel]['function'];
-			$sMessage .= " ({$sCallerObject}::{$sCallerMethod})";
+			$sMessage .= ' (from ';
+			if (array_key_exists('class', $aDebugBacktrace[$iStackCallerMethodLevel])) {
+				$sCallerObject = $aDebugBacktrace[$iStackCallerMethodLevel]['class'];
+				$sCallerMethod = $aDebugBacktrace[$iStackCallerMethodLevel]['function'];
+				$sMessage .= "{$sCallerObject}::{$sCallerMethod}";
+			} else {
+				$sCallerFile = $aDebugBacktrace[$iStackCallerMethodLevel]['file'];
+				$sCallerLine = $aDebugBacktrace[$iStackCallerMethodLevel]['line'];
+				$sMessage .= "{$sCallerFile}#L{$sCallerLine}";
+			}
+			$sMessage .= ')';
 		}
 
 		return $sMessage;

--- a/tests/php-unit-tests/unitary-tests/core/Log/DeprecatedCallsLogTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/Log/DeprecatedCallsLogTest.php
@@ -10,26 +10,28 @@ namespace Combodo\iTop\Test\UnitTest\Core\Log;
 use Combodo\iTop\Test\UnitTest\ItopTestCase;
 use DeprecatedCallsLog;
 
-class DeprecatedCallsLogTest extends ItopTestCase {
+class DeprecatedCallsLogTest extends ItopTestCase
+{
 	/**
 	 * We are testing for a undefined offset error. This was throwing a Notice, but starting with PHP 8.0 it was converted to a Warning ! Also the message was changed :(
 	 *
 	 * @link https://www.php.net/manual/en/migration80.incompatible.php check "A number of notices have been converted into warnings:"
 	 */
-	private function SetUndefinedOffsetExceptionToExpect(): void {
+	private function SetUndefinedOffsetExceptionToExpect(): void
+	{
 		/** @noinspection ConstantCanBeUsedInspection Preferring the function call as it is easier to read and won't cost that much in this PHPUnit context */
 		if (version_compare(PHP_VERSION, '8.0', '>=')) {
 			$this->expectWarning();
 			$sUndefinedOffsetExceptionMessage = 'Undefined array key "tutu"';
-		}
-		else {
+		} else {
 			$this->expectNotice();
 			$sUndefinedOffsetExceptionMessage = 'Undefined index: tutu';
 		}
 		$this->expectExceptionMessage($sUndefinedOffsetExceptionMessage);
 	}
 
-	public function testPhpNoticeWithoutDeprecatedCallsLog(): void {
+	public function testPhpNoticeWithoutDeprecatedCallsLog(): void
+	{
 		$this->SetUndefinedOffsetExceptionToExpect();
 
 		$aArray = [];
@@ -48,7 +50,8 @@ class DeprecatedCallsLogTest extends ItopTestCase {
 	 * @since 3.0.4 N°6274
 	 * @covers DeprecatedCallsLog::DeprecatedNoticesErrorHandler
 	 */
-	public function testPhpNoticeWithDeprecatedCallsLog(): void {
+	public function testPhpNoticeWithDeprecatedCallsLog(): void
+	{
 		$this->RequireOnceItopFile('core/log.class.inc.php');
 		DeprecatedCallsLog::Enable(); // will set error handler
 		$this->SetUndefinedOffsetExceptionToExpect();
@@ -62,10 +65,10 @@ class DeprecatedCallsLogTest extends ItopTestCase {
 	/**
 	 * @dataProvider GetMessageFromStackProvider
 	 */
-	public function testGetMessageFromStack($aDebugBacktrace): void
+	public function testGetMessageFromStack($aDebugBacktrace, $sExpectedMessage): void
 	{
-		$this->InvokeNonPublicStaticMethod(DeprecatedCallsLog::class, 'GetMessageFromStack', [$aDebugBacktrace]);
-		$this->assertTrue(true, 'calling with the stack should not throw a notice or error');
+		$sActualMessage = $this->InvokeNonPublicStaticMethod(DeprecatedCallsLog::class, 'GetMessageFromStack', [$aDebugBacktrace]);
+		$this->assertEquals($sExpectedMessage, $sActualMessage);
 	}
 
 	public function GetMessageFromStackProvider()
@@ -94,6 +97,59 @@ class DeprecatedCallsLogTest extends ItopTestCase {
 						'function' => 'require_once',
 					],
 				],
+				'Call to Combodo\iTop\Application\WebPage\WebPage::add_linked_script in C:\Dev\wamp64\www\itop-32\extensions\itop-object-copier\copy.php#L130 (from C:\Dev\wamp64\www\itop-32\pages\exec.php#L102)',
+			],
+
+			'Call in a file function, outside of a class' => [
+				[
+					[
+						'file'     => 'C:\\Dev\\wamp64\\www\\itop-32\\sources\\Application\\WebPage\\WebPage.php',
+						'line'     => 866,
+						'function' => 'NotifyDeprecatedPhpMethod',
+						'class'    => 'DeprecatedCallsLog',
+						'type'     => '::',
+					],
+					[
+						'file'     => 'C:\\Dev\\wamp64\\www\\itop-32\\extensions\\itop-object-copier\\copy.php',
+						'line'     => 81,
+						'function' => 'add_linked_script',
+						'class'    => 'Combodo\\iTop\\Application\\WebPage\\WebPage',
+						'type'     => '->',
+					],
+					[
+						'file'     => 'C:\\Dev\\wamp64\\www\\itop-32\\extensions\\itop-object-copier\\copy.php',
+						'line'     => 123,
+						'function' => 'myFunction',
+					],
+				],
+				'Call to Combodo\iTop\Application\WebPage\WebPage::add_linked_script in C:\Dev\wamp64\www\itop-32\extensions\itop-object-copier\copy.php#L81 (from C:\Dev\wamp64\www\itop-32\extensions\itop-object-copier\copy.php#L123)',
+			],
+
+			'Call from a class method' => [
+				[
+					[
+						'file'     => 'C:\\Dev\\wamp64\\www\\itop-32\\sources\\Application\\WebPage\\WebPage.php',
+						'line'     => 866,
+						'function' => 'NotifyDeprecatedPhpMethod',
+						'class'    => 'DeprecatedCallsLog',
+						'type'     => '::',
+					],
+					[
+						'file'     => 'C:\\Dev\\wamp64\\www\\itop-32\\extensions\\itop-object-copier\\copy.php',
+						'line'     => 82,
+						'function' => 'add_linked_script',
+						'class'    => 'Combodo\\iTop\\Application\\WebPage\\WebPage',
+						'type'     => '->',
+					],
+					[
+						'file'     => 'C:\\Dev\\wamp64\\www\\itop-32\\extensions\\itop-object-copier\\copy.php',
+						'line'     => 125,
+						'function' => 'MyMethod',
+						'class'    => 'MyClass',
+						'type'     => '::',
+					],
+				],
+				'Call to Combodo\iTop\Application\WebPage\WebPage::add_linked_script in C:\Dev\wamp64\www\itop-32\extensions\itop-object-copier\copy.php#L82 (from MyClass::MyMethod)',
 			],
 		];
 	}

--- a/tests/php-unit-tests/unitary-tests/core/Log/DeprecatedCallsLogTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/Log/DeprecatedCallsLogTest.php
@@ -58,4 +58,43 @@ class DeprecatedCallsLogTest extends ItopTestCase {
 			//Do nothing, just raising a undefined offset warning
 		}
 	}
+
+	/**
+	 * @dataProvider GetMessageFromStackProvider
+	 */
+	public function testGetMessageFromStack($aDebugBacktrace): void
+	{
+		$this->InvokeNonPublicStaticMethod(DeprecatedCallsLog::class, 'GetMessageFromStack', [$aDebugBacktrace]);
+		$this->assertTrue(true, 'calling with the stack should not throw a notice or error');
+	}
+
+	public function GetMessageFromStackProvider()
+	{
+		return [
+			'Call in a file outside of a function or class' => [
+				[
+					[
+						'file'     => 'C:\Dev\wamp64\www\itop-32\sources\Application\WebPage\WebPage.php',
+						'line'     => '866',
+						'function' => 'NotifyDeprecatedPhpMethod',
+						'class'    => 'DeprecatedCallsLog',
+						'type'     => '::',
+					],
+					[
+						'file'     => 'C:\Dev\wamp64\www\itop-32\extensions\itop-object-copier\copy.php',
+						'line'     => '130',
+						'function' => 'add_linked_script',
+						'class'    => 'Combodo\iTop\Application\WebPage\WebPage',
+						'type'     => '->',
+					],
+					[
+						'file'     => 'C:\Dev\wamp64\www\itop-32\pages\exec.php',
+						'line'     => '102',
+						'args'     => ['C:\Dev\wamp64\www\itop-32\extensions\itop-object-copier\copy.php'],
+						'function' => 'require_once',
+					],
+				],
+			],
+		];
+	}
 }

--- a/tests/php-unit-tests/unitary-tests/core/Log/DeprecatedCallsLogTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/Log/DeprecatedCallsLogTest.php
@@ -149,7 +149,7 @@ class DeprecatedCallsLogTest extends ItopTestCase
 						'type'     => '::',
 					],
 				],
-				'Call to Combodo\iTop\Application\WebPage\WebPage::add_linked_script in C:\Dev\wamp64\www\itop-32\extensions\itop-object-copier\copy.php#L82 (from MyClass::MyMethod)',
+				'Call to Combodo\iTop\Application\WebPage\WebPage::add_linked_script in C:\Dev\wamp64\www\itop-32\extensions\itop-object-copier\copy.php#L82 (from MyClass::MyMethod in C:\Dev\wamp64\www\itop-32\extensions\itop-object-copier\copy.php#L125)',
 			],
 		];
 	}


### PR DESCRIPTION
When a call to a deprecated method is done outside of a class method, then DeprecatedCallsLog will generate php notices.

Was seen in nightly builds on iTop 3.2 when calling itop-object-copier copy.php : this script contains calls to \Combodo\iTop\Application\WebPage\WebPage::add_linked_script which are deprecated.

What was done : 
* Extract DeprecatedCallsLog message generation to a method
* Add a test with 3 uses cases (call directly in a file, in a method in a file, in a class method)
* Fix the notice
