### PR TITLE
N°7348 - Enable to param maximum depth of impact analysis in function Ticket::UpdateImpactedItems

### DIFF
--- a/datamodels/2.x/itop-tickets/main.itop-tickets.php
+++ b/datamodels/2.x/itop-tickets/main.itop-tickets.php
@@ -133,7 +133,15 @@ class ResponseTicketTTR extends ResponseTicketSLT implements iMetricComputer
 class _Ticket extends cmdbAbstractObject
 {
 
-	public function UpdateImpactedItems()
+	/**
+	 * @param $iMaxDepth maximum depth of impact analysis
+	 *
+	 * @return void
+	 * @throws \ArchivedObjectException
+	 * @throws \CoreException
+	 * @throws \CoreUnexpectedValue
+	 */
+	public function UpdateImpactedItems($iMaxDepth=10)
 	{
 		require_once(APPROOT.'core/displayablegraph.class.inc.php');
 		/** @var ormLinkSet $oContactsSet */
@@ -188,7 +196,7 @@ class _Ticket extends cmdbAbstractObject
 		}
 		// Merge the directly impacted items with the "new" ones added by the "context" queries
         $aGraphObjects = array();
-        $oRawGraph = MetaModel::GetRelatedObjectsDown('impacts', $aSources, 10, true /* bEnableRedundancy */, $aExcluded);
+        $oRawGraph = MetaModel::GetRelatedObjectsDown('impacts', $aSources, $iMaxDepth, true /* bEnableRedundancy */, $aExcluded);
         $oIterator = new RelationTypeIterator($oRawGraph, 'Node');
         foreach ($oIterator as $oNode)
         {
@@ -200,7 +208,7 @@ class _Ticket extends cmdbAbstractObject
         }
         if (count($aDefaultContexts) > 0)
 		{
-			$oAnnotatedGraph = MetaModel::GetRelatedObjectsDown('impacts', $aSources, 10, true /* bEnableRedundancy */, $aExcluded, $aDefaultContexts);
+			$oAnnotatedGraph = MetaModel::GetRelatedObjectsDown('impacts', $aSources, $iMaxDepth, true /* bEnableRedundancy */, $aExcluded, $aDefaultContexts);
 			$oIterator = new RelationTypeIterator($oAnnotatedGraph, 'Node');
 			foreach ($oIterator as $oNode)
 			{

--- a/datamodels/2.x/itop-tickets/main.itop-tickets.php
+++ b/datamodels/2.x/itop-tickets/main.itop-tickets.php
@@ -134,7 +134,7 @@ class _Ticket extends cmdbAbstractObject
 {
 
 	/**
-	 * @param $iMaxDepth maximum depth of impact analysis
+	 * @param int $iMaxDepth maximum depth of impact analysis
 	 *
 	 * @return void
 	 * @throws \ArchivedObjectException

--- a/datamodels/2.x/itop-tickets/main.itop-tickets.php
+++ b/datamodels/2.x/itop-tickets/main.itop-tickets.php
@@ -132,6 +132,14 @@ class ResponseTicketTTR extends ResponseTicketSLT implements iMetricComputer
 
 class _Ticket extends cmdbAbstractObject
 {
+	/**
+	 * used to limit the depth of analysis in the UpdateImpactedItems function
+	 * @return int
+	 */
+	public function GetImpactAnalysisMaxDepth()
+	{
+		return 10;
+	}
 
 	/**
 	 * @param int $iMaxDepth maximum depth of impact analysis
@@ -141,7 +149,7 @@ class _Ticket extends cmdbAbstractObject
 	 * @throws \CoreException
 	 * @throws \CoreUnexpectedValue
 	 */
-	public function UpdateImpactedItems(int $iMaxDepth = 10)
+	public function UpdateImpactedItems()
 	{
 		require_once(APPROOT.'core/displayablegraph.class.inc.php');
 		/** @var ormLinkSet $oContactsSet */
@@ -196,7 +204,7 @@ class _Ticket extends cmdbAbstractObject
 		}
 		// Merge the directly impacted items with the "new" ones added by the "context" queries
         $aGraphObjects = array();
-        $oRawGraph = MetaModel::GetRelatedObjectsDown('impacts', $aSources, $iMaxDepth, true /* bEnableRedundancy */, $aExcluded);
+        $oRawGraph = MetaModel::GetRelatedObjectsDown('impacts', $aSources, $this->GetImpactAnalysisMaxDepth(), true /* bEnableRedundancy */, $aExcluded);
         $oIterator = new RelationTypeIterator($oRawGraph, 'Node');
         foreach ($oIterator as $oNode)
         {
@@ -208,7 +216,7 @@ class _Ticket extends cmdbAbstractObject
         }
         if (count($aDefaultContexts) > 0)
 		{
-			$oAnnotatedGraph = MetaModel::GetRelatedObjectsDown('impacts', $aSources, $iMaxDepth, true /* bEnableRedundancy */, $aExcluded, $aDefaultContexts);
+			$oAnnotatedGraph = MetaModel::GetRelatedObjectsDown('impacts', $aSources, $this->GetImpactAnalysisMaxDepth(), true /* bEnableRedundancy */, $aExcluded, $aDefaultContexts);
 			$oIterator = new RelationTypeIterator($oAnnotatedGraph, 'Node');
 			foreach ($oIterator as $oNode)
 			{

--- a/datamodels/2.x/itop-tickets/main.itop-tickets.php
+++ b/datamodels/2.x/itop-tickets/main.itop-tickets.php
@@ -141,7 +141,7 @@ class _Ticket extends cmdbAbstractObject
 	 * @throws \CoreException
 	 * @throws \CoreUnexpectedValue
 	 */
-	public function UpdateImpactedItems($iMaxDepth=10)
+	public function UpdateImpactedItems(int $iMaxDepth = 10)
 	{
 		require_once(APPROOT.'core/displayablegraph.class.inc.php');
 		/** @var ormLinkSet $oContactsSet */

--- a/tests/php-unit-tests/src/BaseTestCase/ItopDataTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopDataTestCase.php
@@ -1199,6 +1199,27 @@ abstract class ItopDataTestCase extends ItopTestCase
 		return $sId;
 	}
 
+	/**
+	 * Create an Application Solution in database
+	 *
+	 * @param int $iNum
+	 * @param string $sRedundancy
+	 *
+	 * @throws Exception
+	 */
+	protected function GivenApplicationSolutionInDB($iNum, $sRedundancy = '1'): string
+	{
+		$sName = 'ApplicationSolution_'.$iNum;
+		$sId = $this->GivenObjectInDB('ApplicationSolution', [
+			'name'       => $sName,
+			'org_id'     => $this->getTestOrgId(),
+			'redundancy' => $sRedundancy,
+		]);
+		$this->debug("Created $sName ($sId) redundancy $sRedundancy");
+
+		return $sId;
+	}
+
 	protected function GivenServerInDB($iNum, $iRackUnit = null): string
 	{
 		$sName = 'Server_'.$iNum;
@@ -1251,6 +1272,18 @@ abstract class ItopDataTestCase extends ItopTestCase
 			'functionalci_id' => $sCIId,
 		]);
 		$this->debug("Created $sClass::$sId linking contact $sContactId and CI $sCIId");
+
+		return $sId;
+	}
+
+	protected function GivenLnkApplicationSolutionToFunctionalCIInDB($sApplicationSolutionId, $sCIId): string
+	{
+		$sClass = 'lnkApplicationSolutionToFunctionalCI';
+		$sId = $this->GivenObjectInDB($sClass, [
+			'applicationsolution_id' => $sApplicationSolutionId,
+			'functionalci_id' => $sCIId,
+		]);
+		$this->debug("Created $sClass::$sId linking ApplicationSolution $sApplicationSolutionId and CI $sCIId");
 
 		return $sId;
 	}

--- a/tests/php-unit-tests/unitary-tests/datamodels/2.x/itop-tickets/UpdateImpactedItemsTest.php
+++ b/tests/php-unit-tests/unitary-tests/datamodels/2.x/itop-tickets/UpdateImpactedItemsTest.php
@@ -148,6 +148,7 @@ class UpdateImpactedItemsTest extends ItopDataTestCase
 
 		$oTicket->UpdateImpactedItems(); // impact analysis
 
+		// By default Max depth is 10. Can be changed by overriding _Ticket::GetImpactAnalysisMaxDepth
 		$this->assertCIsOrPersonsListEquals($oTicket, [
 			'ApplicationSolution_0' => 'manual',
 			'ApplicationSolution_1' => 'computed',


### PR DESCRIPTION
In this kind of delta
![image](https://github.com/Combodo/iTop/assets/57360138/c9c94366-55e2-417b-90bd-119bdc817305)

we want to limit depth of impact analysis to 1 or 2. It's actually hard coded to 10.