### PR TITLE
N°7306 - Use iTop configuration settings to run unattended installation (instead of XML file settings)

### DIFF
--- a/setup/unattended-install/unattended-install.php
+++ b/setup/unattended-install/unattended-install.php
@@ -57,10 +57,19 @@ if ($bUseItopConfig && file_exists($sConfigFile)){
 	$aDBXmlSettings ['db_tls_enabled'] = $oConfig->Get('db_tls.enabled');
 	//cannot be null or infinite loop triggered!
 	$aDBXmlSettings ['db_tls_ca'] = $oConfig->Get('db_tls.ca') ?? "";
-
 	$oParams->Set('database', $aDBXmlSettings);
 
-	$oParams->Set('url', $oConfig->Get('app_root_url'));
+	$aFields = [
+		'url' => 'app_root_url',
+		'source_dir' => 'source_dir',
+		'graphviz_path' => 'graphviz_path',
+		'language' => 'default_language',
+	];
+	foreach($aFields as $sSetupField => $sConfField){
+		$oParams->Set($sSetupField, $oConfig->Get($sConfField));
+	}
+
+	$oParams->Set('mysql_bindir', $oConfig->GetModuleSetting('itop-backup', 'mysql_bindir', ""));
 } else {
 	//unattended run based on db settings coming from response_file (XML file)
 	$aDBXmlSettings = $oParams->Get('database', array());

--- a/setup/unattended-install/unattended-install.php
+++ b/setup/unattended-install/unattended-install.php
@@ -63,13 +63,13 @@ if ($bUseItopConfig && file_exists($sConfigFile)){
 		'url' => 'app_root_url',
 		'source_dir' => 'source_dir',
 		'graphviz_path' => 'graphviz_path',
-		'language' => 'default_language',
 	];
 	foreach($aFields as $sSetupField => $sConfField){
 		$oParams->Set($sSetupField, $oConfig->Get($sConfField));
 	}
 
 	$oParams->Set('mysql_bindir', $oConfig->GetModuleSetting('itop-backup', 'mysql_bindir', ""));
+	$oParams->Set('language', $oConfig->GetDefaultLanguage());
 } else {
 	//unattended run based on db settings coming from response_file (XML file)
 	$aDBXmlSettings = $oParams->Get('database', array());

--- a/setup/unattended-install/unattended-install.php
+++ b/setup/unattended-install/unattended-install.php
@@ -48,16 +48,18 @@ if ($bUseItopConfig && file_exists($sConfigFile)){
 	copy($sConfigFile, "$sConfigFile.backup");
 
 	$oConfig = new Config($sConfigFile);
-	$aDBXmlSettings = [
-		'server' => $oConfig->Get('db_host'),
-		'user' => $oConfig->Get('db_user'),
-		'pwd' => $oConfig->Get('db_pwd'),
-		'name' => $oConfig->Get('db_name'),
-		'prefix' => $oConfig->Get('db_subname'),
-		'db_tls_enabled' => $oConfig->Get('db_tls.enabled'),
-		'db_tls_ca' => $oConfig->Get('db_tls.ca'),
-	];
+	$aDBXmlSettings = $oParams->Get('database', array());
+	$aDBXmlSettings ['server'] = $oConfig->Get('db_host');
+	$aDBXmlSettings ['user'] = $oConfig->Get('db_user');
+	$aDBXmlSettings ['pwd'] = $oConfig->Get('db_pwd');
+	$aDBXmlSettings ['name'] = $oConfig->Get('db_name');
+	$aDBXmlSettings ['prefix'] = $oConfig->Get('db_subname');
+	$aDBXmlSettings ['db_tls_enabled'] = $oConfig->Get('db_tls.enabled');
+	//cannot be null or infinite loop triggered!
+	$aDBXmlSettings ['db_tls_ca'] = $oConfig->Get('db_tls.ca') ?? "";
+
 	$oParams->Set('database', $aDBXmlSettings);
+
 	$oParams->Set('url', $oConfig->Get('app_root_url'));
 } else {
 	//unattended run based on db settings coming from response_file (XML file)


### PR DESCRIPTION
### Enhancement
Add an option to use existing configuration file settings (config-itop.php) when installing iTop application via unattended CLI.

```
php unattended-install.php --use-itop-config=1 --response_file=setup_path
```

With this option enabled (=1) you do not have to copy/paste existing settings from config-itop.php to XML setup file (for example DB parameters).  In that case setup XML provided is used to specify how iTop will be installed (fresh installation/ upgrade, which modules/extensions to install, ...).

