### PR TITLE
N°7416 - Setup: Add warning for optionnal PHP extension "APCu"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,9 +44,10 @@
     "ext-libsodium": "Required to use the AttributeEncryptedString.",
     "ext-openssl": "Can be used as a polyfill if libsodium is not installed",
     "ext-mcrypt": "Can be used as a polyfill if either libsodium and openssl are not installed (libsodium and openssl are more secure)",
+    "ext-apcu": "For better performance and stability",
+    "ext-imap": "Required by the extension \"Mail to ticket automation\""
     "ext-ldap": "Required to use LDAP as an identity provider",
     "ext-posix": "Not required by the core, but some extensions uses it.",
-    "ext-imap": "Required by the extension \"Mail to ticket automation\""
   },
   "config": {
     "platform": {

--- a/setup/setuputils.class.inc.php
+++ b/setup/setuputils.class.inc.php
@@ -2169,6 +2169,7 @@ JS
 				'sodium' => 'Strong encryption will not be used.',
 				'openssl' => 'Strong encryption will not be used.',
 			],
+			'apcu' => 'Performances will be slightly degraded.',
 			'ldap' => 'LDAP authentication will be disabled.',
 		];
 


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | N°7416
| Type of change?                                               | Enhancement


## Objective (enhancement)
Today we use APC to cache things in iTop.

However, this extension is rarely present by default with PHP installations, so we have our own APC emulation layer via the files _apc-compat.php_ and _apc-emulation.php_.

The problem is that this emulation is not perfect and often causes problems.

To try to mitigate this issue, we want to encourage people to activate the official PHP _APCu_ extension on their server.


## Proposed solution (bug and enhancement)
As _APCu_ is not present on the majority of PHP installations, we put a _warning_ only during setup, no blocking error.

Our compatibility layer remains present just in case.

_Screenshot without the APCu extension_
![image](https://github.com/Combodo/iTop/assets/5130468/9d5170f6-93be-4bec-a174-a897d5e2517a)


_Screenshot with the APCu extension_
![image](https://github.com/Combodo/iTop/assets/5130468/25d8fd4d-1522-4ca3-b2c4-fc5b35940d39)


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [X] I have added a unit test, otherwise I have explained why I couldn't
  => No unit test on that 
- [X] Is the PR clear and detailed enough so anyone can understand digging in the code?
