### PR TITLE
N°2443 - Boolean don't accept yes/no value

### DIFF
--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -2613,7 +2613,7 @@ JS
 						// convert AttributeBoolean value due to issue with radio style when value is false
 						// @see N°2443 - Boolean don't accept yes/no value
 						if($oAttDef instanceof AttributeBoolean){
-							$value === false ? $value = 0 : $value = 1;
+							$value = $value === false ? 0 : 1;
 						}
 
 						// Discrete list of values, use a SELECT or RADIO buttons depending on the config

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -2609,6 +2609,13 @@ JS
 					$iFieldSize = $oAttDef->GetMaxSize();
 					if ($aAllowedValues !== null)
 					{
+
+						// convert AttributeBoolean value due to issue with radio style when value is false
+						// @see N°2443 - Boolean don't accept yes/no value
+						if($oAttDef instanceof AttributeBoolean){
+							$value === false ? $value = 0 : $value = 1;
+						}
+
 						// Discrete list of values, use a SELECT or RADIO buttons depending on the config
 						$sDisplayStyle = $oAttDef->GetDisplayStyle();
 						switch ($sDisplayStyle)

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -3572,6 +3572,19 @@ class AttributeBoolean extends AttributeInteger
 	{
 		return CMDBChangeOpSetAttributeScalar::class;
 	}
+
+	public function GetAllowedValues($aArgs = array(), $sContains = '') : array
+	{
+		return [
+			0 => $this->GetValueLabel(false),
+			1 => $this->GetValueLabel(true)
+		];
+	}
+
+	public function GetDisplayStyle()
+	{
+		return $this->GetOptional('display_style', 'select');
+	}
 }
 
 /**


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=2443&c[menu]=SearchBugs
| Type of change?                                               | Bug fix


## Symptom (bug) / Objective (enhancement)
Edition of AttributeBoolean is confusing, the component used is a TextField Input, filled with read view representation (yes, no), and cannot be submit until you fill the model representation  (0, 1).

## Reproduction procedure (bug)
Edit an object with a AttributeBoolean (SynchroAttribute for example)

## Cause (bug)
First implementation incomplete.

## Proposed solution (bug and enhancement)
Because this kind of developments may be treated by SDK Form, the proposition is to do the minimalist changes.
In CmdbAbstract class, where attribute components are handled, the AttributeBoolean doesn't have a specific case, so it is handle with a simple text input (the default case).
The default case contain a test that can be usefull for our need, it checks allowed_values parameter existence, so if we provide this attribute parameter it could be handle via a select or radio button component (depending on another parameter display_style) 

![2024-04-15_16h45_31](https://github.com/Combodo/iTop/assets/95754414/2bbc9166-d93a-43e7-955c-a5840cd53288)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge
<!--
Things that needs to be done in the PR before it can be considered as ready to be merged

Examples:
- Changes requested in the review
- Unit test to add
- Dictionary entries to translate
- ...
-->

- [ ] Verify Behat impact
- [ ] ...
- [ ] ...
