### PR TITLE
N°7644 - Add Brand logo and Model picture

### DIFF
--- a/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
+++ b/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
@@ -4491,6 +4491,9 @@
             <attribute id="name"/>
           </attributes>
         </naming>
+        <fields_semantic>
+          <image_attribute>logo</image_attribute>
+        </fields_semantic>
         <style>
           <icon/>
         </style>
@@ -4509,6 +4512,13 @@
         </uniqueness_rules>
       </properties>
       <fields>
+        <field id="logo" xsi:type="AttributeImage">
+          <display_max_width>96</display_max_width>
+          <display_max_height>96</display_max_height>
+          <storage_max_width>128</storage_max_width>
+          <storage_max_height>128</storage_max_height>
+          <is_null_allowed>true</is_null_allowed>
+        </field>
         <field id="physicaldevices_list" xsi:type="AttributeLinkedSet">
           <linked_class>PhysicalDevice</linked_class>
           <ext_key_to_me>brand_id</ext_key_to_me>
@@ -4525,8 +4535,11 @@
             <item id="name">
               <rank>10</rank>
             </item>
-            <item id="physicaldevices_list">
+            <item id="logo">
               <rank>20</rank>
+            </item>
+            <item id="physicaldevices_list">
+              <rank>30</rank>
             </item>
           </items>
         </details>
@@ -4544,6 +4557,13 @@
             </item>
           </items>
         </list>
+        <summary>
+          <items>
+            <item id="name">
+              <rank>10</rank>
+            </item>
+          </items>
+        </summary>
       </presentation>
     </class>
     <class id="Model" _delta="define">
@@ -4564,6 +4584,9 @@
             <attribute id="type"/>
           </complementary_attributes>
         </naming>
+        <fields_semantic>
+          <image_attribute>picture</image_attribute>
+        </fields_semantic>
         <style>
           <icon/>
         </style>
@@ -4595,6 +4618,13 @@
         <field id="brand_name" xsi:type="AttributeExternalField">
           <extkey_attcode>brand_id</extkey_attcode>
           <target_attcode>name</target_attcode>
+        </field>
+        <field id="picture" xsi:type="AttributeImage">
+          <display_max_width>256</display_max_width>
+          <display_max_height>256</display_max_height>
+          <storage_max_width>512</storage_max_width>
+          <storage_max_height>512</storage_max_height>
+          <is_null_allowed>true</is_null_allowed>
         </field>
         <field id="type" xsi:type="AttributeEnum">
           <sort_type>label</sort_type>
@@ -4678,11 +4708,14 @@
             <item id="brand_id">
               <rank>20</rank>
             </item>
-            <item id="type">
+            <item id="picture">
               <rank>30</rank>
             </item>
-            <item id="physicaldevices_list">
+            <item id="type">
               <rank>40</rank>
+            </item>
+            <item id="physicaldevices_list">
+              <rank>50</rank>
             </item>
           </items>
         </details>

--- a/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
+++ b/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
@@ -4750,6 +4750,9 @@
             <item id="type">
               <rank>20</rank>
             </item>
+            <item id="picture">
+              <rank>30</rank>
+            </item>
           </items>
         </summary>
       </presentation>

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/en.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/en.dict.itop-config-mgmt.php
@@ -1092,6 +1092,8 @@ Dict::Add('EN US', 'English', 'English', array(
 Dict::Add('EN US', 'English', 'English', array(
 	'Class:Brand' => 'Brand',
 	'Class:Brand+' => '',
+	'Class:Brand/Attribute:logo' => 'Logo',
+	'Class:Brand/Attribute:logo+' => '',
 	'Class:Brand/Attribute:physicaldevices_list' => 'Physical devices',
 	'Class:Brand/Attribute:physicaldevices_list+' => 'All the physical devices corresponding to this brand',
 	'Class:Brand/UniquenessRule:name+' => 'The name must be unique',
@@ -1110,6 +1112,8 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Class:Model/Attribute:brand_id+' => '',
 	'Class:Model/Attribute:brand_name' => 'Brand name',
 	'Class:Model/Attribute:brand_name+' => '',
+	'Class:Model/Attribute:picture' => 'Picture',
+	'Class:Model/Attribute:picture+' => '',
 	'Class:Model/Attribute:type' => 'Device type',
 	'Class:Model/Attribute:type+' => '',
 	'Class:Model/Attribute:type/Value:PowerSource' => 'Power Source',


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Enhancement

## Objective

Some people (including me) like it to also document the brand logo of their devices. It would also be nice to have a picture of a specific model for easier recognition.

## Proposed solution

* Added a new logo `AttributeImage` field to the class `Brand` and use that also as `image_attribute`:

![Screenshot of a Brand object having the logo](https://github.com/Combodo/iTop/assets/228588/a3684670-fc64-4a15-b743-89317c56f5cf)

![Screenshot of a Server creation form selecting the Brand](https://github.com/Combodo/iTop/assets/228588/124cf1b1-39f8-433a-84e8-f2f50b6a88a7)

* Added a new picture `AttributeImage` field to the class `Model` and use that also as `image_attribute`:

![Screenshot of a Model object having a picture and mouseover on the brand link](https://github.com/Combodo/iTop/assets/228588/2d3b5027-4055-48f3-8c57-1ee5d4433bed)

* Also created a new summary card for `Brand` to be able to see the logo when hovering on a brand link, as seen in previous screenshot.

I don't think it's relevant to add unit tests to the datamodel classes and fields.

## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code
- [ ] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?
