### PR TITLE
N°7639 - Switching tab starts reloading the datatable even if data are already loaded

### DIFF
--- a/js/dataTables.pipeline.js
+++ b/js/dataTables.pipeline.js
@@ -55,7 +55,7 @@ $.fn.dataTable.pipeline = function (opts, initJson) {
 			// API requested that the cache be cleared
 			ajax = true;
 			settings.clearCache = false;
-		} else if (cacheLower < 0 || requestStart < cacheLower || requestEnd > cacheUpper) {
+		} else if (cacheLower < 0 || requestStart < cacheLower || (requestEnd > cacheUpper && cacheUpper <  settings._iRecordsTotal)) {
 			// outside cached data - need to make a request
 			ajax = true;
 		} else if (JSON.stringify(request.order) !== JSON.stringify(cacheLastRequest.order) ||


### PR DESCRIPTION
On an object display, when you display a tab that contains a data table, it is systematically reloaded even though the data is already all present on the screen. This fix prevents this reload.