### PR TITLE
Correctly identify as iTop in cURL requests

### DIFF
--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -1929,7 +1929,7 @@ SQL;
 			CURLOPT_HEADER         => false,    // don't return the headers in the output
 			CURLOPT_FOLLOWLOCATION => true,     // follow redirects
 			CURLOPT_ENCODING       => "",       // handle all encodings
-			CURLOPT_USERAGENT      => ITOP_APPLICATION.'/'.ITOP_VERSION, // who am i
+			CURLOPT_USERAGENT      => static::GetConfig()->Get('http.request.user_agent'), // who am i
 			CURLOPT_AUTOREFERER    => true,     // set referer on redirect
 			CURLOPT_CONNECTTIMEOUT => 120,      // timeout on connect
 			CURLOPT_TIMEOUT        => 120,      // timeout on response

--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -1929,7 +1929,7 @@ SQL;
 			CURLOPT_HEADER         => false,    // don't return the headers in the output
 			CURLOPT_FOLLOWLOCATION => true,     // follow redirects
 			CURLOPT_ENCODING       => "",       // handle all encodings
-			CURLOPT_USERAGENT      => "spider", // who am i
+			CURLOPT_USERAGENT      => ITOP_APPLICATION.'/'.ITOP_VERSION, // who am i
 			CURLOPT_AUTOREFERER    => true,     // set referer on redirect
 			CURLOPT_CONNECTTIMEOUT => 120,      // timeout on connect
 			CURLOPT_TIMEOUT        => 120,      // timeout on response

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1787,6 +1787,13 @@ class Config
 			'source_of_value'     => '',
 			'show_in_conf_sample' => false,
 		],
+		'http.request.user_agent' => [
+			'type'                => 'string',
+			'description'         => 'HTTP request user agent, use this to set a custom agent on external requests.',
+			'default'             => ITOP_APPLICATION.'/'.ITOP_VERSION,
+			'source_of_value'     => '',
+			'show_in_conf_sample' => false,
+		]
 	];
 
 	public function IsProperty($sPropCode)


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Enhancement


## Objective

Outgoing HTTP requests are identified with "spider" user agent, which can simply be blocked sometimes.

## Proposed solution

Use for example `iTop/3.2.0` as user agent when doing HTTP requests to other services..

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?
