### PR TITLE
N°7636 - Too many OQL requests executed in order to display a lnk

### DIFF
--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -698,8 +698,7 @@ HTML
 			$sLinkedClass = $oAttDef->GetLinkedClass();
 
 			// Filter out links pointing to obsolete objects (if relevant)
-            if (array_key_exists($sAttCode, $this->GetValues()))
-            {
+            if (array_key_exists($sAttCode, $this->GetValues())) {
                 $oOrmLinkSet = $this->GetValues()[$sAttCode];
             } else {
                  $oOrmLinkSet = $this->Get($sAttCode);
@@ -5195,7 +5194,11 @@ HTML
 							$aKeys = array_keys($aValues[$sAttCode]);
 							$currValue = $aKeys[0]; // The only value is the first key
 							if ($oAttDef->GetEditClass() == 'LinkedSet') {
-								$oOrmLinkSet = $oDummyObj->GetValues()[$sAttCode];
+                                if (array_key_exists($sAttCode, $oDummyObj->GetValues())) {
+                                    $oOrmLinkSet = $oDummyObj->GetValues()[$sAttCode];
+                                } else {
+                                    $oOrmLinkSet = $oDummyObj->Get($sAttCode);
+                                }
 								LinkSetDataTransformer::StringToOrmLinkSet($aValues[$sAttCode][$currValue]['edit_value'], $oOrmLinkSet);
 
 							} else {
@@ -5249,7 +5252,11 @@ HTML
 								}
 								$oDummyObj->Set($sAttCode, $oTagSet);
 							} else if ($oAttDef->GetEditClass() == 'LinkedSet') {
-								$oOrmLinkSet = $oDummyObj->GetValues()[$sAttCode];
+                                if (array_key_exists($sAttCode, $oDummyObj->GetValues())) {
+                                    $oOrmLinkSet = $oDummyObj->GetValues()[$sAttCode];
+                                } else {
+                                    $oOrmLinkSet = $oDummyObj->Get($sAttCode);
+                                }
 								foreach ($aMultiValues as $key => $sValue) {
 									LinkSetDataTransformer::StringToOrmLinkSet($sValue['edit_value'], $oOrmLinkSet);
 								}

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -698,7 +698,8 @@ HTML
 			$sLinkedClass = $oAttDef->GetLinkedClass();
 
 			// Filter out links pointing to obsolete objects (if relevant)
-			$oOrmLinkSet = $this->Get($sAttCode);
+			//$oOrmLinkSet = $this->Get($sAttCode);
+			$oOrmLinkSet = $this->GetValues()[$sAttCode];
 			$oLinkSet = $oOrmLinkSet->ToDBObjectSet(utils::ShowObsoleteData());
 
 			$iCount = $oLinkSet->Count();
@@ -766,9 +767,9 @@ HTML
 				$oPage->add($sHTMLValue);
 			} else {
 				if ($oAttDef->IsIndirect()) {
-					$oBlockLinkSetViewTable = new BlockIndirectLinkSetViewTable($oPage, $this, $sClass, $sAttCode, $oAttDef, $bReadOnly);
+					$oBlockLinkSetViewTable = new BlockIndirectLinkSetViewTable($oPage, $this, $sClass, $sAttCode, $oAttDef, $bReadOnly, $iCount);
 				} else {
-					$oBlockLinkSetViewTable = new BlockDirectLinkSetViewTable($oPage, $this, $sClass, $sAttCode, $oAttDef, $bReadOnly);
+					$oBlockLinkSetViewTable = new BlockDirectLinkSetViewTable($oPage, $this, $sClass, $sAttCode, $oAttDef, $bReadOnly, $iCount);
 				}
 				$oPage->AddUiBlock($oBlockLinkSetViewTable);
 			}
@@ -5190,7 +5191,7 @@ HTML
 							$aKeys = array_keys($aValues[$sAttCode]);
 							$currValue = $aKeys[0]; // The only value is the first key
 							if ($oAttDef->GetEditClass() == 'LinkedSet') {
-								$oOrmLinkSet = $oDummyObj->Get($sAttCode);
+								$oOrmLinkSet = $oDummyObj->GetValues()[$sAttCode];
 								LinkSetDataTransformer::StringToOrmLinkSet($aValues[$sAttCode][$currValue]['edit_value'], $oOrmLinkSet);
 
 							} else {
@@ -5244,7 +5245,7 @@ HTML
 								}
 								$oDummyObj->Set($sAttCode, $oTagSet);
 							} else if ($oAttDef->GetEditClass() == 'LinkedSet') {
-								$oOrmLinkSet = $oDummyObj->Get($sAttCode);
+								$oOrmLinkSet = $oDummyObj->GetValues()[$sAttCode];
 								foreach ($aMultiValues as $key => $sValue) {
 									LinkSetDataTransformer::StringToOrmLinkSet($sValue['edit_value'], $oOrmLinkSet);
 								}

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -698,13 +698,12 @@ HTML
 			$sLinkedClass = $oAttDef->GetLinkedClass();
 
 			// Filter out links pointing to obsolete objects (if relevant)
-            if(array_key_exists($sAttCode, $this->GetValues()))
+            if (array_key_exists($sAttCode, $this->GetValues()))
             {
                 $oOrmLinkSet = $this->GetValues()[$sAttCode];
             } else {
-                $oOrmLinkSet = $this->Get($sAttCode);
+                 $oOrmLinkSet = $this->Get($sAttCode);
             }
-            $oOrmLinkSet->Rewind();
             $oLinkSet = $oOrmLinkSet->ToDBObjectSet(utils::ShowObsoleteData());
             $iCount = $oLinkSet->Count();
 

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -698,11 +698,16 @@ HTML
 			$sLinkedClass = $oAttDef->GetLinkedClass();
 
 			// Filter out links pointing to obsolete objects (if relevant)
-			//$oOrmLinkSet = $this->Get($sAttCode);
-			$oOrmLinkSet = $this->GetValues()[$sAttCode];
-			$oLinkSet = $oOrmLinkSet->ToDBObjectSet(utils::ShowObsoleteData());
+            if(array_key_exists($sAttCode, $this->GetValues()))
+            {
+                $oOrmLinkSet = $this->GetValues()[$sAttCode];
+            } else {
+                $oOrmLinkSet = $this->Get($sAttCode);
+            }
+            $oOrmLinkSet->Rewind();
+            $oLinkSet = $oOrmLinkSet->ToDBObjectSet(utils::ShowObsoleteData());
+            $iCount = $oLinkSet->Count();
 
-			$iCount = $oLinkSet->Count();
 			if ($this->IsNew()) {
 				$iFlags = $this->GetInitialStateAttributeFlags($sAttCode);
 			} else {

--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -698,11 +698,7 @@ HTML
 			$sLinkedClass = $oAttDef->GetLinkedClass();
 
 			// Filter out links pointing to obsolete objects (if relevant)
-            if (array_key_exists($sAttCode, $this->GetValues())) {
-                $oOrmLinkSet = $this->GetValues()[$sAttCode];
-            } else {
-                 $oOrmLinkSet = $this->Get($sAttCode);
-            }
+            $oOrmLinkSet = $this->Get($sAttCode);
             $oLinkSet = $oOrmLinkSet->ToDBObjectSet(utils::ShowObsoleteData());
             $iCount = $oLinkSet->Count();
 
@@ -5194,11 +5190,7 @@ HTML
 							$aKeys = array_keys($aValues[$sAttCode]);
 							$currValue = $aKeys[0]; // The only value is the first key
 							if ($oAttDef->GetEditClass() == 'LinkedSet') {
-                                if (array_key_exists($sAttCode, $oDummyObj->GetValues())) {
-                                    $oOrmLinkSet = $oDummyObj->GetValues()[$sAttCode];
-                                } else {
-                                    $oOrmLinkSet = $oDummyObj->Get($sAttCode);
-                                }
+                                $oOrmLinkSet = $oDummyObj->Get($sAttCode);
 								LinkSetDataTransformer::StringToOrmLinkSet($aValues[$sAttCode][$currValue]['edit_value'], $oOrmLinkSet);
 
 							} else {
@@ -5252,11 +5244,7 @@ HTML
 								}
 								$oDummyObj->Set($sAttCode, $oTagSet);
 							} else if ($oAttDef->GetEditClass() == 'LinkedSet') {
-                                if (array_key_exists($sAttCode, $oDummyObj->GetValues())) {
-                                    $oOrmLinkSet = $oDummyObj->GetValues()[$sAttCode];
-                                } else {
-                                    $oOrmLinkSet = $oDummyObj->Get($sAttCode);
-                                }
+                                $oOrmLinkSet = $oDummyObj->Get($sAttCode);
 								foreach ($aMultiValues as $key => $sValue) {
 									LinkSetDataTransformer::StringToOrmLinkSet($sValue['edit_value'], $oOrmLinkSet);
 								}

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -263,6 +263,8 @@ class DisplayBlock
 				/** param for export.php */
 				'refresh_action',
 				/**to add refresh button in datatable*/
+				'iCount',
+				/** int number of objects in list */
 			], DataTableUIBlockFactory::GetAllowedParams()),
 			static::ENUM_STYLE_LIST_SEARCH => array_merge([
 				'update_history',
@@ -1860,7 +1862,11 @@ class MenuBlock extends DisplayBlock
 		$aSelectedClasses = $this->GetFilter()->GetSelectedClasses();
 		$bIsForLinkset = isset($aExtraParams['target_attr']);
 		$oSet = new CMDBObjectSet($this->GetFilter());
-		$iSetCount = $oSet->Count();
+		if(isset($aExtraParams['iCount'])){
+			$iSetCount = $aExtraParams['iCount'];
+		} else {
+			$iSetCount = $oSet->Count();
+		}
 		/** @var string $sRefreshAction JS snippet to run when clicking on the refresh button of the menu */
 		$sRefreshAction = $aExtraParams['refresh_action'] ?? '';
 		$bIsCreationInModal = isset($aExtraParams['creation_in_modal']) && $aExtraParams['creation_in_modal'] === true;

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -263,7 +263,7 @@ class DisplayBlock
 				/** param for export.php */
 				'refresh_action',
 				/**to add refresh button in datatable*/
-				'iCount',
+				'object_count',
 				/** int number of objects in list */
 			], DataTableUIBlockFactory::GetAllowedParams()),
 			static::ENUM_STYLE_LIST_SEARCH => array_merge([
@@ -1862,8 +1862,8 @@ class MenuBlock extends DisplayBlock
 		$aSelectedClasses = $this->GetFilter()->GetSelectedClasses();
 		$bIsForLinkset = isset($aExtraParams['target_attr']);
 		$oSet = new CMDBObjectSet($this->GetFilter());
-		if(isset($aExtraParams['iCount'])){
-			$iSetCount = $aExtraParams['iCount'];
+		if(isset($aExtraParams['object_count'])){
+			$iSetCount = $aExtraParams['object_count'];
 		} else {
 			$iSetCount = $oSet->Count();
 		}

--- a/core/metamodel.class.php
+++ b/core/metamodel.class.php
@@ -7112,16 +7112,7 @@ abstract class MetaModel
 		if ($iKey < 0) {
 			return "$sTargetClass: $iKey (invalid value)";
 		}
-
-		$sObjOql = 'SELECT '.$sTargetClass.' WHERE id='.$iKey;
-		$oObjFilter = DBSearch::FromOQL($sObjOql);
-		$oSet = new DBObjectSet($oObjFilter);
-
-		// we will only use id and friendlyname, so let's remove other fields !
-		$aAttToLoad = [];
-		$oSet->OptimizeColumnLoad($aAttToLoad);
-
-		$oObj = $oSet->Fetch();
+        $oObj = self::GetObject($sTargetClass, $iKey, false);
 		if (is_null($oObj)) {
 			// Whatever we are looking for, the root class is the key to search for
 			$sRootClass = self::GetRootClass($sTargetClass);

--- a/core/metamodel.class.php
+++ b/core/metamodel.class.php
@@ -7112,7 +7112,16 @@ abstract class MetaModel
 		if ($iKey < 0) {
 			return "$sTargetClass: $iKey (invalid value)";
 		}
-		$oObj = self::GetObject($sTargetClass, $iKey, false);
+
+		$sObjOql = 'SELECT '.$sTargetClass.' WHERE id='.$iKey;
+		$oObjFilter = DBSearch::FromOQL($sObjOql);
+		$oSet = new DBObjectSet($oObjFilter);
+
+		// we will only use id and friendlyname, so let's remove other fields !
+		$aAttToLoad = [];
+		$oSet->OptimizeColumnLoad($aAttToLoad);
+
+		$oObj = $oSet->Fetch();
 		if (is_null($oObj)) {
 			// Whatever we are looking for, the root class is the key to search for
 			$sRootClass = self::GetRootClass($sTargetClass);

--- a/sources/Application/UI/Links/AbstractBlockLinkSetViewTable.php
+++ b/sources/Application/UI/Links/AbstractBlockLinkSetViewTable.php
@@ -82,6 +82,7 @@ abstract class AbstractBlockLinkSetViewTable extends UIContentBlock
 	protected bool $bIsAllowCreate;
 	protected bool $bIsAllowModify;
 	protected bool $bIsAllowDelete;
+	protected int $iCount;
 
 	/**
 	 * Constructor.
@@ -95,7 +96,7 @@ abstract class AbstractBlockLinkSetViewTable extends UIContentBlock
 	 *
 	 * @throws \CoreException
 	 */
-	public function __construct(WebPage $oPage, DBObject $oDbObject, string $sObjectClass, string $sAttCode, AttributeLinkedSet $oAttDef, bool $bIsReadOnly = false)
+	public function __construct(WebPage $oPage, DBObject $oDbObject, string $sObjectClass, string $sAttCode, AttributeLinkedSet $oAttDef, bool $bIsReadOnly = false, $iCount = -1)
 	{
 		parent::__construct("links_view_table_$sAttCode", ["ibo-block-links-table"]);
 
@@ -106,6 +107,7 @@ abstract class AbstractBlockLinkSetViewTable extends UIContentBlock
 		$this->oDbObject = $oDbObject;
 		$this->sTableId = 'rel_'.$this->sAttCode;
 		$this->bIsAttEditable = !$bIsReadOnly;
+		$this->iCount = $iCount;
 		$this->SetDataAttributes(['role' => 'ibo-block-links-table', 'link-attcode' => $sAttCode, 'link-class' => $this->oAttDef->GetLinkedClass()]);
 		// Initialization
 		$this->Init();
@@ -192,12 +194,17 @@ abstract class AbstractBlockLinkSetViewTable extends UIContentBlock
 	private function InitTable(WebPage $oPage)
 	{
 		// retrieve db object set
-		$oOrmLinkSet = $this->oDbObject->Get($this->sAttCode);
+		//$oOrmLinkSet = $this->oDbObject->Get($this->sAttCode);
+		$oOrmLinkSet = $this->oDbObject->GetValues()[$this->sAttCode];
 		$oLinkSet = $oOrmLinkSet->ToDBObjectSet(utils::ShowObsoleteData());
 
+		$aExtraParams = $this->GetExtraParam();
+		if($this->iCount != -1) {
+			$aExtraParams['iCount' ] = $this->iCount;
+		}
 		// add list block
 		$oBlock = new DisplayBlock($oLinkSet->GetFilter(), DisplayBlock::ENUM_STYLE_LIST_IN_OBJECT, false);
-		$this->AddSubBlock($oBlock->GetRenderContent($oPage, $this->GetExtraParam(), $this->sTableId));
+		$this->AddSubBlock($oBlock->GetRenderContent($oPage, $aExtraParams, $this->sTableId));
 	}
 	
 	

--- a/sources/Application/UI/Links/AbstractBlockLinkSetViewTable.php
+++ b/sources/Application/UI/Links/AbstractBlockLinkSetViewTable.php
@@ -96,7 +96,7 @@ abstract class AbstractBlockLinkSetViewTable extends UIContentBlock
 	 *
 	 * @throws \CoreException
 	 */
-	public function __construct(WebPage $oPage, DBObject $oDbObject, string $sObjectClass, string $sAttCode, AttributeLinkedSet $oAttDef, bool $bIsReadOnly = false, $iCount = null)
+	public function __construct(WebPage $oPage, DBObject $oDbObject, string $sObjectClass, string $sAttCode, AttributeLinkedSet $oAttDef, bool $bIsReadOnly = false, ?int $iCount = null)
 	{
 		parent::__construct("links_view_table_$sAttCode", ["ibo-block-links-table"]);
 
@@ -194,13 +194,12 @@ abstract class AbstractBlockLinkSetViewTable extends UIContentBlock
 	private function InitTable(WebPage $oPage)
 	{
 		// retrieve db object set
-		//$oOrmLinkSet = $this->oDbObject->Get($this->sAttCode);
-		$oOrmLinkSet = $this->oDbObject->GetValues()[$this->sAttCode];
+		$oOrmLinkSet = $this->oDbObject->Get($this->sAttCode);
 		$oLinkSet = $oOrmLinkSet->ToDBObjectSet(utils::ShowObsoleteData());
 
 		$aExtraParams = $this->GetExtraParam();
-		if(is_null($this->iCount ) === false) {
-			$aExtraParams['iCount' ] = $this->iCount;
+		if (is_null($this->iCount) === false) {
+			$aExtraParams['object_count' ] = $this->iCount;
 		}
 		// add list block
 		$oBlock = new DisplayBlock($oLinkSet->GetFilter(), DisplayBlock::ENUM_STYLE_LIST_IN_OBJECT, false);

--- a/sources/Application/UI/Links/AbstractBlockLinkSetViewTable.php
+++ b/sources/Application/UI/Links/AbstractBlockLinkSetViewTable.php
@@ -96,7 +96,7 @@ abstract class AbstractBlockLinkSetViewTable extends UIContentBlock
 	 *
 	 * @throws \CoreException
 	 */
-	public function __construct(WebPage $oPage, DBObject $oDbObject, string $sObjectClass, string $sAttCode, AttributeLinkedSet $oAttDef, bool $bIsReadOnly = false, $iCount = -1)
+	public function __construct(WebPage $oPage, DBObject $oDbObject, string $sObjectClass, string $sAttCode, AttributeLinkedSet $oAttDef, bool $bIsReadOnly = false, $iCount = null)
 	{
 		parent::__construct("links_view_table_$sAttCode", ["ibo-block-links-table"]);
 
@@ -199,7 +199,7 @@ abstract class AbstractBlockLinkSetViewTable extends UIContentBlock
 		$oLinkSet = $oOrmLinkSet->ToDBObjectSet(utils::ShowObsoleteData());
 
 		$aExtraParams = $this->GetExtraParam();
-		if($this->iCount != -1) {
+		if(is_null($this->iCount ) === false) {
 			$aExtraParams['iCount' ] = $this->iCount;
 		}
 		// add list block

--- a/sources/Controller/AjaxRenderController.php
+++ b/sources/Controller/AjaxRenderController.php
@@ -70,8 +70,14 @@ class AjaxRenderController
 			$bShowObsoleteData = utils::ShowObsoleteData();
 		}
 		$oSet->SetShowObsoleteData($bShowObsoleteData);
+		$iCount = 0;
+		if(isset($aExtraParams['iCount'])){
+			$iCount = $aExtraParams['iCount'];
+		} else {
+			$iCount = $oSet->Count();
+		}
 		$aResult["draw"] = $iDrawNumber;
-		$aResult["recordsTotal"] = $oSet->Count();
+		$aResult["recordsTotal"] = $iCount;
 		$aResult["recordsFiltered"] = $aResult["recordsTotal"] ;
 		$aResult["data"] = [];
 		while ($aObject = $oSet->FetchAssoc()) {

--- a/sources/Controller/AjaxRenderController.php
+++ b/sources/Controller/AjaxRenderController.php
@@ -71,8 +71,8 @@ class AjaxRenderController
 		}
 		$oSet->SetShowObsoleteData($bShowObsoleteData);
 		$iCount = 0;
-		if(isset($aExtraParams['iCount'])){
-			$iCount = $aExtraParams['iCount'];
+		if (isset($aExtraParams['object_count'])) {
+			$iCount = $aExtraParams['object_count'];
 		} else {
 			$iCount = $oSet->Count();
 		}

--- a/tests/php-unit-tests/unitary-tests/core/DBObjectTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBObjectTest.php
@@ -21,6 +21,7 @@ namespace Combodo\iTop\Test\UnitTest\Core;
 
 use Attachment;
 use AttributeDateTime;
+use Combodo\iTop\Application\WebPage\WebPage;
 use Combodo\iTop\Service\Events\EventData;
 use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
 use CoreException;
@@ -1414,5 +1415,34 @@ class DBObjectTest extends ItopDataTestCase
 		$this->assertTrue(true,'No fatal error on computing date');
 		$this->assertEquals("2024-01-15 09:45:00", $oObject->Get('end_date'), 'SetComputedDate +2 weeks on a WorkOrder DateTimeAttribute');
 
+	}
+	/**
+	 * @covers DBObject::NewObject
+	 * @covers DBObject::Get
+	 * @covers DBObject::Set
+	 */
+	public function testGetLinkSet()
+	{
+		$iServer = $this->GivenObjectInDB('Server', [
+			'name' => 'The Boss',
+		]);
+
+		$iUserRequest = $this->GivenObjectInDB('UserRequest', [
+			'ref' => 'UR1', 'title' => 'UR1', 'description' => 'UR1', 'caller_id' => 3, 'org_id' => 3, 'service_id' => 1,
+			'functionalcis_list' => [
+				"functionalci_id:$iServer"
+			],
+		]);
+		$oUserRequest = MetaModel::GetObject('UserRequest', $iUserRequest);
+
+		$this->assertDBQueryCount(2, function () use (&$oUserRequest) {
+			$oUserRequest->Get('functionalcis_list');
+		});
+		$this->assertDBQueryCount(0, function () use (&$oUserRequest) {
+			$oUserRequest->Get('functionalcis_list');
+		});
+		$this->assertDBQueryCount(0, function () use (&$oUserRequest) {
+			$oUserRequest->GetValues()['functionalcis_list'];
+		});
 	}
 }

--- a/tests/php-unit-tests/unitary-tests/core/DBObjectTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBObjectTest.php
@@ -21,6 +21,7 @@ namespace Combodo\iTop\Test\UnitTest\Core;
 
 use Attachment;
 use AttributeDateTime;
+use Combodo\iTop\Application\WebPage\iTopWebPage;
 use Combodo\iTop\Application\WebPage\WebPage;
 use Combodo\iTop\Service\Events\EventData;
 use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
@@ -1417,9 +1418,7 @@ class DBObjectTest extends ItopDataTestCase
 
 	}
 	/**
-	 * @covers DBObject::NewObject
 	 * @covers DBObject::Get
-	 * @covers DBObject::Set
 	 */
 	public function testGetLinkSet()
 	{
@@ -1440,9 +1439,6 @@ class DBObjectTest extends ItopDataTestCase
 		});
 		$this->assertDBQueryCount(0, function () use (&$oUserRequest) {
 			$oUserRequest->Get('functionalcis_list');
-		});
-		$this->assertDBQueryCount(0, function () use (&$oUserRequest) {
-			$oUserRequest->GetValues()['functionalcis_list'];
 		});
 	}
 }


### PR DESCRIPTION
Improve performance of displaying links on screen

Currently when displaying a user query, displaying a lnk requires 5 sql queries :
![Capture d'écran 2024-07-30 124309](https://github.com/user-attachments/assets/0e2e4fb5-f2fc-412d-80b3-1c5741a956f9)

After the PR, the same lnk only requires 2 SQL queries:
![Capture d'écran 2024-07-30 124629](https://github.com/user-attachments/assets/3514b517-7412-415a-b77d-df4556e1871b)

In total on the screen, the gain is 12 requests:
before:
![Capture d'écran 2024-07-30 124540](https://github.com/user-attachments/assets/bac0f769-85d8-457f-8fce-25d478433586)
after:
![Capture d'écran 2024-07-30 124551](https://github.com/user-attachments/assets/5b59d56b-00a2-4fb9-8ea8-b99b8d52b0f9)

