### PR TITLE
New Triggers: TriggerOnAttachmentAdded and TriggerOnAttachmentRemoved

### DIFF
--- a/datamodels/2.x/itop-attachments/dictionaries/de.dict.itop-attachments.php
+++ b/datamodels/2.x/itop-attachments/dictionaries/de.dict.itop-attachments.php
@@ -59,5 +59,9 @@ oder melden Sie dem '.ITOP_APPLICATION_SHORT.' Administrator diesen Fehler, weil
 	'Class:Attachment/Attribute:user_id+' => '',
 	'Class:TriggerOnAttachmentDownload' => 'Trigger (beim Herunterladen eines Attachment eines Objekts)',
 	'Class:TriggerOnAttachmentDownload+' => 'Trigger für das Herunterladen des Attachments der angegebenen Klasse oder einer Unterklasse',
+	'Class:TriggerOnAttachmentAdded' => 'Trigger (beim Hinzufügen eines Attachments)',
+	'Class:TriggerOnAttachmentAdded+' => 'Trigger für das Hinzufügen des Attachments an einem Objekt der angegebenen Klasse oder einer Unterklasse',
+	'Class:TriggerOnAttachmentRemoved' => 'Trigger (beim Entfernen eines Attachments)',
+	'Class:TriggerOnAttachmentRemoved+' => 'Trigger für das Entfernen des Attachments an einem Objekt der angegebenen Klasse oder einer Unterklasse',
 	'UI:Attachments:DropYourFileHint' => 'Dateien in diesem Bereich ablegen...',
 ]);

--- a/datamodels/2.x/itop-attachments/dictionaries/en.dict.itop-attachments.php
+++ b/datamodels/2.x/itop-attachments/dictionaries/en.dict.itop-attachments.php
@@ -92,3 +92,21 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Class:TriggerOnAttachmentDownload' => 'Trigger (on object\'s attachment download)',
 	'Class:TriggerOnAttachmentDownload+' => 'Trigger on object\'s attachment download of [a child class of] the given class',
 ));
+
+//
+// Class: TriggerOnAttachmentAdded
+//
+
+Dict::Add('EN US', 'English', 'English', array(
+	'Class:TriggerOnAttachmentAdded' => 'Trigger (on object\'s attachment added)',
+	'Class:TriggerOnAttachmentAdded+' => 'Trigger on object\'s attachment added of [a child class of] the given class',
+));
+
+//
+// Class: TriggerOnAttachmentRemoved
+//
+
+Dict::Add('EN US', 'English', 'English', array(
+	'Class:TriggerOnAttachmentRemoved' => 'Trigger (on object\'s attachment removed)',
+	'Class:TriggerOnAttachmentRemoved+' => 'Trigger on object\'s attachment removed of [a child class of] the given class',
+));

--- a/datamodels/2.x/itop-attachments/main.itop-attachments.php
+++ b/datamodels/2.x/itop-attachments/main.itop-attachments.php
@@ -784,6 +784,70 @@ class TriggerOnAttachmentDownload extends TriggerOnAttributeBlobDownload
 	}
 }
 
+/**
+ * Class TriggerOnAttachmentAdded
+ *
+ * @since 3.3.0
+ */
+class TriggerOnAttachmentAdded extends TriggerOnObject
+{
+	/**
+	 * @inheritDoc
+	 * @throws \CoreException
+	 * @throws \Exception
+	 */
+	public static function Init()
+	{
+		$aParams = array
+		(
+			"category" => "grant_by_profile,core/cmdb,application",
+			"key_type" => "autoincrement",
+			"name_attcode" => "description",
+			"complementary_name_attcode" => ['finalclass', 'complement'],
+			"state_attcode" => "",
+			"reconc_keys" => ['description'],
+			"db_table" => "priv_trigger_onattadded",
+			"db_key_field" => "id",
+			"db_finalclass_field" => "",
+			"display_template" => "",
+		);
+		MetaModel::Init_Params($aParams);
+		MetaModel::Init_InheritAttributes();
+	}
+}
+
+/**
+ * Class TriggerOnAttachmentRemoved
+ *
+ * @since 3.3.0
+ */
+class TriggerOnAttachmentRemoved extends TriggerOnObject
+{
+	/**
+	 * @inheritDoc
+	 * @throws \CoreException
+	 * @throws \Exception
+	 */
+	public static function Init()
+	{
+		$aParams = array
+		(
+			"category" => "grant_by_profile,core/cmdb,application",
+			"key_type" => "autoincrement",
+			"name_attcode" => "description",
+			"complementary_name_attcode" => ['finalclass', 'complement'],
+			"state_attcode" => "",
+			"reconc_keys" => ['description'],
+			"db_table" => "priv_trigger_onattremoved",
+			"db_key_field" => "id",
+			"db_finalclass_field" => "",
+			"display_template" => "",
+		);
+		MetaModel::Init_Params($aParams);
+		MetaModel::Init_InheritAttributes();
+	}
+}
+
 
 class AttachmentsHelper
 {

--- a/datamodels/2.x/itop-attachments/src/Hook/EventListener.php
+++ b/datamodels/2.x/itop-attachments/src/Hook/EventListener.php
@@ -10,6 +10,7 @@ namespace Combodo\iTop\Attachments\Hook;
 use Combodo\iTop\Service\Events\EventData;
 use Combodo\iTop\Service\Events\EventService;
 use Combodo\iTop\Service\Events\iEventServiceSetup;
+use DBObject;
 use DBObjectSearch;
 use DBObjectSet;
 use Exception;
@@ -18,6 +19,8 @@ use LogChannels;
 use MetaModel;
 use ormDocument;
 use TriggerOnAttachmentDownload;
+use TriggerOnAttachmentAdded;
+use TriggerOnAttachmentRemoved;
 
 /**
  * Class EventListener
@@ -37,6 +40,14 @@ class EventListener implements iEventServiceSetup
 			[$this, 'OnAttachmentDownloadActivateTriggers'],
 			'Attachment'
 		);
+		EventService::RegisterListener(
+			EVENT_ADD_ATTACHMENT_TO_OBJECT,
+			[$this, 'OnAttachmentAddedActivateTriggers']
+		);
+		EventService::RegisterListener(
+			EVENT_REMOVE_ATTACHMENT_FROM_OBJECT,
+			[$this, 'OnAttachmentRemovedActivateTriggers']
+		);
 	}
 
 	/**
@@ -45,6 +56,7 @@ class EventListener implements iEventServiceSetup
 	 * @param \Combodo\iTop\Service\Events\EventData $oEventData
 	 *
 	 * @return void
+	 * @throws \CoreException
 	 */
 	public function OnAttachmentDownloadActivateTriggers(EventData $oEventData): void
 	{
@@ -52,14 +64,83 @@ class EventListener implements iEventServiceSetup
 		if ($oEventData->Get('content_disposition') !== ormDocument::ENUM_CONTENT_DISPOSITION_ATTACHMENT) {
 			return;
 		}
-
-		/** @var \DBObject $oAttachment */
+		/** @var DBObject $oAttachment */
 		$oAttachment = $oEventData->Get('object');
 		$oHostObj = MetaModel::GetObject($oAttachment->Get('item_class'), $oAttachment->Get('item_id'), false /* false to avoid exception during trigger */, true);
-		/** @var \ormDocument $oDocument */
+		/** @var ormDocument $oDocument */
 		$oDocument = $oEventData->Get('document');
 
-		$sTriggerClass = TriggerOnAttachmentDownload::class;
+		$this->OnAttachmentActivateTriggers(
+			$oHostObj,
+			$oAttachment,
+			$oDocument,
+			TriggerOnAttachmentDownload::class
+		);
+	}
+
+	/**
+	 * Callback when an Attachment is added: Activate corresponding triggers
+	 *
+	 * @param \Combodo\iTop\Service\Events\EventData $oEventData
+	 *
+	 * @return void
+	 * @throws \CoreException
+	 */
+	public function OnAttachmentAddedActivateTriggers(EventData $oEventData): void
+	{
+		/** @var DBObject $oAttachment */
+		$oAttachment = $oEventData->Get('attachment');
+		/** @var DBObject $oHostObj */
+		$oHostObj = $oEventData->Get('object');
+		/** @var ormDocument $oDocument */
+		$oDocument = $oAttachment->Get('contents');
+
+		$this->OnAttachmentActivateTriggers(
+			$oHostObj,
+			$oAttachment,
+			$oDocument,
+			TriggerOnAttachmentAdded::class
+		);
+	}
+
+	/**
+	 * Callback when an Attachment is removed: Activate corresponding triggers
+	 *
+	 * @param \Combodo\iTop\Service\Events\EventData $oEventData
+	 *
+	 * @return void
+	 * @throws \CoreException
+	 */
+	public function OnAttachmentRemovedActivateTriggers(EventData $oEventData): void
+	{
+		/** @var DBObject $oAttachment */
+		$oAttachment = $oEventData->Get('attachment');
+		/** @var DBObject $oHostObj */
+		$oHostObj = $oEventData->Get('object');
+		/** @var ormDocument $oDocument */
+		$oDocument = $oAttachment->Get('contents');
+
+		$this->OnAttachmentActivateTriggers(
+			$oHostObj,
+			$oAttachment,
+			$oDocument,
+			TriggerOnAttachmentRemoved::class
+		);
+	}
+
+	/**
+	 * Callback when an Attachment downloaded, added or removed: Activate corresponding triggers
+	 *
+	 * @param DBObject $oHostObj
+	 * @param DBObject $oAttachment
+	 * @param ormDocument $oDocument
+	 * @param string $sTriggerClass
+	 *
+	 * @return void
+	 * @throws \CoreException
+	 */
+	protected function OnAttachmentActivateTriggers(DBObject $oHostObj, DBObject $oAttachment, ormDocument $oDocument, string $sTriggerClass): void
+	{
 		$aTriggerContextArgs = [
 			'this->object()' => $oHostObj,
 			'attachment->object()' => $oAttachment,


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | Already discussed with @v-dumas 
| Type of change?                                               | Enhancement


## Symptom (bug) / Objective (enhancement)
Currently there is only a `TriggerOnAttachmentDownload` which is triggered via an event listener, but there are already events for adding and removing attachments (`EVENT_ADD_ATTACHMENT_TO_OBJECT`, `EVENT_REMOVE_ATTACHMENT_FROM_OBJECT`). 
Why not adding triggers here as well, wo make it possible to execute an action each time an attachment is added or removed?

## Proposed solution (bug and enhancement)
With this PR, two additional triggers (`TriggerOnAttachmentAdded`,`TriggerOnAttachmentRemoved`) are added to be triggered when adding or removing an attachment, with the same logic as currently when downloading an attachment.

So far I have not added any UnitTests as it seems that there is no test case for the existing class `TriggerOnAttachmentDownload`. So I was not sure if and how a unit test would be appropriate here.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge

- [ ] Clarification of whether unit tests are required
- [ ] Code review by Combodo
- [ ] Translations for all languages beside English and German (at least add the placeholders), might by easier to be done by Combodo?
