### PR TITLE
N°8893 - :lipstick: Transition validation markup

### DIFF
--- a/pages/UI.php
+++ b/pages/UI.php
@@ -1301,6 +1301,8 @@ try
 					if (count($aErrors) == 0)
 					{
 						$sIssues = '';
+						/** @var CoreCannotSaveObjectException|null $oException */
+						$oException = null;
 						$bApplyStimulus = true;
 						list($bRes, $aIssues) = $oObj->CheckToWrite(); // Check before trying to write the object
 						if ($bRes)
@@ -1315,6 +1317,11 @@ try
 								$oObj = MetaModel::GetObject(get_class($oObj), $oObj->GetKey());
 								$oObj->UpdateObjectFromPostedForm('', array_keys($aExpectedAttributes), $aExpectedAttributes);
 								$sIssues = $e->getMessage();
+								
+								if($e instanceof CoreCannotSaveObjectException) {
+									$oException = $e;
+								}
+
 							}
 						}
 						else
@@ -1355,7 +1362,7 @@ try
 								$sMessage = $e->getMessage();
 								$sSeverity = 'info';
 							}
-							$sIssueDesc = Dict::Format('UI:ObjectCouldNotBeWritten',$sIssues);
+							$sIssueDesc = ($oException !== null ? '<div style="display: block;"><style scoped> ul { list-style-type: disc; } </style>'.$oException->getHtmlMessage().'</div>' : Dict::Format('UI:ObjectCouldNotBeWritten', $sIssues));
 							$oP->add_ready_script("CombodoModal.OpenErrorModal('".addslashes($sIssueDesc)."');");
 						}
 						else


### PR DESCRIPTION


## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | No
| Type of change?                                               | Enhancement


## Symptom (bug) / Objective (enhancement)

When using for example the new event listeners to perform a check before the object is written **during a transition;** the current error modal is ugly. It does not use a nice list; and it shows context data.



## Proposed solution (bug and enhancement)

The error messages are just examples. 

Before:
![image](https://github.com/user-attachments/assets/2b1625c9-9881-4de7-9962-10378f1650e6)


After:
![image](https://github.com/user-attachments/assets/77c3dfbe-469f-40a1-9ee1-52c742ee9a9c)



## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge

