### PR TITLE
N°7914 :sparkles: REST: Allow class based output fields

### DIFF
--- a/core/restservices.class.inc.php
+++ b/core/restservices.class.inc.php
@@ -503,8 +503,8 @@ class CoreServices implements iRestServiceProvider
 		case 'core/get':
 			$sClass = RestUtils::GetClass($aParams, 'class');
 			$key = RestUtils::GetMandatoryParam($aParams, 'key');
+			$sShowFields = RestUtils::GetOptionalParam($aParams, 'output_fields', '*');
 			$aShowFields = RestUtils::GetFieldList($sClass, $aParams, 'output_fields');
-			$bExtendedOutput = (RestUtils::GetOptionalParam($aParams, 'output_fields', '*') == '*+');
 			$iLimit = (int)RestUtils::GetOptionalParam($aParams, 'limit', 0);
 			$iPage = (int)RestUtils::GetOptionalParam($aParams, 'page', 1);
 
@@ -528,7 +528,8 @@ class CoreServices implements iRestServiceProvider
             }
 			else
 			{
-                                if (!$bExtendedOutput && RestUtils::GetOptionalParam($aParams, 'output_fields', '*') != '*') 
+
+                                if (!RestUtils::HasRequestedAllOutputFields($sShowFields))
                                 {
                                         $aFields = $aShowFields[$sClass];
                                         //Id is not a valid attribute to optimize
@@ -542,7 +543,7 @@ class CoreServices implements iRestServiceProvider
                                 
 				while ($oObject = $oObjectSet->Fetch())
 				{
-					$oResult->AddObject(0, '', $oObject, $aShowFields, $bExtendedOutput);
+					$oResult->AddObject(0, '', $oObject, $aShowFields, RestUtils::HasRequestedExtendedOutput($sShowFields));
 				}
 				$oResult->message = "Found: ".$oObjectSet->Count();
 			}

--- a/tests/php-unit-tests/unitary-tests/webservices/RestUtilsTest.php
+++ b/tests/php-unit-tests/unitary-tests/webservices/RestUtilsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Combodo\iTop\Test\UnitTest\Webservices;
+
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use MetaModel;
+use RestUtils;
+use Ticket;
+use UserRequest;
+
+
+class RestUtilsTest extends ItopDataTestCase
+{
+	public function testGetFieldListForSingleClass(): void
+	{
+		$aList = RestUtils::GetFieldList(Ticket::class, (object) ['output_fields' => 'ref,start_date,end_date'], 'output_fields');
+		$this->assertSame([Ticket::class => ['ref', 'start_date', 'end_date']], $aList);
+	}
+
+	public function testGetFieldListForSingleClassWithInvalidFieldNameFails(): void
+	{
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('output_fields: invalid attribute code \'something\'');
+		$aList = RestUtils::GetFieldList(Ticket::class, (object) ['output_fields' => 'ref,something'], 'output_fields');
+		$this->assertSame([Ticket::class => ['ref', 'start_date', 'end_date']], $aList);
+	}
+
+	public function testGetFieldListWithAsteriskOnParentClass(): void
+	{
+		$aList = RestUtils::GetFieldList(Ticket::class, (object) ['output_fields' => '*'], 'output_fields');
+		$this->assertArrayHasKey(Ticket::class, $aList);
+		$this->assertContains('operational_status', $aList[Ticket::class]);
+		$this->assertNotContains('status', $aList[Ticket::class], 'Representation of Class Ticket should not contain status, since it is defined by children');
+	}
+
+	public function testGetFieldListWithAsteriskPlusOnParentClass(): void
+	{
+		$aList = RestUtils::GetFieldList(Ticket::class, (object) ['output_fields' => '*+'], 'output_fields');
+		$this->assertArrayHasKey(Ticket::class, $aList);
+		$this->assertArrayHasKey(UserRequest::class, $aList);
+		$this->assertContains('operational_status', $aList[Ticket::class]);
+		$this->assertContains('status', $aList[UserRequest::class]);
+	}
+
+	public function testGetFieldListForMultipleClasses(): void
+	{
+		$aList = RestUtils::GetFieldList(Ticket::class, (object) ['output_fields' => 'Ticket:ref,start_date,end_date;UserRequest:ref,status'], 'output_fields');
+		$this->assertArrayHasKey(Ticket::class, $aList);
+		$this->assertArrayHasKey(UserRequest::class, $aList);
+		$this->assertContains('ref', $aList[Ticket::class]);
+		$this->assertContains('end_date', $aList[Ticket::class]);
+		$this->assertNotContains('status', $aList[Ticket::class]);
+		$this->assertContains('status', $aList[UserRequest::class]);
+		$this->assertNotContains('end_date', $aList[UserRequest::class]);
+	}
+
+	public function testGetFieldListForMultipleClassesWithInvalidFieldNameFails(): void
+	{
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('output_fields: invalid attribute code \'something\'');
+		RestUtils::GetFieldList(Ticket::class, (object) ['output_fields' => 'Ticket:ref;UserRequest:ref,something'], 'output_fields');
+	}
+
+	/**
+	 * @dataProvider extendedOutputDataProvider
+	 */
+	public function testIsExtendedOutputRequest(bool $bExpected, string $sFields): void
+	{
+		$this->assertSame($bExpected, RestUtils::HasRequestedExtendedOutput($sFields));
+	}
+
+	/**
+	 * @dataProvider allFieldsOutputDataProvider
+	 */
+	public function testIsAllFieldsOutputRequest(bool $bExpected, string $sFields): void
+	{
+		$this->assertSame($bExpected, RestUtils::HasRequestedAllOutputFields($sFields));
+	}
+
+	public function extendedOutputDataProvider(): array
+	{
+		return [
+			[false, 'ref,start_date,end_date'],
+			[false, '*'],
+			[true, '*+'],
+			[false, 'Ticket:ref'],
+			[true, 'Ticket:ref;UserRequest:ref'],
+		];
+	}
+
+	public function allFieldsOutputDataProvider(): array
+	{
+		return [
+			[false, 'ref,start_date,end_date'],
+			[true, '*'],
+			[true, '*+'],
+			[false, 'Ticket:ref'],
+			[false, 'Ticket:ref;UserRequest:ref'],
+		];
+	}
+}


### PR DESCRIPTION

<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Enhancement


## Objective
When performing core/get with multiple return types (parent and child classes) on REST Service, you may either only return fields from the parent object or enforce return all the fields for each object (with `*+`). 

When, for example, requesting information for Tickets of various types and also including some, but not all the custom properties in the output, you can not provide output_fields which may exist in all implementations, if it does not exist in the requested parent implementation.

The following is currently not possible:

```javascript
{
   "operation": "core/get",
   "class": "Ticket",
   "key": "SELECT UserRequest UNION SELECT Change",
   "output_fields": "ref,status,finalclass"
}
``` 

This is because the "status" is not defined on "Ticket", but rather in each implementation. Querying with "*+" is possible, but then you also request, join, process and transfer a lot of data that was not required.

## Proposed solution

My proposed change makes it possible to optionally define a list of output_fields for each class. You can now pass
`<Class>:<output_fields>;<Class>:<output_fields>;...`.

```javascript
{
   "operation": "core/get",
   "class": "Ticket",
   "key": "SELECT UserRequest UNION SELECT Change",
   "output_fields": "Ticket:ref;UserRequest:ref,status,origin;Change:ref,status,outage"
}
``` 

I've also added tests for the RestUtils::GetFieldList to ensure backwards compatibility.

Limitation and possible further improvement: For now you need to provide a field list for each each class that can be returned and also the requested class in the "class" parameter. Perhaps this could be changed to have a base list, which would be extended for all child classes, and then override those lists for specific classes when provided in the list.

For now you must also provide the parents (e.g. "Ticket") output_fields, even though no object of parents type (e.g. "Ticket") could ever be returned directly.

## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge
<!--
Things that needs to be done in the PR before it can be considered as ready to be merged

Examples:
- Changes requested in the review
- Unit test to add
- Dictionary entries to translate
- ...
-->

- [ ] Consider different syntax
- [ ] Check if Column Load could be optimized in this case
