### PR TITLE
:bug: N°7917 SF#2272 EmailLaminas.php: Fix Message-ID format

### DIFF
--- a/sources/Core/Email/EmailLaminas.php
+++ b/sources/Core/Email/EmailLaminas.php
@@ -331,11 +331,11 @@ class EMailLaminas extends Email
 	{
 		$this->m_aData['message_id'] = $sId;
 
-		// Note: Swift will add the angle brackets for you
+		// Note: The email library will add the angle brackets for you
 		// so let's remove the angle brackets if present, for historical reasons
 		$sId = str_replace(array('<', '>'), '', $sId);
 
-		$this->m_oMessage->getHeaders()->addHeaderLine('Message-ID', $sId);
+		$this->m_oMessage->getHeaders()->addHeader((new Laminas\Mail\Header\MessageId())->setId($sId));
 	}
 
 	public function SetReferences($sReferences)

--- a/sources/Core/Email/EmailLaminas.php
+++ b/sources/Core/Email/EmailLaminas.php
@@ -8,6 +8,7 @@
 
 use Combodo\iTop\Core\Authentication\Client\OAuth\OAuthClientProviderFactory;
 use Laminas\Mail\Header\ContentType;
+use Laminas\Mail\Header\MessageId;
 use Laminas\Mail\Message;
 use Laminas\Mail\Protocol\Smtp\Auth\Oauth;
 use Laminas\Mail\Transport\File;
@@ -335,7 +336,7 @@ class EMailLaminas extends Email
 		// so let's remove the angle brackets if present, for historical reasons
 		$sId = str_replace(array('<', '>'), '', $sId);
 
-		$this->m_oMessage->getHeaders()->addHeader((new Laminas\Mail\Header\MessageId())->setId($sId));
+		$this->m_oMessage->getHeaders()->addHeader((new MessageId())->setId($sId));
 	}
 
 	public function SetReferences($sReferences)


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | [SourceForge ticket 2272](https://sourceforge.net/p/itop/tickets/2272/)
| Type of change?                                               | Bug fix


## Symptom
iTop since version 3.1 (after switching to Laminas-mail, N°4307) sends emails with incorrectly formatted Message-ID. This sometimes results in Gmail classifying them as spam or even outright refusing to accept them for delivery. In another case, a client was reporting issues with their (possibly custom) system for automated email processing. More information is in the above-linked SourceForge issue.

## Reproduction procedure
1. On iTop 3.1.1-1
2. With PHP 7.4.33
3. Make iTop send you an email (assuming Gmail inbox).
4. If the email arrives at all, examine its message ID ("Show original" in Gmail web application).
5. See that the message ID got changed to `<66bb805d.170a0220.2d49d4.f281SMTPIN_ADDED_BROKEN@mx.google.com>` and an `X-Google-Original-Message-ID` header was added.

## Cause
After switching to the Laminas-mail library, the `addHeaderLine` function is used to add the `Message-ID` header to the email that is about to be sent. This function can add arbitrary headers and uses [Q-encoding](https://en.wikipedia.org/wiki/MIME#Encoded-Word) to encode the entire value. This is not allowed for structured headers such as `Message-ID` according to the relevant RFCs ([RFC 2047](https://datatracker.ietf.org/doc/html/rfc2047), [RFC 2822](https://datatracker.ietf.org/doc/html/rfc2822)).

## Proposed solution
Laminas-mail provides a `MessageId` class. An object of this type is created and added using `addHeader`.

## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge
<!--
Things that needs to be done in the PR before it can be considered as ready to be merged

Examples:
- Changes requested in the review
- Unit test to add
- Dictionary entries to translate
- ...
-->