### PR TITLE
 N°7995 - Allow to redefine portal twig template for all bricks in a portal

### DIFF
--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/AbstractBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/AbstractBrick.php
@@ -680,7 +680,15 @@ abstract class AbstractBrick
 			
 			// Call the set method for the template
 			$sSetTemplateMethodName = 'Set'.$sTemplateId.'TemplatePath';
-			$this->{$sSetTemplateMethodName}($sTemplate);
+			
+			if(method_exists($this, $sSetTemplateMethodName)) {
+				$this->{$sSetTemplateMethodName}($sTemplate);
+			} 
+			else {
+				throw new DOMFormatException(
+					'Template "'.$sTemplateId.'" is not a valid template for brick ' . $sClassFQDN,
+					null, null);
+			}
 		}
 	}
 }

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/AbstractBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/AbstractBrick.php
@@ -668,7 +668,8 @@ abstract class AbstractBrick
 	 * @throws \DOMFormatException
 	 * @since 3.2.1
 	 */
-	public function LoadFromPortalProperties($aPortalProperties) {
+	public function LoadFromPortalProperties($aPortalProperties)
+	{
 		// Get the bricks templates
 		$aBricksTemplates = $aPortalProperties['templates']['bricks'];
 		$sClassFQCN = get_class($this);

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/AbstractBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/AbstractBrick.php
@@ -659,4 +659,28 @@ abstract class AbstractBrick
 		return $this;
 	}
 
+	/**
+	 *  Load brick configuration that is not part of the brick definition but is part of the portal global properties.
+	 * 
+	 * @param $aPortalProperties
+	 *
+	 * @return void
+	 * @since 3.2.1
+	 */
+	public function LoadFromPortalProperties($aPortalProperties) {
+		// Get the bricks templates
+		$aBricksTemplates = $aPortalProperties['templates']['bricks'];
+		$sClassFQDN = get_class($this);
+		
+		// Get the current brick templates
+		$aCurrentBricksTemplates = array_key_exists($sClassFQDN, $aBricksTemplates) ? $aBricksTemplates[$sClassFQDN] : [];
+		foreach($aCurrentBricksTemplates as $sTemplateKey => $sTemplate) {
+			// Clean the template id
+			$sTemplateId = str_ireplace($sClassFQDN.':', '', $sTemplateKey);
+			
+			// Call the set method for the template
+			$sSetTemplateMethodName = 'Set'.$sTemplateId.'TemplatePath';
+			$this->{$sSetTemplateMethodName}($sTemplate);
+		}
+	}
 }

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/AbstractBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/AbstractBrick.php
@@ -661,22 +661,23 @@ abstract class AbstractBrick
 
 	/**
 	 *  Load brick configuration that is not part of the brick definition but is part of the portal global properties.
-	 * 
+	 *
 	 * @param $aPortalProperties
 	 *
 	 * @return void
+	 * @throws \DOMFormatException
 	 * @since 3.2.1
 	 */
 	public function LoadFromPortalProperties($aPortalProperties) {
 		// Get the bricks templates
 		$aBricksTemplates = $aPortalProperties['templates']['bricks'];
-		$sClassFQDN = get_class($this);
+		$sClassFQCN = get_class($this);
 		
 		// Get the current brick templates
-		$aCurrentBricksTemplates = array_key_exists($sClassFQDN, $aBricksTemplates) ? $aBricksTemplates[$sClassFQDN] : [];
+		$aCurrentBricksTemplates = array_key_exists($sClassFQCN, $aBricksTemplates) ? $aBricksTemplates[$sClassFQCN] : [];
 		foreach($aCurrentBricksTemplates as $sTemplateKey => $sTemplate) {
 			// Clean the template id
-			$sTemplateId = str_ireplace($sClassFQDN.':', '', $sTemplateKey);
+			$sTemplateId = str_ireplace($sClassFQCN.':', '', $sTemplateKey);
 			
 			// Call the set method for the template
 			$sSetTemplateMethodName = 'Set'.$sTemplateId.'TemplatePath';
@@ -686,7 +687,7 @@ abstract class AbstractBrick
 			} 
 			else {
 				throw new DOMFormatException(
-					'Template "'.$sTemplateId.'" is not a valid template for brick ' . $sClassFQDN,
+					'Template "'.$sTemplateId.'" is not a valid template for brick ' . $sClassFQCN,
 					null, null);
 			}
 		}

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/BrickCollection.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/BrickCollection.php
@@ -48,21 +48,21 @@ class BrickCollection
 	private $aHomeOrdering;
 	/** @var array $aNavigationMenuOrdering */
 	private $aNavigationMenuOrdering;
-	/** @var \Symfony\Component\DependencyInjection\ContainerInterface $container
+	/** @var \array $aCombodoPortalInstanceConf
 	 * @since 3.2.1 
 	 */
-	private $container;
+	private $aCombodoPortalInstanceConf;
 
 	/**
 	 * BrickCollection constructor.
 	 *
 	 * @param \ModuleDesign $oModuleDesign
-	 * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+	 * @param $aCombodoPortalInstanceConf
 	 *
 	 * @throws \Exception
-	 * @since 3.2.1 Added $container parameter
+	 * @since 3.2.1 Added $aCombodoPortalInstanceConf parameter
 	 */
-	public function __construct(ModuleDesign $oModuleDesign, ContainerInterface $container)
+	public function __construct(ModuleDesign $oModuleDesign, $aCombodoPortalInstanceConf)
 	{
 		$this->oModuleDesign = $oModuleDesign;
 		$this->aAllowedBricks = null;
@@ -70,7 +70,7 @@ class BrickCollection
 		$this->iDisplayedInNavigationMenu = 0;
 		$this->aHomeOrdering = array();
 		$this->aNavigationMenuOrdering = array();
-		$this->container = $container;
+		$this->aCombodoPortalInstanceConf = $aCombodoPortalInstanceConf;
 
 		$this->Load();
 	}
@@ -206,8 +206,7 @@ class BrickCollection
 					$oBrick = new $sBrickClass();
 					
 					// Load the portal properties that are common to all bricks of this type
-					$oPortalConf = $this->container->getParameter('combodo.portal.instance.conf');
-					$oBrick->LoadFromPortalProperties($oPortalConf['properties']);
+					$oBrick->LoadFromPortalProperties($this->aCombodoPortalInstanceConf['properties']);
 					
 					// Load the brick specific properties from its XML definition
 					$oBrick->LoadFromXml($oBrickNode);

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/BrickCollection.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/BrickCollection.php
@@ -21,6 +21,7 @@ namespace Combodo\iTop\Portal\Brick;
 
 use DOMFormatException;
 use Exception;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use UserRights;
 use ModuleDesign;
 use Combodo\iTop\Portal\Helper\ApplicationHelper;
@@ -47,15 +48,21 @@ class BrickCollection
 	private $aHomeOrdering;
 	/** @var array $aNavigationMenuOrdering */
 	private $aNavigationMenuOrdering;
+	/** @var \Symfony\Component\DependencyInjection\ContainerInterface $container
+	 * @since 3.2.1 
+	 */
+	private $container;
 
 	/**
 	 * BrickCollection constructor.
 	 *
 	 * @param \ModuleDesign $oModuleDesign
+	 * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
 	 *
 	 * @throws \Exception
+	 * @since 3.2.1 Added $container parameter
 	 */
-	public function __construct(ModuleDesign $oModuleDesign)
+	public function __construct(ModuleDesign $oModuleDesign, ContainerInterface $container)
 	{
 		$this->oModuleDesign = $oModuleDesign;
 		$this->aAllowedBricks = null;
@@ -63,6 +70,7 @@ class BrickCollection
 		$this->iDisplayedInNavigationMenu = 0;
 		$this->aHomeOrdering = array();
 		$this->aNavigationMenuOrdering = array();
+		$this->container = $container;
 
 		$this->Load();
 	}
@@ -196,6 +204,12 @@ class BrickCollection
 				{
 					/** @var \Combodo\iTop\Portal\Brick\PortalBrick $oBrick */
 					$oBrick = new $sBrickClass();
+					
+					// Load the portal properties that are common to all bricks of this type
+					$oPortalConf = $this->container->getParameter('combodo.portal.instance.conf');
+					$oBrick->LoadFromPortalProperties($oPortalConf['properties']);
+					
+					// Load the brick specific properties from its XML definition
 					$oBrick->LoadFromXml($oBrickNode);
 
 					$aBricks[] = $oBrick;

--- a/datamodels/2.x/itop-portal-base/portal/src/DependencyInjection/SilexCompatBootstrap/PortalXmlConfiguration/Basic.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/DependencyInjection/SilexCompatBootstrap/PortalXmlConfiguration/Basic.php
@@ -85,6 +85,7 @@ class Basic extends AbstractConfiguration
 				'templates' => array(
 					'layout' => 'itop-portal-base/portal/templates/layout.html.twig',
 					'home' => 'itop-portal-base/portal/templates/home/layout.html.twig',
+					'bricks' => array(),
 				),
 				'urlmaker_class' => null,
 				'triggers_query' => null,
@@ -185,6 +186,14 @@ class Basic extends AbstractConfiguration
 							$aPortalConf['properties']['templates'][$sNodeId] = $oSubNode->GetText(null);
 							break;
 						default:
+							// Try to accept the value as a global brick template
+							$sXsiType = $oSubNode->getAttribute('xsi:type');
+							if (utils::IsNotNullOrEmptyString($sXsiType))
+							{
+								$aPortalConf['properties']['templates']['bricks'][$sXsiType][$sNodeId] = $oSubNode->GetText(null);
+								break;
+							}
+
 							throw new DOMFormatException(
 								'Value "'.$sNodeId.'" is not handled for template[@id]',
 								null, null, $oSubNode

--- a/datamodels/2.x/itop-portal-base/portal/src/DependencyInjection/SilexCompatBootstrap/PortalXmlConfiguration/Basic.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/DependencyInjection/SilexCompatBootstrap/PortalXmlConfiguration/Basic.php
@@ -186,11 +186,11 @@ class Basic extends AbstractConfiguration
 							$aPortalConf['properties']['templates'][$sNodeId] = $oSubNode->GetText(null);
 							break;
 						default:
-							// Try to accept the value as a global brick template
-							$sXsiType = $oSubNode->getAttribute('xsi:type');
-							if (utils::IsNotNullOrEmptyString($sXsiType))
+							// Try to accept the value as a global brick template, brick id format is "FQCN:page"
+							[$sBrickFQCN, $sPage] = explode(':', $sNodeId);
+							if (utils::IsNotNullOrEmptyString($sBrickFQCN) && utils::IsNotNullOrEmptyString($sPage))
 							{
-								$aPortalConf['properties']['templates']['bricks'][$sXsiType][$sNodeId] = $oSubNode->GetText(null);
+								$aPortalConf['properties']['templates']['bricks'][$sBrickFQCN][$sPage] = $oSubNode->GetText(null);
 								break;
 							}
 


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | N°7995
| Type of change?                                               | Enhancement


## Objective 
When redefining a brick template, you need to overload the `<template>` for every brick definition.
It works well for one specific iTop, but as we plan to release an extension bringing the 3.3.0 portal design compatible with iTop 3.2.1+, we need to be able to overload templates for all bricks in a portal without overloading every brick definition


## Proposed solution

This pull request use the `<template>` defined in the portal properties, allowing it to define new default templates that bricks will take into account if they do not have a specific template in their definition.

Example of a customization that'll affect every BrowseBrick in a portal: 
```
  <module_design xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="itop-portal" xsi:type="portal">
  <properties>
    <templates>
      <template id="Combodo\iTop\Portal\Brick\BrowseBrick:page" _delta="define">itop-custom-browse-brick/templates/page.html.twig</template>
    </templates>
  </properties>
  </module_design>
```


## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand digging in the code?