### PR TITLE
N°8031 - Make all portal bricks use custom templates for all templates

### DIFF
--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/AbstractBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/AbstractBrick.php
@@ -65,6 +65,10 @@ abstract class AbstractBrick
 	const DEFAULT_ALLOWED_PROFILES_OQL = '';
 	/** @var string DEFAULT_DENIED_PROFILES_OQL */
 	const DEFAULT_DENIED_PROFILES_OQL = '';
+	/** @var array $DEFAULT_TEMPLATES_PATH  */
+	protected static $DEFAULT_TEMPLATES_PATH = [
+		'page' => self::DEFAULT_PAGE_TEMPLATE_PATH,
+	];
 
 	/** @var string $sId */
 	protected $sId;
@@ -112,7 +116,7 @@ abstract class AbstractBrick
 		$this->bActive = static::DEFAULT_ACTIVE;
 		$this->bVisible = static::DEFAULT_VISIBLE;
 		$this->fRank = static::DEFAULT_RANK;
-		$this->sPageTemplatePath = static::DEFAULT_PAGE_TEMPLATE_PATH;
+		$this->sPageTemplatePath = static::$DEFAULT_TEMPLATES_PATH['page'];
 		$this->sTitle = static::DEFAULT_TITLE;
 		$this->sDescription = static::DEFAULT_DESCRIPTION;
 		$this->sDataLoading = static::DEFAULT_DATA_LOADING;
@@ -573,6 +577,20 @@ abstract class AbstractBrick
 	}
 
 	/**
+	 * @param $sTemplateName
+	 * @param $sTemplatePath
+	 *
+	 * @return void
+	 * @since 3.2.1
+	 */
+	public static function SetDefaultTemplatePath($sTemplateName, $sTemplatePath)
+	{
+		if(array_key_exists($sTemplateName, static::$DEFAULT_TEMPLATES_PATH)) {
+			static::$DEFAULT_TEMPLATES_PATH[$sTemplateName] = $sTemplatePath;
+		}
+	}
+
+	/**
 	 * Load the brick's data from the xml passed as a ModuleDesignElement.
 	 * This is used to set all the brick attributes at once.
 	 *
@@ -665,14 +683,13 @@ abstract class AbstractBrick
 	 * @param $aPortalProperties
 	 *
 	 * @return void
-	 * @throws \DOMFormatException
 	 * @since 3.2.1
 	 */
-	public function LoadFromPortalProperties($aPortalProperties)
+	public static function LoadFromPortalProperties($aPortalProperties)
 	{
 		// Get the bricks templates
 		$aBricksTemplates = $aPortalProperties['templates']['bricks'];
-		$sClassFQCN = get_class($this);
+		$sClassFQCN = static::class;
 		
 		// Get the current brick templates
 		$aCurrentBricksTemplates = array_key_exists($sClassFQCN, $aBricksTemplates) ? $aBricksTemplates[$sClassFQCN] : [];
@@ -681,16 +698,7 @@ abstract class AbstractBrick
 			$sTemplateId = str_ireplace($sClassFQCN.':', '', $sTemplateKey);
 			
 			// Call the set method for the template
-			$sSetTemplateMethodName = 'Set'.$sTemplateId.'TemplatePath';
-			
-			if(method_exists($this, $sSetTemplateMethodName)) {
-				$this->{$sSetTemplateMethodName}($sTemplate);
-			} 
-			else {
-				throw new DOMFormatException(
-					'Template "'.$sTemplateId.'" is not a valid template for brick ' . $sClassFQCN,
-					null, null);
-			}
+			static::SetDefaultTemplatePath($sTemplateId, $sTemplate);
 		}
 	}
 }

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/AbstractBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/AbstractBrick.php
@@ -685,7 +685,7 @@ abstract class AbstractBrick
 	 * @return void
 	 * @since 3.2.1
 	 */
-	public static function LoadFromPortalProperties($aPortalProperties)
+	public static function LoadClassDefinitionFromPortalProperties($aPortalProperties)
 	{
 		// Get the bricks templates
 		$aBricksTemplates = $aPortalProperties['templates']['bricks'];

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/AbstractBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/AbstractBrick.php
@@ -577,16 +577,16 @@ abstract class AbstractBrick
 	}
 
 	/**
-	 * @param $sTemplateName
+	 * @param $sTemplateId
 	 * @param $sTemplatePath
 	 *
 	 * @return void
 	 * @since 3.2.1
 	 */
-	public static function SetDefaultTemplatePath($sTemplateName, $sTemplatePath)
+	public static function SetDefaultTemplatePath($sTemplateId, $sTemplatePath)
 	{
-		if(array_key_exists($sTemplateName, static::$DEFAULT_TEMPLATES_PATH)) {
-			static::$DEFAULT_TEMPLATES_PATH[$sTemplateName] = $sTemplatePath;
+		if(array_key_exists($sTemplateId, static::$DEFAULT_TEMPLATES_PATH)) {
+			static::$DEFAULT_TEMPLATES_PATH[$sTemplateId] = $sTemplatePath;
 		}
 	}
 

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/AggregatePageBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/AggregatePageBrick.php
@@ -39,7 +39,10 @@ class AggregatePageBrick extends PortalBrick
 	const DEFAULT_DECORATION_CLASS_HOME = 'fas fa-tachometer-alt';
 	const DEFAULT_DECORATION_CLASS_NAVIGATION_MENU = 'fas fa-tachometer-alt fa-2x';
 	const DEFAULT_PAGE_TEMPLATE_PATH = 'itop-portal-base/portal/templates/bricks/aggregate-page/layout.html.twig';
-
+	protected static $DEFAULT_TEMPLATES_PATH = [
+		'page' => self::DEFAULT_PAGE_TEMPLATE_PATH,
+		'tile' => self::DEFAULT_TILE_TEMPLATE_PATH,
+	];
 	// Overloaded variables
 	public static $sRouteName = 'p_aggregatepage_brick';
 

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/BrickCollection.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/BrickCollection.php
@@ -204,7 +204,7 @@ class BrickCollection
 				{
 					
 					// Load the portal properties that are common to all bricks of this type
-					$sBrickClass::LoadFromPortalProperties($this->aCombodoPortalInstanceConf['properties']);
+					$sBrickClass::LoadClassDefinitionFromPortalProperties($this->aCombodoPortalInstanceConf['properties']);
 					
 					/** @var \Combodo\iTop\Portal\Brick\PortalBrick $oBrick */
 					$oBrick = new $sBrickClass();

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/BrickCollection.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/BrickCollection.php
@@ -62,7 +62,7 @@ class BrickCollection
 	 * @throws \Exception
 	 * @since 3.2.1 Added $aCombodoPortalInstanceConf parameter
 	 */
-	public function __construct(ModuleDesign $oModuleDesign, $aCombodoPortalInstanceConf)
+	public function __construct(ModuleDesign $oModuleDesign, array $aCombodoPortalInstanceConf)
 	{
 		$this->oModuleDesign = $oModuleDesign;
 		$this->aAllowedBricks = null;
@@ -202,11 +202,12 @@ class BrickCollection
 			{
 				if (class_exists($sBrickClass))
 				{
-					/** @var \Combodo\iTop\Portal\Brick\PortalBrick $oBrick */
-					$oBrick = new $sBrickClass();
 					
 					// Load the portal properties that are common to all bricks of this type
-					$oBrick->LoadFromPortalProperties($this->aCombodoPortalInstanceConf['properties']);
+					$sBrickClass::LoadFromPortalProperties($this->aCombodoPortalInstanceConf['properties']);
+					
+					/** @var \Combodo\iTop\Portal\Brick\PortalBrick $oBrick */
+					$oBrick = new $sBrickClass();
 					
 					// Load the brick specific properties from its XML definition
 					$oBrick->LoadFromXml($oBrickNode);

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/BrowseBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/BrowseBrick.php
@@ -77,6 +77,13 @@ class BrowseBrick extends PortalBrick
 	const DEFAULT_ACTION_OPENING_TARGET = self::ENUM_OPENING_TARGET_MODAL;
 	/** @var int DEFAULT_LIST_LENGTH */
 	const DEFAULT_LIST_LENGTH = 20;
+	protected static $DEFAULT_TEMPLATES_PATH = [
+		'page' => self::DEFAULT_PAGE_TEMPLATE_PATH,
+		'tile' => self::DEFAULT_TILE_TEMPLATE_PATH,
+		'mode-list'=> 'itop-portal-base/portal/templates/bricks/browse/mode_list.html.twig',
+		'mode-mosaic'=> 'itop-portal-base/portal/templates/bricks/browse/mode_mosaic.html.twig',
+		'mode-tree'=> 'itop-portal-base/portal/templates/bricks/browse/mode_tree.html.twig',
+	];
 
 	// Overloaded variables
 	public static $sRouteName = 'p_browse_brick';
@@ -359,7 +366,7 @@ class BrowseBrick extends PortalBrick
 									}
 									else
 									{
-										$sTemplatePath = 'itop-portal-base/portal/templates/bricks/browse/mode_'.$sModeId.'.html.twig';
+										$sTemplatePath = static::$DEFAULT_TEMPLATES_PATH['mode-'.$sModeId];
 									}
 									$aModeData['template'] = $sTemplatePath;
 

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/BrowseBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/BrowseBrick.php
@@ -32,6 +32,13 @@ use Combodo\iTop\DesignElement;
  */
 class BrowseBrick extends PortalBrick
 {
+	/** @var string DEFAULT_PAGE_TEMPLATE_PATH */
+	const DEFAULT_MODE_LIST_TEMPLATE_PATH = 'itop-portal-base/portal/templates/bricks/browse/mode_list.html.twig';
+	/** @var string  DEFAULT_MODE_MOSAIC_TEMPLATE_PATH */
+	const DEFAULT_MODE_MOSAIC_TEMPLATE_PATH = 'itop-portal-base/portal/templates/bricks/browse/mode_mosaic.html.twig';
+	/** @var string DEFAULT_MODE_TREE_TEMPLATE_PATH */
+	const DEFAULT_MODE_TREE_TEMPLATE_PATH = 'itop-portal-base/portal/templates/bricks/browse/mode_tree.html.twig';
+	
 	/** @var string ENUM_BROWSE_MODE_LIST */
 	const ENUM_BROWSE_MODE_LIST = 'list';
 	/** @var string ENUM_BROWSE_MODE_TREE */
@@ -80,9 +87,9 @@ class BrowseBrick extends PortalBrick
 	protected static $DEFAULT_TEMPLATES_PATH = [
 		'page' => self::DEFAULT_PAGE_TEMPLATE_PATH,
 		'tile' => self::DEFAULT_TILE_TEMPLATE_PATH,
-		'mode-list'=> 'itop-portal-base/portal/templates/bricks/browse/mode_list.html.twig',
-		'mode-mosaic'=> 'itop-portal-base/portal/templates/bricks/browse/mode_mosaic.html.twig',
-		'mode-tree'=> 'itop-portal-base/portal/templates/bricks/browse/mode_tree.html.twig',
+		'mode-list'=> self::DEFAULT_MODE_LIST_TEMPLATE_PATH,
+		'mode-mosaic'=> self::DEFAULT_MODE_MOSAIC_TEMPLATE_PATH,
+		'mode-tree'=> self::DEFAULT_MODE_TREE_TEMPLATE_PATH,
 	];
 
 	// Overloaded variables

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/CreateBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/CreateBrick.php
@@ -36,7 +36,10 @@ class CreateBrick extends PortalBrick
 	const DEFAULT_DECORATION_CLASS_HOME = 'fas fa-plus';
 	const DEFAULT_DECORATION_CLASS_NAVIGATION_MENU = 'fas fa-plus fa-2x';
 	const DEFAULT_PAGE_TEMPLATE_PATH = 'itop-portal-base/portal/templates/bricks/create/modal.html.twig';
-
+	protected static $DEFAULT_TEMPLATES_PATH = [
+		'page' => self::DEFAULT_PAGE_TEMPLATE_PATH,
+		'tile' => self::DEFAULT_TILE_TEMPLATE_PATH,
+	];
 	/** @var string DEFAULT_CLASS */
 	const DEFAULT_CLASS = '';
 

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/FilterBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/FilterBrick.php
@@ -37,7 +37,10 @@ class FilterBrick extends PortalBrick
 	const DEFAULT_TILE_TEMPLATE_PATH = 'itop-portal-base/portal/templates/bricks/filter/tile.html.twig';
     const DEFAULT_DECORATION_CLASS_HOME = 'fas fa-search';
     const DEFAULT_DECORATION_CLASS_NAVIGATION_MENU = 'fas fa-search fa-2x';
-
+	protected static $DEFAULT_TEMPLATES_PATH = [
+		'page' => self::DEFAULT_PAGE_TEMPLATE_PATH,
+		'tile' => self::DEFAULT_TILE_TEMPLATE_PATH,
+	];
     /** @var string DEFAULT_TARGET_BRICK_CLASS */
 	const DEFAULT_TARGET_BRICK_CLASS = 'Combodo\\iTop\\Portal\\Brick\\BrowseBrick';
 	/** @var string DEFAULT_SEARCH_PLACEHOLDER_VALUE */

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/ObjectBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/ObjectBrick.php
@@ -10,11 +10,17 @@ namespace Combodo\iTop\Portal\Brick;
  */
 abstract class ObjectBrick extends  AbstractBrick
 {
+	/** @var string DEFAULT_PAGE_TEMPLATE_PATH */
+	const DEFAULT_PAGE_TEMPLATE_PATH = 'itop-portal-base/portal/templates/bricks/object/layout.html.twig';
+	/** @var string DEFAULT_MODAL_TEMPLATE_PATH */
+	const DEFAULT_MODAL_TEMPLATE_PATH = 'itop-portal-base/portal/templates/bricks/object/modal.html.twig';
+	/** @var string DEFAULT_MODE_LOADER_TEMPLATE_PATH */
+	const DEFAULT_MODE_LOADER_TEMPLATE_PATH = 'itop-portal-base/portal/templates/modal/mode_loader.html.twig';
 
 	protected static $DEFAULT_TEMPLATES_PATH = [
-		'page'  => 'itop-portal-base/portal/templates/bricks/object/layout.html.twig',
-		'modal' => 'itop-portal-base/portal/templates/bricks/object/modal.html.twig',
-		'mode_loader' => 'itop-portal-base/portal/templates/modal/mode_loader.html.twig',
+		'page'  => self::DEFAULT_PAGE_TEMPLATE_PATH,
+		'modal' => self::DEFAULT_MODAL_TEMPLATE_PATH,
+		'mode_loader' => self::DEFAULT_MODE_LOADER_TEMPLATE_PATH,
 	];
 
 	/**

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/ObjectBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/ObjectBrick.php
@@ -1,0 +1,53 @@
+<?php
+namespace Combodo\iTop\Portal\Brick;
+
+/**
+ * Description of ObjectBrick
+ *
+ * @package Combodo\iTop\Portal\Brick
+ * @since  3.2.1
+ * @author Stephen Abello <stephen.abello@combodo.com>
+ */
+abstract class ObjectBrick extends  AbstractBrick
+{
+
+	protected static $DEFAULT_TEMPLATES_PATH = [
+		'page'  => 'itop-portal-base/portal/templates/bricks/object/layout.html.twig',
+		'modal' => 'itop-portal-base/portal/templates/bricks/object/modal.html.twig',
+		'mode_loader' => 'itop-portal-base/portal/templates/modal/mode_loader.html.twig',
+	];
+
+	/**
+	 * @param $aCombodoPortalInstanceConf
+	 *
+	 * @return void
+	 */
+	public static function InitializeSelf($aCombodoPortalInstanceConf): void
+	{
+		static::LoadFromPortalProperties($aCombodoPortalInstanceConf['properties']);
+	}
+
+	/**
+	 * @return string
+	 */
+	public static function GetPageDefaultTemplatePath(): string
+	{
+		return static::$DEFAULT_TEMPLATES_PATH['page'];
+	}
+
+	/**
+	 * @return string
+	 */
+	public static function GetModalDefaultTemplatePath(): string
+	{
+		return static::$DEFAULT_TEMPLATES_PATH['modal'];
+	}
+
+	/**
+	 * @return string
+	 */
+	public static function GetModeLoaderDefaultTemplatePath(): string
+	{
+		return static::$DEFAULT_TEMPLATES_PATH['mode_loader'];
+	}
+}

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/ObjectBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/ObjectBrick.php
@@ -30,7 +30,7 @@ abstract class ObjectBrick extends  AbstractBrick
 	 */
 	public static function InitializeSelf($aCombodoPortalInstanceConf): void
 	{
-		static::LoadFromPortalProperties($aCombodoPortalInstanceConf['properties']);
+		static::LoadClassDefinitionFromPortalProperties($aCombodoPortalInstanceConf['properties']);
 	}
 
 	/**

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/PortalBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/PortalBrick.php
@@ -63,6 +63,11 @@ abstract class PortalBrick extends AbstractBrick
 	/** @var string DEFAULT_OPENING_TARGET */
 	const DEFAULT_OPENING_TARGET = self::ENUM_OPENING_TARGET_MODAL;
 
+	protected static $DEFAULT_TEMPLATES_PATH = [
+		'page' => self::DEFAULT_PAGE_TEMPLATE_PATH,
+		'tile' => self::DEFAULT_TILE_TEMPLATE_PATH,
+	];
+
 	/** @var string|null $sRouteName */
 	static $sRouteName = null;
 	/** @var array $aOpeningTargets */
@@ -121,7 +126,7 @@ abstract class PortalBrick extends AbstractBrick
 		$this->bVisibleNavigationMenu = static::DEFAULT_VISIBLE_NAVIGATION_MENU;
 		$this->sDecorationClassHome = static::DEFAULT_DECORATION_CLASS_HOME;
 		$this->sDecorationClassNavigationMenu = static::DEFAULT_DECORATION_CLASS_NAVIGATION_MENU;
-		$this->sTileTemplatePath = static::DEFAULT_TILE_TEMPLATE_PATH;
+		$this->sTileTemplatePath = static::$DEFAULT_TEMPLATES_PATH['tile'];
 		$this->sTileControllerAction = static::DEFAULT_TILE_CONTROLLER_ACTION;
 		$this->sOpeningTarget = static::DEFAULT_OPENING_TARGET;
 	}

--- a/datamodels/2.x/itop-portal-base/portal/src/Brick/UserProfileBrick.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Brick/UserProfileBrick.php
@@ -39,7 +39,10 @@ class UserProfileBrick extends PortalBrick
 	const DEFAUT_TITLE                             = 'Brick:Portal:UserProfile:Title';
 	const DEFAULT_DECORATION_CLASS_HOME            = 'glyphicon glyphicon-user';
 	const DEFAULT_DECORATION_CLASS_NAVIGATION_MENU = 'glyphicon glyphicon-user';
-
+	protected static $DEFAULT_TEMPLATES_PATH = [
+		'page' => self::DEFAULT_PAGE_TEMPLATE_PATH,
+		'tile' => self::DEFAULT_TILE_TEMPLATE_PATH,
+	];
 	/** @var bool DEFAULT_SHOW_PICTURE_FORM */
 	const DEFAULT_SHOW_PICTURE_FORM = true;
 	/** @var bool DEFAULT_SHOW_PREFERENCES_FORM */

--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/ManageBrickController.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/ManageBrickController.php
@@ -70,7 +70,9 @@ use utils;
  */
 class ManageBrickController extends BrickController
 {
-	/** @var string EXCEL_EXPORT_TEMPLATE_PATH */
+	/** @var string EXCEL_EXPORT_TEMPLATE_PATH 
+	 * @deprecated since 3.2.1
+	 */
 	const EXCEL_EXPORT_TEMPLATE_PATH = 'itop-portal-base/portal/templates/bricks/manage/popup-export-excel.html.twig';
 
 	/**
@@ -281,7 +283,7 @@ class ManageBrickController extends BrickController
             'sWikiUrl' => 'https://www.itophub.io/wiki/page?id='.utils::GetItopVersionWikiSyntax().'%3Auser%3Alists#excel_export',
 		);
 
-		return $this->render(static::EXCEL_EXPORT_TEMPLATE_PATH, $aData);
+		return $this->render($oBrick->GetPopupExportExcelTemplatePath(), $aData);
 	}
 
 	/**

--- a/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Controller/ObjectController.php
@@ -29,6 +29,7 @@ use BinaryExpression;
 use Combodo\iTop\Form\Field\DateTimeField;
 use Combodo\iTop\Portal\Brick\BrickCollection;
 use Combodo\iTop\Portal\Brick\CreateBrick;
+use Combodo\iTop\Portal\Brick\ObjectBrick;
 use Combodo\iTop\Portal\Helper\ApplicationHelper;
 use Combodo\iTop\Portal\Helper\ContextManipulatorHelper;
 use Combodo\iTop\Portal\Helper\NavigationRuleHelper;
@@ -82,8 +83,11 @@ class ObjectController extends BrickController
 	 * @param \Combodo\iTop\Portal\Brick\BrickCollection $oBrickCollection
 	 * @param \Combodo\iTop\Portal\Helper\ObjectFormHandlerHelper $oObjectFormHandlerHelper
 	 * @param \Combodo\iTop\Portal\Helper\NavigationRuleHelper $oNavigationRuleHelper
+	 * @param \Combodo\iTop\Portal\Helper\ContextManipulatorHelper $oContextManipulatorHelper
+	 * @param array $aCombodoPortalInstanceConf
 	 *
 	 * @since 3.2.0 N°6933
+	 * @since 3.2.1 Added $aCombodoPortalInstanceConf parameter
 	 */
 	public function __construct(
 		protected SecurityHelper $oSecurityHelper,
@@ -93,10 +97,11 @@ class ObjectController extends BrickController
 		protected BrickCollection $oBrickCollection,
 		protected ObjectFormHandlerHelper $oObjectFormHandlerHelper,
 		protected NavigationRuleHelper $oNavigationRuleHelper,
-		protected ContextManipulatorHelper $oContextManipulatorHelper
-
+		protected ContextManipulatorHelper $oContextManipulatorHelper,
+		protected  array $aCombodoPortalInstanceConf
 	)
 	{
+		ObjectBrick::InitializeSelf($this->aCombodoPortalInstanceConf);
 	}
 
 	/**
@@ -232,7 +237,7 @@ class ObjectController extends BrickController
 		if ($oRequest->isXmlHttpRequest()) {
 			// We have to check whether the 'operation' parameter is defined or not in order to know if the form is required via ajax (to be displayed as a modal dialog) or if it's a lifecycle call from a existing form.
 			if (empty($sOperation)) {
-				$oResponse = $this->render('itop-portal-base/portal/templates/bricks/object/modal.html.twig', $aData);
+				$oResponse = $this->render(ObjectBrick::GetModalDefaultTemplatePath(), $aData);
 			} else {
 				$oResponse = new JsonResponse($aData);
 			}
@@ -246,7 +251,7 @@ class ObjectController extends BrickController
 				}
 			}
 			$aData['sPageTitle'] = $aData['form']['title'];
-			$oResponse = $this->render('itop-portal-base/portal/templates/bricks/object/layout.html.twig', $aData);
+			$oResponse = $this->render(ObjectBrick::GetPageDefaultTemplatePath(), $aData);
 		}
 
 		return $oResponse;
@@ -307,7 +312,7 @@ class ObjectController extends BrickController
 			// We have to check whether the 'operation' parameter is defined or not in order to know if the form is required via ajax (to be displayed as a modal dialog) or if it's a lifecycle call from a existing form.
 			if (empty($sOperation))
 			{
-				$oResponse = $this->render('itop-portal-base/portal/templates/bricks/object/modal.html.twig', $aData);
+				$oResponse = $this->render(ObjectBrick::GetModalDefaultTemplatePath(), $aData);
 			}
 			else
 			{
@@ -327,7 +332,7 @@ class ObjectController extends BrickController
 				}
 			}
 			$aData['sPageTitle'] = $aData['form']['title'];
-			$oResponse = $this->render('itop-portal-base/portal/templates/bricks/object/layout.html.twig', $aData);
+			$oResponse = $this->render(ObjectBrick::GetPageDefaultTemplatePath(), $aData);
 		}
 
 		return $oResponse;
@@ -534,11 +539,11 @@ class ObjectController extends BrickController
 			// We have to check whether the 'operation' parameter is defined or not in order to know if the form is required via ajax (to be displayed as a modal dialog) or if it's a lifecycle call from a existing form.
 			if (empty($sOperation))
 			{
-				$oResponse = $this->render('itop-portal-base/portal/templates/bricks/object/modal.html.twig', $aData);
+				$oResponse = $this->render(ObjectBrick::GetModalDefaultTemplatePath(), $aData);
 			}
 			elseif ($sOperation === 'redirect')
 			{
-				$oResponse = $this->render('itop-portal-base/portal/templates/modal/mode_loader.html.twig', $aData);
+				$oResponse = $this->render(ObjectBrick::GetModeLoaderDefaultTemplatePath(), $aData);
 			}
 			else
 			{
@@ -547,7 +552,7 @@ class ObjectController extends BrickController
 		}
 		else
 		{
-			$oResponse = $this->render('itop-portal-base/portal/templates/bricks/object/layout.html.twig', $aData);
+			$oResponse = $this->render(ObjectBrick::GetPageDefaultTemplatePath(), $aData);
 		}
 
 		return $oResponse;
@@ -1011,12 +1016,12 @@ class ObjectController extends BrickController
 
 			if ($oRequest->isXmlHttpRequest())
 			{
-				$oResponse = $this->render('itop-portal-base/portal/templates/bricks/object/modal.html.twig', $aData);
+				$oResponse = $this->render(ObjectBrick::GetModalDefaultTemplatePath(), $aData);
 			}
 			else
 			{
 				//throw new HttpException(Response::HTTP_NOT_FOUND, Dict::S('UI:ObjectDoesNotExist'));
-				$oResponse = $this->render('itop-portal-base/portal/templates/bricks/object/layout.html.twig', $aData);
+				$oResponse = $this->render(ObjectBrick::GetPageDefaultTemplatePath(), $aData);
 			}
 		}
 		else
@@ -1560,7 +1565,7 @@ class ObjectController extends BrickController
 			// We have to check whether the 'operation' parameter is defined or not in order to know if the form is required via ajax (to be displayed as a modal dialog) or if it's a lifecycle call from a existing form.
 			if (empty($sOperation))
 			{
-				$oResponse = $this->render('itop-portal-base/portal/templates/bricks/object/modal.html.twig', $aData);
+				$oResponse = $this->render(ObjectBrick::GetModalDefaultTemplatePath(), $aData);
 			}
 			else
 			{
@@ -1580,7 +1585,7 @@ class ObjectController extends BrickController
 				}
 			}
 			$aData['sPageTitle'] = $aData['form']['title'];
-			$oResponse = $this->render('itop-portal-base/portal/templates/bricks/object/layout.html.twig', $aData);
+			$oResponse = $this->render(ObjectBrick::GetPageDefaultTemplatePath(), $aData);
 		}
 
 		return $oResponse;

--- a/datamodels/2.x/itop-portal-base/portal/vendor/composer/autoload_classmap.php
+++ b/datamodels/2.x/itop-portal-base/portal/vendor/composer/autoload_classmap.php
@@ -14,6 +14,7 @@ return array(
     'Combodo\\iTop\\Portal\\Brick\\CreateBrick' => $baseDir . '/src/Brick/CreateBrick.php',
     'Combodo\\iTop\\Portal\\Brick\\FilterBrick' => $baseDir . '/src/Brick/FilterBrick.php',
     'Combodo\\iTop\\Portal\\Brick\\ManageBrick' => $baseDir . '/src/Brick/ManageBrick.php',
+    'Combodo\\iTop\\Portal\\Brick\\ObjectBrick' => $baseDir . '/src/Brick/ObjectBrick.php',
     'Combodo\\iTop\\Portal\\Brick\\PortalBrick' => $baseDir . '/src/Brick/PortalBrick.php',
     'Combodo\\iTop\\Portal\\Brick\\PropertyNotFoundException' => $baseDir . '/src/Brick/PropertyNotFoundException.php',
     'Combodo\\iTop\\Portal\\Brick\\UserProfileBrick' => $baseDir . '/src/Brick/UserProfileBrick.php',

--- a/datamodels/2.x/itop-portal-base/portal/vendor/composer/autoload_static.php
+++ b/datamodels/2.x/itop-portal-base/portal/vendor/composer/autoload_static.php
@@ -34,6 +34,7 @@ class ComposerStaticInitdf408f3f8ea034d298269cdf7647358b
         'Combodo\\iTop\\Portal\\Brick\\CreateBrick' => __DIR__ . '/../..' . '/src/Brick/CreateBrick.php',
         'Combodo\\iTop\\Portal\\Brick\\FilterBrick' => __DIR__ . '/../..' . '/src/Brick/FilterBrick.php',
         'Combodo\\iTop\\Portal\\Brick\\ManageBrick' => __DIR__ . '/../..' . '/src/Brick/ManageBrick.php',
+        'Combodo\\iTop\\Portal\\Brick\\ObjectBrick' => __DIR__ . '/../..' . '/src/Brick/ObjectBrick.php',
         'Combodo\\iTop\\Portal\\Brick\\PortalBrick' => __DIR__ . '/../..' . '/src/Brick/PortalBrick.php',
         'Combodo\\iTop\\Portal\\Brick\\PropertyNotFoundException' => __DIR__ . '/../..' . '/src/Brick/PropertyNotFoundException.php',
         'Combodo\\iTop\\Portal\\Brick\\UserProfileBrick' => __DIR__ . '/../..' . '/src/Brick/UserProfileBrick.php',


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? |N°8031
| Type of change?                                               | Enhancement


## Objective (enhancement)
With  #686, we added a way to define a twig template for all Bricks without altering their definition. In this PR, we make bricks correctly collect, and use these custom twig templates.

This also adds a common way to define default templates for bricks and will be used to develop further brick template customization through its definition

## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?
