### PR TITLE
N°7633 - Reloads the same user multiple times if it no longer exists

### DIFF
--- a/core/userrights.class.inc.php
+++ b/core/userrights.class.inc.php
@@ -1923,7 +1923,7 @@ class UserRights
 	{
 		if ($sAuthentication === 'any')
 		{
-			$oUser = self::FindUser($sLogin, 'internal');
+			$oUser = self::FindUser($sLogin, 'internal', $bAllowDisabledUsers);
 			if ($oUser !== null)
 			{
 				return $oUser;

--- a/core/userrights.class.inc.php
+++ b/core/userrights.class.inc.php
@@ -1921,50 +1921,51 @@ class UserRights
 	 */
 	protected static function FindUser($sLogin, $sAuthentication = 'any', $bAllowDisabledUsers = false)
 	{
-		if ($sAuthentication == 'any')
+		if ($sAuthentication === 'any')
 		{
 			$oUser = self::FindUser($sLogin, 'internal');
-			if ($oUser == null)
+			if ($oUser !== null)
 			{
-				$oUser = self::FindUser($sLogin, 'external');
+				return $oUser;
 			}
+
+			return self::FindUser($sLogin, 'external');
 		}
-		else
+
+		if (!isset(self::$m_aCacheUsers))
 		{
-			if (!isset(self::$m_aCacheUsers))
-			{
-				self::$m_aCacheUsers = array('internal' => array(), 'external' => array());
-			}
-
-			if (!isset(self::$m_aCacheUsers[$sAuthentication][$sLogin]))
-			{
-				switch($sAuthentication)
-				{
-					case 'external':
-					$sBaseClass = 'UserExternal';
-					break;
-
-					case 'internal':
-					$sBaseClass = 'UserInternal';
-					break;
-
-					default:
-					echo "<p>sAuthentication = $sAuthentication</p>\n";
-					assert(false); // should never happen
-				}
-				$oSearch = DBObjectSearch::FromOQL("SELECT $sBaseClass WHERE login = :login");
-				$oSearch->AllowAllData();
-				if (!$bAllowDisabledUsers)
-				{
-					$oSearch->AddCondition('status', 'enabled');
-				}
-				$oSet = new DBObjectSet($oSearch, array(), array('login' => $sLogin));
-				$oUser = $oSet->fetch();
-				self::$m_aCacheUsers[$sAuthentication][$sLogin] = $oUser;
-			}
-			$oUser = self::$m_aCacheUsers[$sAuthentication][$sLogin];
+			self::$m_aCacheUsers = [ 'internal' => array(), 'external' => array() ];
 		}
-		return $oUser;
+
+		if (! isset(self::$m_aCacheUsers[$sAuthentication]) || ! array_key_exists($sLogin, self::$m_aCacheUsers[$sAuthentication]))
+		{
+			switch($sAuthentication)
+			{
+				case 'external':
+				$sBaseClass = 'UserExternal';
+				break;
+
+				case 'internal':
+				$sBaseClass = 'UserInternal';
+				break;
+
+				default:
+				echo "<p>sAuthentication = $sAuthentication</p>\n";
+				assert(false); // should never happen
+			}
+			$oSearch = DBObjectSearch::FromOQL("SELECT $sBaseClass WHERE login = :login");
+			$oSearch->AllowAllData();
+			if (!$bAllowDisabledUsers)
+			{
+				$oSearch->AddCondition('status', 'enabled');
+			}
+			$oSet = new DBObjectSet($oSearch, array(), array('login' => $sLogin));
+			$oUser = $oSet->fetch();
+
+			self::$m_aCacheUsers[$sAuthentication][$sLogin] = $oUser;
+		}
+
+		return self::$m_aCacheUsers[$sAuthentication][$sLogin];
 	}
 
 	/**

--- a/core/userrights.class.inc.php
+++ b/core/userrights.class.inc.php
@@ -1934,7 +1934,7 @@ class UserRights
 
 		if (!isset(self::$m_aCacheUsers))
 		{
-			self::$m_aCacheUsers = [ 'internal' => array(), 'external' => array() ];
+			self::$m_aCacheUsers = [ 'internal' => [], 'external' => [] ];
 		}
 
 		if (! isset(self::$m_aCacheUsers[$sAuthentication]) || ! array_key_exists($sLogin, self::$m_aCacheUsers[$sAuthentication]))

--- a/core/userrights.class.inc.php
+++ b/core/userrights.class.inc.php
@@ -1929,7 +1929,7 @@ class UserRights
 				return $oUser;
 			}
 
-			return self::FindUser($sLogin, 'external');
+			return self::FindUser($sLogin, 'external', $bAllowDisabledUsers);
 		}
 
 		if (!isset(self::$m_aCacheUsers))

--- a/core/userrights.class.inc.php
+++ b/core/userrights.class.inc.php
@@ -1921,26 +1921,21 @@ class UserRights
 	 */
 	protected static function FindUser($sLogin, $sAuthentication = 'any', $bAllowDisabledUsers = false)
 	{
-		if ($sAuthentication === 'any')
-		{
+		if ($sAuthentication === 'any') {
 			$oUser = self::FindUser($sLogin, 'internal', $bAllowDisabledUsers);
-			if ($oUser !== null)
-			{
+			if ($oUser !== null) {
 				return $oUser;
 			}
 
 			return self::FindUser($sLogin, 'external', $bAllowDisabledUsers);
 		}
 
-		if (!isset(self::$m_aCacheUsers))
-		{
+		if (!isset(self::$m_aCacheUsers)) {
 			self::$m_aCacheUsers = [ 'internal' => [], 'external' => [] ];
 		}
 
-		if (! isset(self::$m_aCacheUsers[$sAuthentication]) || ! array_key_exists($sLogin, self::$m_aCacheUsers[$sAuthentication]))
-		{
-			switch($sAuthentication)
-			{
+		if (! isset(self::$m_aCacheUsers[$sAuthentication]) || ! array_key_exists($sLogin, self::$m_aCacheUsers[$sAuthentication])) {
+			switch($sAuthentication) {
 				case 'external':
 				$sBaseClass = 'UserExternal';
 				break;
@@ -1955,8 +1950,7 @@ class UserRights
 			}
 			$oSearch = DBObjectSearch::FromOQL("SELECT $sBaseClass WHERE login = :login");
 			$oSearch->AllowAllData();
-			if (!$bAllowDisabledUsers)
-			{
+			if (!$bAllowDisabledUsers) {
 				$oSearch->AddCondition('status', 'enabled');
 			}
 			$oSet = new DBObjectSet($oSearch, array(), array('login' => $sLogin));

--- a/tests/php-unit-tests/unitary-tests/core/UserRightsTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/UserRightsTest.php
@@ -489,7 +489,7 @@ class UserRightsTest extends ItopDataTestCase
 		];
 	}
 
-	public function testFindUser_internaluser()
+	public function testFindUser_ExistingInternalUser()
 	{
 		$sLogin = 'admin'.uniqid();
 		$iKey = $this->CreateUser($sLogin, self::$aURP_Profiles['Administrator'])->GetKey();
@@ -506,33 +506,14 @@ class UserRightsTest extends ItopDataTestCase
 		});
 	}
 
-	public function testFindUserUnknownLogin_AvoidSameSearchAgain()
-	{
-		$sLogin = 'admin'.uniqid();
-		$oUser = $this->InvokeNonPublicStaticMethod(UserRights::class, "FindUser", [$sLogin]);
-		$this->assertNull($oUser);
-
-		$this->assertDBQueryCount(0, function() use ($sLogin){
-			$oUser = $this->InvokeNonPublicStaticMethod(UserRights::class, "FindUser", [$sLogin]);
-			$this->assertNull($oUser);
-		});
-	}
-
-	public function testFindUser_externaluser()
+	public function testFindUser_ExistingExternalUser()
 	{
 		$sLogin = 'admin'.uniqid();
 
-		$oUserProfile = new URP_UserProfile();
-		$oUserProfile->Set('profileid', self::$aURP_Profiles['Administrator']);
-		$oUserProfile->Set('reason', 'UNIT Tests');
-		$oSet = DBObjectSet::FromObject($oUserProfile);
-		/** @var \UserLocal $oUser */
-		$oUser = $this->createObject(\UserExternal::class, array(
+		$iKey = $this->GivenObjectInDB(\UserExternal::class, [
 			'login' => $sLogin,
 			'language' => 'EN US',
-			'profile_list' => $oSet,
-		));
-		$iKey = $oUser->GetKey();
+		]);
 
 		$oUser = $this->InvokeNonPublicStaticMethod(UserRights::class, "FindUser", [$sLogin]);
 
@@ -547,4 +528,15 @@ class UserRightsTest extends ItopDataTestCase
 		});
 	}
 
+	public function testFindUser_UnknownLogin_AvoidSameSqlQueryTwice()
+	{
+		$sLogin = 'admin'.uniqid();
+		$oUser = $this->InvokeNonPublicStaticMethod(UserRights::class, "FindUser", [$sLogin]);
+		$this->assertNull($oUser);
+
+		$this->assertDBQueryCount(0, function() use ($sLogin){
+			$oUser = $this->InvokeNonPublicStaticMethod(UserRights::class, "FindUser", [$sLogin]);
+			$this->assertNull($oUser);
+		});
+	}
 }

--- a/tests/php-unit-tests/unitary-tests/core/UserRightsTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/UserRightsTest.php
@@ -488,4 +488,63 @@ class UserRightsTest extends ItopDataTestCase
 			'with Admins hidden' => [true, 0],
 		];
 	}
+
+	public function testFindUser_internaluser()
+	{
+		$sLogin = 'admin'.uniqid();
+		$iKey = $this->CreateUser($sLogin, self::$aURP_Profiles['Administrator'])->GetKey();
+		$oUser = $this->InvokeNonPublicStaticMethod(UserRights::class, "FindUser", [$sLogin]);
+
+		$this->assertNotNull($oUser);
+		$this->assertEquals($iKey, $oUser->GetKey());
+		$this->assertEquals(\UserLocal::class, get_class($oUser));
+
+		$this->assertDBQueryCount(0, function() use ($sLogin, $iKey){
+			$oUser = $this->InvokeNonPublicStaticMethod(UserRights::class, "FindUser", [$sLogin]);
+			static::assertEquals($iKey, $oUser->GetKey());
+			static::assertEquals(\UserLocal::class, get_class($oUser));
+		});
+	}
+
+	public function testFindUserUnknownLogin_AvoidSameSearchAgain()
+	{
+		$sLogin = 'admin'.uniqid();
+		$oUser = $this->InvokeNonPublicStaticMethod(UserRights::class, "FindUser", [$sLogin]);
+		$this->assertNull($oUser);
+
+		$this->assertDBQueryCount(0, function() use ($sLogin){
+			$oUser = $this->InvokeNonPublicStaticMethod(UserRights::class, "FindUser", [$sLogin]);
+			$this->assertNull($oUser);
+		});
+	}
+
+	public function testFindUser_externaluser()
+	{
+		$sLogin = 'admin'.uniqid();
+
+		$oUserProfile = new URP_UserProfile();
+		$oUserProfile->Set('profileid', self::$aURP_Profiles['Administrator']);
+		$oUserProfile->Set('reason', 'UNIT Tests');
+		$oSet = DBObjectSet::FromObject($oUserProfile);
+		/** @var \UserLocal $oUser */
+		$oUser = $this->createObject(\UserExternal::class, array(
+			'login' => $sLogin,
+			'language' => 'EN US',
+			'profile_list' => $oSet,
+		));
+		$iKey = $oUser->GetKey();
+
+		$oUser = $this->InvokeNonPublicStaticMethod(UserRights::class, "FindUser", [$sLogin]);
+
+		$this->assertNotNull($oUser);
+		$this->assertEquals($iKey, $oUser->GetKey());
+		$this->assertEquals(\UserExternal::class, get_class($oUser));
+
+		$this->assertDBQueryCount(0, function() use ($sLogin, $iKey){
+			$oUser = $this->InvokeNonPublicStaticMethod(UserRights::class, "FindUser", [$sLogin]);
+			static::assertEquals($iKey, $oUser->GetKey());
+			static::assertEquals(\UserExternal::class, get_class($oUser));
+		});
+	}
+
 }

--- a/tests/php-unit-tests/unitary-tests/core/UserRightsTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/UserRightsTest.php
@@ -491,7 +491,7 @@ class UserRightsTest extends ItopDataTestCase
 
 	public function testFindUser_ExistingInternalUser()
 	{
-		$sLogin = 'admin'.uniqid();
+		$sLogin = 'UserRightsFindUser'.uniqid();
 		$iKey = $this->CreateUser($sLogin, self::$aURP_Profiles['Administrator'])->GetKey();
 		$oUser = $this->InvokeNonPublicStaticMethod(UserRights::class, "FindUser", [$sLogin]);
 
@@ -508,7 +508,7 @@ class UserRightsTest extends ItopDataTestCase
 
 	public function testFindUser_ExistingExternalUser()
 	{
-		$sLogin = 'admin'.uniqid();
+		$sLogin = 'UserRightsFindUser'.uniqid();
 
 		$iKey = $this->GivenObjectInDB(\UserExternal::class, [
 			'login' => $sLogin,
@@ -530,7 +530,7 @@ class UserRightsTest extends ItopDataTestCase
 
 	public function testFindUser_UnknownLogin_AvoidSameSqlQueryTwice()
 	{
-		$sLogin = 'admin'.uniqid();
+		$sLogin = 'UserRightsFindUser'.uniqid();
 		$oUser = $this->InvokeNonPublicStaticMethod(UserRights::class, "FindUser", [$sLogin]);
 		$this->assertNull($oUser);
 


### PR DESCRIPTION
**Symptom**
Same user is searched further times to display an object history with many caselogs (up to 300 searches observed by a customer). The cache management does not deal properly caselogs with author set with contact name (instead of login). 
Fallback when unfound user is done on caselog display side...

**Fix**
Remember that a previous search failed to find a user by its contact name (UserRights::FindUser).