### PR TITLE
:bug: Use Cancel-Button results in Ajax-Unauthorized Response

### DIFF
--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -62,7 +62,7 @@ try
 	// check if header contains X-Combodo-Ajax for POST request (CSRF protection for ajax calls)
 	// check must be performed after DoLoginEx to be logged in and to be able to check the token (based on the transaction id)
 	if (!isset($_SERVER['HTTP_X_COMBODO_AJAX']) && $_SERVER['REQUEST_METHOD'] !== 'GET') {
-		$sTransactionId = utils::ReadPostedParam("transaction_id");
+		$sTransactionId = utils::ReadPostedParam("transaction_id",'','transaction_id');
 		if (!utils::IsTransactionValid($sTransactionId, false)) { // if a form is submitted without header but contains a token... should be exceptional
 			$sReferer = $_SERVER['HTTP_REFERER'];
 			$sErrorMsg = 'Unauthorized access. Please see https://www.itophub.io/wiki/page?id=3_2_0:release:developer#checking_for_the_presence_of_specific_header_in_the_post_to_enhance_protection_against_csrf_attacks';


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | no
| Type of change?                                               | Bug fix


## Symptom (bug) / Objective (enhancement)

When calling "cancel button" in edit or creation dialog the ajax request responded with unauthorized 401. This results in login mask when using IIS with Windows Authentication. You can continue to use itop without enter credentials, but it appears everytime canceling a edit/new mask. The reason is the Transaction_id validation in ajax.render.php failed. After changing the ReadPostedParam Parameter "sSanitizationFilter" from default "parameter" to "transaction_id" the validation is true and itop is handleling everything fine.

## Reproduction procedure (bug)

1. On iTop 3.2.0 <!-- Put complete iTop version (eg. 3.1.0-2) -->
2. With PHP 8.1.30 <!-- Put complete PHP version (eg. 8.1.24) -->
3. IIS and Windows Authentication (The Bug also happend everywhere else but you will only see it in the developer console of the browser that the ajax-result answers 401)
1. First go and add a new Object (Server as example) or edit any existing cmdb object or ticket
2. Then do cancel this dialog
3. Finally, see that a login mask appears, which can be canceled and you can continue to use itop.

## Cause (bug)

The reason is when unloading the new object page or edit page the unload function calls a function where the transaction_id verification failed. 


## Proposed solution (bug and enhancement)

Editing one line in ajax.render.php for header and transaction_id check  from using the default parameters of ReadPostedParam to specific parameter "transaction_id" as sSanitizationFilter


## Checklist before requesting a review
- [x ] I have performed a self-review of my code
- [x ] I have tested all changes I made on an iTop instance
- [x ] no unit test, because only one line changed with existing functions
- [ x] Is the PR clear and detailed enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge
