### PR TITLE
N°8245 - External key not saved in n-n link in edition

### DIFF
--- a/js/links/links_widget.js
+++ b/js/links/links_widget.js
@@ -390,16 +390,17 @@ function LinksWidget(id, sClass, sAttCode, iInputId, sSuffix, bDuplicates, oWizH
 
 	this.RegisterChange = function () {
 		// Listen only used inputs
-		$('#linkedset_'+me.id+' :input[name^="attr_'+me.sAttCode+'["]').off('change').on('change', function () {
+		$('body').off('change', '#linkedset_'+me.id+' :input[name^="attr_'+me.sAttCode+'["]')
+			.on('change', '#linkedset_'+me.id+' :input[name^="attr_'+me.sAttCode+'["]', function () {
 			if (!($(this).hasClass('selection')))
-			{
-				let oCheckbox = $(this).closest('tr').find('.selection');
-				let iLink = oCheckbox.attr('data-link-id');
-				let iUniqueId = oCheckbox.attr('data-unique-id');
-				let sAttCode = $(this).closest('.attribute-edit').attr('data-attcode');
-				let value = $(this).val();;
-				return me.OnValueChange(iLink, iUniqueId, sAttCode, value, this);
-			}
+				{
+					let oCheckbox = $(this).closest('tr').find('.selection');
+					let iLink = oCheckbox.attr('data-link-id');
+					let iUniqueId = oCheckbox.attr('data-unique-id');
+					let sAttCode = $(this).closest('.attribute-edit').attr('data-attcode');
+					let value = $(this).val();;
+					return me.OnValueChange(iLink, iUniqueId, sAttCode, value, this);
+				}
 			return true;
 		});
 	};

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinkSetEditTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinkSetEditTable.php
@@ -360,6 +360,17 @@ JS
 					);
 			}
 
+			// !!patch!! Change registration needs to be performed after Selectize initialization
+			// @see N°8245 - External key not saved in n-n link in edition
+			// @see N°8245 since N°7264 Update selectize.js from 0.12.4 to 0.15.2
+			if ($iUniqueId > 0) {
+				$oP->add_ready_script(
+					<<<EOF
+oWidget{$this->oUILinksWidget->GetInputId()}.OnLinkAdded($iUniqueId, $iRemoteObjKey);
+EOF
+				);
+			}
+
 			$sState = '';
 			$sRemoteKeySafeFieldId = $this->GetFieldId($iUniqueId, $this->oUILinksWidget->GetExternalKeyToRemote());
 		}

--- a/sources/Application/UI/Links/Indirect/BlockIndirectLinkSetEditTable.php
+++ b/sources/Application/UI/Links/Indirect/BlockIndirectLinkSetEditTable.php
@@ -360,17 +360,6 @@ JS
 					);
 			}
 
-			// !!patch!! Change registration needs to be performed after Selectize initialization
-			// @see N°8245 - External key not saved in n-n link in edition
-			// @see N°8245 since N°7264 Update selectize.js from 0.12.4 to 0.15.2
-			if ($iUniqueId > 0) {
-				$oP->add_ready_script(
-					<<<EOF
-oWidget{$this->oUILinksWidget->GetInputId()}.OnLinkAdded($iUniqueId, $iRemoteObjKey);
-EOF
-				);
-			}
-
 			$sState = '';
 			$sRemoteKeySafeFieldId = $this->GetFieldId($iUniqueId, $this->oUILinksWidget->GetExternalKeyToRemote());
 		}


### PR DESCRIPTION
@see https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=8245

Bug introduced with bug N°8245 since N°7264 Update selectize.js from 0.12.4 to 0.15.2
This version of Selectize library reset the input change listeners on initialization.

Needs a better implementation because the code is quite ugly.