### PR TITLE
N°8367 - Add helper method to create an ObjectResult from a DBObject.

### DIFF
--- a/core/restservices.class.inc.php
+++ b/core/restservices.class.inc.php
@@ -77,6 +77,52 @@ class ObjectResult
 	}
 
 	/**
+	 * Creates an ObjectResult from a DBObject.
+	 *
+	 * @param DBObject $oObj The object.
+	 * @param array|null $aFieldSpec An array of class => attribute codes (Cf. RestUtils::GetFieldList). List of the attributes to be reported.
+	 * @param boolean $bExtendedOutput Output all of the link set attributes ?
+	 * @param integer $iCode An error code (RestResult::OK is no issue has been found)
+	 * @param string $sMessage Description of the error if any, an empty string otherwise
+	 * 
+	 * @return ObjectResult
+	 */
+	public static function FromDBObject(DBObject $oObj, ?array $aFieldSpec = null, $bExtendedOutput = false, $iCode = 0, $sMessage = '') : ObjectResult {
+
+		$oObjRes = new ObjectResult($oObj::class, $oObj->GetKey());
+		$oObjRes->code = $iCode;
+		$oObjRes->message = $sMessage;
+
+		$aFields = null;
+		if (!is_null($aFieldSpec))
+		{
+			// Enum all classes in the hierarchy, starting with the current one
+			foreach (MetaModel::EnumParentClasses($oObj::class, ENUM_PARENT_CLASSES_ALL, false) as $sRefClass)
+			{
+				if (array_key_exists($sRefClass, $aFieldSpec))
+				{
+					$aFields = $aFieldSpec[$sRefClass];
+					break;
+				}
+			}
+		}
+		if (is_null($aFields))
+		{
+			// No fieldspec given, or not found...
+			$aFields = array('id', 'friendlyname');
+		}
+
+		foreach ($aFields as $sAttCode)
+		{
+			$oObjRes->AddField($oObj, $sAttCode, $bExtendedOutput);
+		}
+
+		return $oObjRes;
+
+	}
+
+
+	/**
 	 * Helper to make an output value for a given attribute
 	 *
 	 * @api
@@ -204,34 +250,7 @@ class RestResultWithObjects extends RestResult
 	 */
 	public function AddObject($iCode, $sMessage, $oObject, $aFieldSpec = null, $bExtendedOutput = false)
 	{
-		$sClass = get_class($oObject);
-		$oObjRes = new ObjectResult($sClass, $oObject->GetKey());
-		$oObjRes->code = $iCode;
-		$oObjRes->message = $sMessage;
-
-		$aFields = null;
-		if (!is_null($aFieldSpec))
-		{
-			// Enum all classes in the hierarchy, starting with the current one
-			foreach (MetaModel::EnumParentClasses($sClass, ENUM_PARENT_CLASSES_ALL, false) as $sRefClass)
-			{
-				if (array_key_exists($sRefClass, $aFieldSpec))
-				{
-					$aFields = $aFieldSpec[$sRefClass];
-					break;
-				}
-			}
-		}
-		if (is_null($aFields))
-		{
-			// No fieldspec given, or not found...
-			$aFields = array('id', 'friendlyname');
-		}
-
-		foreach ($aFields as $sAttCode)
-		{
-			$oObjRes->AddField($oObject, $sAttCode, $bExtendedOutput);
-		}
+		$oObjRes = ObjectResult::FromDBObject($oObject, $aFieldSpec, $bExtendedOutput, $iCode, $sMessage);
 
 		$sObjKey = get_class($oObject).'::'.$oObject->GetKey();
 		$this->objects[$sObjKey] = $oObjRes;


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | No
| Type of change?                                               | Enhancement


## Symptom (bug) / Objective (enhancement)
  - For some purposes (e.g. my report generator and maps extensions), it would be handy to re-use the structure from the iTop REST/JSON API. 
  
  - The end goal is to have a built-in method to convert an iTop object to JSON. With this PR, it's still quite generic (in most cases no need for "code" or "message"). It also still allows the options to specify the desired fields etc.
  
  


## Proposed solution (bug and enhancement)
  - Make it possible to create an ObjectResult from a DBObject. This is done by moving some logic in its own helper method (a static method on ObjectResult).


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't => I think this is covered in existing tests.
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?

