### PR TITLE
N°7914 - REST: Allow class based output fields + Allow OQL with multiclass result

### DIFF
--- a/application/applicationextension/rest/RestUtils.php
+++ b/application/applicationextension/rest/RestUtils.php
@@ -107,6 +107,15 @@ class RestUtils
 		};
 	}
 
+	/**
+	 * Check if the requested field list asks for an extended output.
+	 *
+	 * Extended output is requested when using '*+' or class-scoped field definitions.
+	 *
+	 * @param string $sFields Requested field specification.
+	 *
+	 * @return bool
+	 */
 	public static function HasRequestedExtendedOutput(string $sFields): bool
 	{
 		return match($sFields) {
@@ -116,6 +125,13 @@ class RestUtils
 		};
 	}
 
+	/**
+	 * Check if the requested field list asks for all output fields.
+	 *
+	 * @param string $sFields Requested field specification.
+	 *
+	 * @return bool
+	 */
 	public static function HasRequestedAllOutputFields(string $sFields): bool
 	{
 		return match($sFields) {
@@ -129,6 +145,13 @@ class RestUtils
 		return [$sClass => array_keys(MetaModel::ListAttributeDefs($sClass))];
 	}
 
+	/**
+	 * Build a field list for all child classes of the given parent class.
+	 *
+	 * @param string $sClass Parent class name.
+	 *
+	 * @return array Array of class => list of attribute codes.
+	 */
 	protected static function GetFieldListForParentClass(string $sClass): array
 	{
 		$aFieldList = array();
@@ -138,6 +161,17 @@ class RestUtils
 		return $aFieldList;
 	}
 
+	/**
+	 * Build a restricted field list for one class from a comma-separated attribute list.
+	 *
+	 * @param string $sClass Class name.
+	 * @param string $sFields Comma-separated list of requested attribute codes.
+	 * @param string $sParamName Input parameter name used in error messages.
+	 * @param bool $bFailIfNotFound If true, throws when an attribute code is invalid.
+	 *
+	 * @return array Array containing one class => list of attribute codes.
+	 * @throws Exception When an attribute code is invalid and $bFailIfNotFound is true.
+	 */
 	protected static function GetLimitedFieldListForSingleClass(string $sClass, string $sFields, string $sParamName, bool $bFailIfNotFound = true): array
 	{
 		$aFieldList = [$sClass => []];
@@ -154,6 +188,20 @@ class RestUtils
 		return $aFieldList;
 	}
 
+	/**
+	 * Build a restricted field list for one or several classes.
+	 *
+	 * Accepted formats are either "att1,att2" for a single class, or
+	 * "ClassA:att1,att2;ClassB:att3" for class-scoped field definitions.
+	 *
+	 * @param string $sClass Default class name used when no class scope is specified.
+	 * @param string $sFields Requested field specification.
+	 * @param string $sParamName Input parameter name used in error messages.
+	 * @param bool $bFailIfNotFound If true, throws when an attribute code is invalid.
+	 *
+	 * @return array Array of class => list of attribute codes.
+	 * @throws Exception Propagated from GetLimitedFieldListForSingleClass.
+	 */
 	protected static function GetLimitedFieldListForClass(string $sClass, string $sFields, string $sParamName, bool $bFailIfNotFound = true): array
 	{
 		if (!str_contains($sFields, ':')) {

--- a/application/applicationextension/rest/RestUtils.php
+++ b/application/applicationextension/rest/RestUtils.php
@@ -97,33 +97,77 @@ class RestUtils
 	 * @throws Exception
 	 * @api
 	 */
-	public static function GetFieldList($sClass, $oData, $sParamName)
+	public static function GetFieldList($sClass, $oData, $sParamName, $bFailIfNotFound = true)
 	{
 		$sFields = self::GetOptionalParam($oData, $sParamName, '*');
-		$aShowFields = [];
-		if ($sFields == '*') {
-			foreach (MetaModel::ListAttributeDefs($sClass) as $sAttCode => $oAttDef) {
-				$aShowFields[$sClass][] = $sAttCode;
-			}
-		} elseif ($sFields == '*+') {
-			foreach (MetaModel::EnumChildClasses($sClass, ENUM_CHILD_CLASSES_ALL) as $sRefClass) {
-				foreach (MetaModel::ListAttributeDefs($sRefClass) as $sAttCode => $oAttDef) {
-					$aShowFields[$sRefClass][] = $sAttCode;
-				}
-			}
-		} else {
-			foreach (explode(',', $sFields) as $sAttCode) {
-				$sAttCode = trim($sAttCode);
-				if (($sAttCode != 'id') && (!MetaModel::IsValidAttCode($sClass, $sAttCode))) {
-					throw new Exception("$sParamName: invalid attribute code '$sAttCode'");
-				}
-				$aShowFields[$sClass][] = $sAttCode;
-			}
-		}
-
-		return $aShowFields;
+		return match($sFields) {
+			'*' => self::GetFieldListForClass($sClass),
+			'*+' => self::GetFieldListForParentClass($sClass),
+			default => self::GetLimitedFieldListForClass($sClass, $sFields, $sParamName, $bFailIfNotFound),
+		};
 	}
 
+	public static function HasRequestedExtendedOutput(string $sFields): bool
+	{
+		return match($sFields) {
+			'*' => false,
+			'*+' => true,
+			default => substr_count($sFields, ':') > 1,
+		};
+	}
+
+	public static function HasRequestedAllOutputFields(string $sFields): bool
+	{
+		return match($sFields) {
+			'*', '*+' => true,
+			default => false,
+		};
+	}
+
+	protected static function GetFieldListForClass(string $sClass): array
+	{
+		return [$sClass => array_keys(MetaModel::ListAttributeDefs($sClass))];
+	}
+
+	protected static function GetFieldListForParentClass(string $sClass): array
+	{
+		$aFieldList = array();
+		foreach (MetaModel::EnumChildClasses($sClass, ENUM_CHILD_CLASSES_ALL) as $sRefClass) {
+			$aFieldList = array_merge($aFieldList, self::GetFieldListForClass($sRefClass));
+		}
+		return $aFieldList;
+	}
+
+	protected static function GetLimitedFieldListForSingleClass(string $sClass, string $sFields, string $sParamName, bool $bFailIfNotFound = true): array
+	{
+		$aFieldList = [$sClass => []];
+		foreach (explode(',', $sFields) as $sAttCode) {
+			$sAttCode = trim($sAttCode);
+			if (($sAttCode == 'id') || (MetaModel::IsValidAttCode($sClass, $sAttCode))) {
+				$aFieldList[$sClass][] = $sAttCode;
+			} else {
+				if ($bFailIfNotFound) {
+					throw new Exception("$sParamName: invalid attribute code '$sAttCode' for class '$sClass'");
+				}
+			}
+		}
+		return $aFieldList;
+	}
+
+	protected static function GetLimitedFieldListForClass(string $sClass, string $sFields, string $sParamName, bool $bFailIfNotFound = true): array
+	{
+		if (!str_contains($sFields, ':')) {
+			return self::GetLimitedFieldListForSingleClass($sClass, $sFields, $sParamName, $bFailIfNotFound);
+		}
+
+		$aFieldList = [];
+		$aFieldListParts = explode(';', $sFields);
+		foreach ($aFieldListParts as $sClassFields) {
+			list($sSubClass, $sSubClassFields) = explode(':', $sClassFields);
+			$aFieldList = array_merge($aFieldList, self::GetLimitedFieldListForSingleClass(trim($sSubClass), trim($sSubClassFields), $sParamName, $bFailIfNotFound));
+		}
+		return $aFieldList;
+	}
 	/**
 	 * Read and interpret object search criteria from a Rest/Json structure
 	 *

--- a/core/restservices.class.inc.php
+++ b/core/restservices.class.inc.php
@@ -572,13 +572,21 @@ class CoreServices implements iRestServiceProvider, iRestInputSanitizer
 				break;
 
 			case 'core/get':
-				$sClass = RestUtils::GetClass($aParams, 'class');
+			$sClassParam =  RestUtils::GetMandatoryParam($aParams, 'class');
 				$key = RestUtils::GetMandatoryParam($aParams, 'key');
 				$sShowFields = RestUtils::GetOptionalParam($aParams, 'output_fields', '*');
 				$iLimit = (int)RestUtils::GetOptionalParam($aParams, 'limit', 0);
 				$iPage = (int)RestUtils::GetOptionalParam($aParams, 'page', 1);
 
-				$oObjectSet = RestUtils::GetObjectSetFromKey($sClass, $key, $iLimit, self::getOffsetFromLimitAndPage($iLimit, $iPage));
+			// Validate the class(es)
+			$aClass = explode(',', $sClassParam);
+			foreach ($aClass as $sClass) {
+				if (!MetaModel::IsValidClass(trim($sClass))) {
+					throw new Exception("class '$sClass' is not valid");
+				}
+			}
+
+			$oObjectSet = RestUtils::GetObjectSetFromKey($sClassParam, $key, $iLimit, self::getOffsetFromLimitAndPage($iLimit, $iPage));
 				$sTargetClass = $oObjectSet->GetFilter()->GetClass();
 
 				if (UserRights::IsActionAllowed($sTargetClass, UR_ACTION_READ) != UR_ALLOWED_YES) {
@@ -597,7 +605,7 @@ class CoreServices implements iRestServiceProvider, iRestInputSanitizer
 				$aCache = [];
 				$aShowFields = [];
 				foreach ($oObjectSet->GetSelectedClasses() as $sSelectedClass) {
-					$aShowFields = array_merge( $aShowFields, RestUtils::GetFieldList($sSelectedClass, $aParams, 'output_fields'));
+					$aShowFields = array_merge( $aShowFields, RestUtils::GetFieldList($sSelectedClass, $aParams, 'output_fields', false));
 				}
 
 				while ($oObjects = $oObjectSet->FetchAssoc()) {
@@ -635,9 +643,13 @@ class CoreServices implements iRestServiceProvider, iRestInputSanitizer
 				}
 				$oResult->message = "Found: ".$oObjectSet->Count();
 			} else {
-				$aShowFields = RestUtils::GetFieldList($sClass, $aParams, 'output_fields');
+				$aShowFields =[];
+				foreach ($aClass  as $sSelectedClass) {
+					$sSelectedClass = trim($sSelectedClass);
+					$aShowFields = array_merge($aShowFields, RestUtils::GetFieldList($sSelectedClass, $aParams, 'output_fields', false));
+				}
 
-                if (!RestUtils::HasRequestedAllOutputFields($sShowFields)) {
+                if (!RestUtils::HasRequestedAllOutputFields($sShowFields) && count($aShowFields) == 1) {
 	                $aFields = $aShowFields[$sClass];
 	                //Id is not a valid attribute to optimize
 	                if (in_array('id', $aFields)) {

--- a/core/restservices.class.inc.php
+++ b/core/restservices.class.inc.php
@@ -214,40 +214,6 @@ class RestResultWithObjects extends RestResult
 	/** @var array "DBObject_class:DBObject_key" as key, {@see \ObjectResult} as value */
 	public $objects;
 
-	public function PrepareObject($iCode, $sMessage, $oObject, $aFieldSpec = null, $bExtendedOutput = false)
-	{
-		$sClass = get_class($oObject);
-		$oObjRes = new ObjectResult($sClass, $oObject->GetKey());
-		$oObjRes->code = $iCode;
-		$oObjRes->message = $sMessage;
-
-		$aFields = null;
-		if (!is_null($aFieldSpec))
-		{
-			// Enum all classes in the hierarchy, starting with the current one
-			foreach (MetaModel::EnumParentClasses($sClass, ENUM_PARENT_CLASSES_ALL, false) as $sRefClass)
-			{
-				if (array_key_exists($sRefClass, $aFieldSpec))
-				{
-					$aFields = $aFieldSpec[$sRefClass];
-					break;
-				}
-			}
-		}
-		if (is_null($aFields))
-		{
-			// No fieldspec given, or not found...
-			$aFields = array('id', 'friendlyname');
-		}
-
-		foreach ($aFields as $sAttCode)
-		{
-			$oObjRes->AddField($oObject, $sAttCode, $bExtendedOutput);
-		}
-
-		return $oObjRes;
-	}
-
 	/**
 	 * Report the given object
 	 *
@@ -266,7 +232,8 @@ class RestResultWithObjects extends RestResult
 	 */
 	public function AddObject($iCode, $sMessage, $oObject, $aFieldSpec = null, $bExtendedOutput = false)
 	{
-		$oObjRes = $this->PrepareObject($iCode, $sMessage, $oObject, $aFieldSpec, $bExtendedOutput);
+		$oObjRes = ObjectResult::FromDBObject($oObject, $aFieldSpec, $bExtendedOutput, $iCode, $sMessage);
+
 		$sObjKey = get_class($oObject).'::'.$oObject->GetKey();
 		$this->objects[$sObjKey] = $oObjRes;
 	}
@@ -315,7 +282,7 @@ class RestResultWithObjectSets extends RestResultWithObjects
 	 */
 	public function AppendSubObject($sObjectAlias, $iCode, $sMessage, $oObject, $aFieldSpec = null, $bExtendedOutput = false)
 	{
-		$oObjRes = $this->PrepareObject($iCode, $sMessage, $oObject, $aFieldSpec, $bExtendedOutput);
+		$oObjRes = ObjectResult::FromDBObject($oObject, $aFieldSpec, $bExtendedOutput, $iCode, $sMessage);
 		$this->current_object[$sObjectAlias] = $oObjRes;
 	}
 }
@@ -587,7 +554,7 @@ class CoreServices implements iRestServiceProvider, iRestInputSanitizer
 			}
 
 			$oObjectSet = RestUtils::GetObjectSetFromKey($sClassParam, $key, $iLimit, self::getOffsetFromLimitAndPage($iLimit, $iPage));
-				$sTargetClass = $oObjectSet->GetFilter()->GetClass();
+			$sTargetClass = $oObjectSet->GetFilter()->GetClass();
 
 				if (UserRights::IsActionAllowed($sTargetClass, UR_ACTION_READ) != UR_ALLOWED_YES) {
 					$oResult->code = RestResult::UNAUTHORIZED;
@@ -598,68 +565,66 @@ class CoreServices implements iRestServiceProvider, iRestInputSanitizer
 				} elseif ($iPage < 1) {
 					$oResult->code = RestResult::INVALID_PAGE;
 					$oResult->message = "The request page number is not valid. It must be an integer greater than 0";
-            }
-			elseif (count($oObjectSet->GetSelectedClasses()) > 1)
-			{
-				$oResult = new RestResultWithObjectSets();
-				$aCache = [];
-				$aShowFields = [];
-				foreach ($oObjectSet->GetSelectedClasses() as $sSelectedClass) {
-					$aShowFields = array_merge( $aShowFields, RestUtils::GetFieldList($sSelectedClass, $aParams, 'output_fields', false));
-				}
-
-				while ($oObjects = $oObjectSet->FetchAssoc()) {
-					$oResult->MakeNewObjectSet();
-
-					foreach ($oObjects as $sAlias => $oObject) {
-						if (!$oObject) {
-							continue;
-						}
-
-						if (!array_key_exists($sAlias, $aCache)) {
-							$sClass = get_class($oObject);
-							$bExtendedOutput = RestUtils::HasRequestedExtendedOutput($sShowFields);
-
-							if (!RestUtils::HasRequestedAllOutputFields($sShowFields)) {
-								$aFields = $aShowFields[$sClass];
-								//Id is not a valid attribute to optimize
-								if ($aFields && in_array('id', $aFields)) {
-									unset($aFields[array_search('id', $aFields)]);
-								}
-								$aAttToLoad = [$sAlias => $aFields];
-								$oObjectSet->OptimizeColumnLoad($aAttToLoad);
-							}
-							$aCache[$sAlias] = [
-								'aShowFields' => $aShowFields,
-								'bExtendedOutput' => $bExtendedOutput,
-							];
-						} else {
-							$aShowFields = $aCache[$sAlias]['aShowFields'];
-							$bExtendedOutput = $aCache[$sAlias]['bExtendedOutput'];
-						}
-
-						$oResult->AppendSubObject($sAlias, 0, '', $oObject, $aShowFields, $bExtendedOutput);
+	            } elseif (count($oObjectSet->GetSelectedClasses()) > 1) {
+					$oResult = new RestResultWithObjectSets();
+					$aCache = [];
+					$aShowFields = [];
+					foreach ($oObjectSet->GetSelectedClasses() as $sSelectedClass) {
+						$aShowFields = array_merge( $aShowFields, RestUtils::GetFieldList($sSelectedClass, $aParams, 'output_fields', false));
 					}
-				}
-				$oResult->message = "Found: ".$oObjectSet->Count();
-			} else {
-				$aShowFields =[];
-				foreach ($aClass  as $sSelectedClass) {
-					$sSelectedClass = trim($sSelectedClass);
-					$aShowFields = array_merge($aShowFields, RestUtils::GetFieldList($sSelectedClass, $aParams, 'output_fields', false));
-				}
 
-                if (!RestUtils::HasRequestedAllOutputFields($sShowFields) && count($aShowFields) == 1) {
-	                $aFields = $aShowFields[$sClass];
-	                //Id is not a valid attribute to optimize
-	                if (in_array('id', $aFields)) {
-	                    unset($aFields[array_search('id', $aFields)]);
-	                }
+					while ($oObjects = $oObjectSet->FetchAssoc()) {
+						$oResult->MakeNewObjectSet();
+
+						foreach ($oObjects as $sAlias => $oObject) {
+							if (!$oObject) {
+								continue;
+							}
+
+							if (!array_key_exists($sAlias, $aCache)) {
+								$sClass = get_class($oObject);
+								$bExtendedOutput = RestUtils::HasRequestedExtendedOutput($sShowFields);
+
+								if (!RestUtils::HasRequestedAllOutputFields($sShowFields)) {
+									$aFields = $aShowFields[$sClass];
+									//Id is not a valid attribute to optimize
+									if ($aFields && in_array('id', $aFields)) {
+										unset($aFields[array_search('id', $aFields)]);
+									}
+									$aAttToLoad = [$sAlias => $aFields];
+									$oObjectSet->OptimizeColumnLoad($aAttToLoad);
+								}
+								$aCache[$sAlias] = [
+									'aShowFields' => $aShowFields,
+									'bExtendedOutput' => $bExtendedOutput,
+								];
+							} else {
+								$aShowFields = $aCache[$sAlias]['aShowFields'];
+								$bExtendedOutput = $aCache[$sAlias]['bExtendedOutput'];
+							}
+
+							$oResult->AppendSubObject($sAlias, 0, '', $oObject, $aShowFields, $bExtendedOutput);
+						}
+					}
+					$oResult->message = "Found: ".$oObjectSet->Count();
+				} else {
+					$aShowFields =[];
+					foreach ($aClass  as $sSelectedClass) {
+						$sSelectedClass = trim($sSelectedClass);
+						$aShowFields = array_merge($aShowFields, RestUtils::GetFieldList($sSelectedClass, $aParams, 'output_fields', false));
+					}
+
+	                if (!RestUtils::HasRequestedAllOutputFields($sShowFields) && count($aShowFields) == 1) {
+		                $aFields = $aShowFields[$sClass];
+		                //Id is not a valid attribute to optimize
+		                if (in_array('id', $aFields)) {
+		                    unset($aFields[array_search('id', $aFields)]);
+		                }
 						$aAttToLoad = [$oObjectSet->GetClassAlias() => $aFields];
-	                $oObjectSet->OptimizeColumnLoad($aAttToLoad);
-                }
+		                $oObjectSet->OptimizeColumnLoad($aAttToLoad);
+	                }
 
-				while ($oObject = $oObjectSet->Fetch()) {
+					while ($oObject = $oObjectSet->Fetch()) {
 						$oResult->AddObject(0, '', $oObject, $aShowFields, RestUtils::HasRequestedExtendedOutput($sShowFields));
 					}
 					$oResult->message = "Found: ".$oObjectSet->Count();

--- a/core/restservices.class.inc.php
+++ b/core/restservices.class.inc.php
@@ -575,7 +575,6 @@ class CoreServices implements iRestServiceProvider, iRestInputSanitizer
 				$sClass = RestUtils::GetClass($aParams, 'class');
 				$key = RestUtils::GetMandatoryParam($aParams, 'key');
 				$sShowFields = RestUtils::GetOptionalParam($aParams, 'output_fields', '*');
-				$aShowFields = RestUtils::GetFieldList($sClass, $aParams, 'output_fields');
 				$iLimit = (int)RestUtils::GetOptionalParam($aParams, 'limit', 0);
 				$iPage = (int)RestUtils::GetOptionalParam($aParams, 'page', 1);
 
@@ -595,40 +594,38 @@ class CoreServices implements iRestServiceProvider, iRestInputSanitizer
 			elseif (count($oObjectSet->GetSelectedClasses()) > 1)
 			{
 				$oResult = new RestResultWithObjectSets();
-				$aCache = array();
+				$aCache = [];
+				$aShowFields = [];
+				foreach ($oObjectSet->GetSelectedClasses() as $sSelectedClass) {
+					$aShowFields = array_merge( $aShowFields, RestUtils::GetFieldList($sSelectedClass, $aParams, 'output_fields'));
+				}
 
-				while ($oObjects = $oObjectSet->FetchAssoc())
-				{
+				while ($oObjects = $oObjectSet->FetchAssoc()) {
 					$oResult->MakeNewObjectSet();
 
 					foreach ($oObjects as $sAlias => $oObject) {
-						if (!$oObject)
+						if (!$oObject) {
 							continue;
+						}
 
-						if (!array_key_exists($sAlias, $aCache))
-						{
+						if (!array_key_exists($sAlias, $aCache)) {
 							$sClass = get_class($oObject);
-							$aShowFields = RestUtils::GetFieldList($sClass, $aParams, 'output_fields');
 							$bExtendedOutput = RestUtils::HasRequestedExtendedOutput($sShowFields);
 
-							if (!RestUtils::HasRequestedAllOutputFields($sShowFields))
-							{
+							if (!RestUtils::HasRequestedAllOutputFields($sShowFields)) {
 								$aFields = $aShowFields[$sClass];
 								//Id is not a valid attribute to optimize
-								if ($aFields && in_array('id', $aFields))
-								{
+								if ($aFields && in_array('id', $aFields)) {
 									unset($aFields[array_search('id', $aFields)]);
 								}
-								$aAttToLoad = array($sAlias => $aFields);
+								$aAttToLoad = [$sAlias => $aFields];
 								$oObjectSet->OptimizeColumnLoad($aAttToLoad);
 							}
-							$aCache[$sAlias] = array(
+							$aCache[$sAlias] = [
 								'aShowFields' => $aShowFields,
 								'bExtendedOutput' => $bExtendedOutput,
-							);
-						}
-						else
-						{
+							];
+						} else {
 							$aShowFields = $aCache[$sAlias]['aShowFields'];
 							$bExtendedOutput = $aCache[$sAlias]['bExtendedOutput'];
 						}
@@ -637,21 +634,20 @@ class CoreServices implements iRestServiceProvider, iRestInputSanitizer
 					}
 				}
 				$oResult->message = "Found: ".$oObjectSet->Count();
-			}
-			else
-			{
+			} else {
+				$aShowFields = RestUtils::GetFieldList($sClass, $aParams, 'output_fields');
 
-                  if (!RestUtils::HasRequestedAllOutputFields($sShowFields)) {
-						$aFields = $aShowFields[$sClass];
-						//Id is not a valid attribute to optimize
-						if (in_array('id', $aFields)) {
-							unset($aFields[array_search('id', $aFields)]);
-						}
+                if (!RestUtils::HasRequestedAllOutputFields($sShowFields)) {
+	                $aFields = $aShowFields[$sClass];
+	                //Id is not a valid attribute to optimize
+	                if (in_array('id', $aFields)) {
+	                    unset($aFields[array_search('id', $aFields)]);
+	                }
 						$aAttToLoad = [$oObjectSet->GetClassAlias() => $aFields];
-						$oObjectSet->OptimizeColumnLoad($aAttToLoad);
-					}
+	                $oObjectSet->OptimizeColumnLoad($aAttToLoad);
+                }
 
-					while ($oObject = $oObjectSet->Fetch()) {
+				while ($oObject = $oObjectSet->Fetch()) {
 						$oResult->AddObject(0, '', $oObject, $aShowFields, RestUtils::HasRequestedExtendedOutput($sShowFields));
 					}
 					$oResult->message = "Found: ".$oObjectSet->Count();

--- a/core/restservices.class.inc.php
+++ b/core/restservices.class.inc.php
@@ -214,6 +214,40 @@ class RestResultWithObjects extends RestResult
 	/** @var array "DBObject_class:DBObject_key" as key, {@see \ObjectResult} as value */
 	public $objects;
 
+	public function PrepareObject($iCode, $sMessage, $oObject, $aFieldSpec = null, $bExtendedOutput = false)
+	{
+		$sClass = get_class($oObject);
+		$oObjRes = new ObjectResult($sClass, $oObject->GetKey());
+		$oObjRes->code = $iCode;
+		$oObjRes->message = $sMessage;
+
+		$aFields = null;
+		if (!is_null($aFieldSpec))
+		{
+			// Enum all classes in the hierarchy, starting with the current one
+			foreach (MetaModel::EnumParentClasses($sClass, ENUM_PARENT_CLASSES_ALL, false) as $sRefClass)
+			{
+				if (array_key_exists($sRefClass, $aFieldSpec))
+				{
+					$aFields = $aFieldSpec[$sRefClass];
+					break;
+				}
+			}
+		}
+		if (is_null($aFields))
+		{
+			// No fieldspec given, or not found...
+			$aFields = array('id', 'friendlyname');
+		}
+
+		foreach ($aFields as $sAttCode)
+		{
+			$oObjRes->AddField($oObject, $sAttCode, $bExtendedOutput);
+		}
+
+		return $oObjRes;
+	}
+
 	/**
 	 * Report the given object
 	 *
@@ -232,8 +266,7 @@ class RestResultWithObjects extends RestResult
 	 */
 	public function AddObject($iCode, $sMessage, $oObject, $aFieldSpec = null, $bExtendedOutput = false)
 	{
-		$oObjRes = ObjectResult::FromDBObject($oObject, $aFieldSpec, $bExtendedOutput, $iCode, $sMessage);
-
+		$oObjRes = $this->PrepareObject($iCode, $sMessage, $oObject, $aFieldSpec, $bExtendedOutput);
 		$sObjKey = get_class($oObject).'::'.$oObject->GetKey();
 		$this->objects[$sObjKey] = $oObjRes;
 	}
@@ -245,6 +278,45 @@ class RestResultWithObjects extends RestResult
 		foreach ($this->objects as $sObjKey => $oObjRes) {
 			$oObjRes->SanitizeContent();
 		}
+	}
+}
+
+/**
+ * @package RESTAPI
+ * @api
+ */
+class RestResultWithObjectSets extends RestResultWithObjects
+{
+	private $current_object = null;
+
+	public function MakeNewObjectSet()
+	{
+		$arr = array();
+		$this->current_object = &$arr;
+		$this->objects[] = &$arr;
+	}
+
+	/**
+	 * Report the given object
+	 *
+	 * @api
+	 * @param string $sObjectAlias Name of the subobject, usually the OQL class alias
+	 * @param int $iCode An error code (RestResult::OK is no issue has been found)
+	 * @param string $sMessage Description of the error if any, an empty string otherwise
+	 * @param DBObject $oObject The object being reported
+	 * @param array|null $aFieldSpec An array of class => attribute codes (Cf. RestUtils::GetFieldList). List of the attributes to be reported.
+	 * @param boolean $bExtendedOutput Output all of the link set attributes ?
+	 *
+	 * @return void
+	 * @throws \ArchivedObjectException
+	 * @throws \CoreException
+	 * @throws \CoreUnexpectedValue
+	 * @throws \MySQLException
+	 */
+	public function AppendSubObject($sObjectAlias, $iCode, $sMessage, $oObject, $aFieldSpec = null, $bExtendedOutput = false)
+	{
+		$oObjRes = $this->PrepareObject($iCode, $sMessage, $oObject, $aFieldSpec, $bExtendedOutput);
+		$this->current_object[$sObjectAlias] = $oObjRes;
 	}
 }
 
@@ -502,8 +574,8 @@ class CoreServices implements iRestServiceProvider, iRestInputSanitizer
 			case 'core/get':
 				$sClass = RestUtils::GetClass($aParams, 'class');
 				$key = RestUtils::GetMandatoryParam($aParams, 'key');
+				$sShowFields = RestUtils::GetOptionalParam($aParams, 'output_fields', '*');
 				$aShowFields = RestUtils::GetFieldList($sClass, $aParams, 'output_fields');
-				$bExtendedOutput = (RestUtils::GetOptionalParam($aParams, 'output_fields', '*') == '*+');
 				$iLimit = (int)RestUtils::GetOptionalParam($aParams, 'limit', 0);
 				$iPage = (int)RestUtils::GetOptionalParam($aParams, 'page', 1);
 
@@ -519,8 +591,57 @@ class CoreServices implements iRestServiceProvider, iRestInputSanitizer
 				} elseif ($iPage < 1) {
 					$oResult->code = RestResult::INVALID_PAGE;
 					$oResult->message = "The request page number is not valid. It must be an integer greater than 0";
-				} else {
-					if (!$bExtendedOutput && RestUtils::GetOptionalParam($aParams, 'output_fields', '*') != '*') {
+            }
+			elseif (count($oObjectSet->GetSelectedClasses()) > 1)
+			{
+				$oResult = new RestResultWithObjectSets();
+				$aCache = array();
+
+				while ($oObjects = $oObjectSet->FetchAssoc())
+				{
+					$oResult->MakeNewObjectSet();
+
+					foreach ($oObjects as $sAlias => $oObject) {
+						if (!$oObject)
+							continue;
+
+						if (!array_key_exists($sAlias, $aCache))
+						{
+							$sClass = get_class($oObject);
+							$aShowFields = RestUtils::GetFieldList($sClass, $aParams, 'output_fields');
+							$bExtendedOutput = RestUtils::HasRequestedExtendedOutput($sShowFields);
+
+							if (!RestUtils::HasRequestedAllOutputFields($sShowFields))
+							{
+								$aFields = $aShowFields[$sClass];
+								//Id is not a valid attribute to optimize
+								if ($aFields && in_array('id', $aFields))
+								{
+									unset($aFields[array_search('id', $aFields)]);
+								}
+								$aAttToLoad = array($sAlias => $aFields);
+								$oObjectSet->OptimizeColumnLoad($aAttToLoad);
+							}
+							$aCache[$sAlias] = array(
+								'aShowFields' => $aShowFields,
+								'bExtendedOutput' => $bExtendedOutput,
+							);
+						}
+						else
+						{
+							$aShowFields = $aCache[$sAlias]['aShowFields'];
+							$bExtendedOutput = $aCache[$sAlias]['bExtendedOutput'];
+						}
+
+						$oResult->AppendSubObject($sAlias, 0, '', $oObject, $aShowFields, $bExtendedOutput);
+					}
+				}
+				$oResult->message = "Found: ".$oObjectSet->Count();
+			}
+			else
+			{
+
+                  if (!RestUtils::HasRequestedAllOutputFields($sShowFields)) {
 						$aFields = $aShowFields[$sClass];
 						//Id is not a valid attribute to optimize
 						if (in_array('id', $aFields)) {
@@ -531,7 +652,7 @@ class CoreServices implements iRestServiceProvider, iRestInputSanitizer
 					}
 
 					while ($oObject = $oObjectSet->Fetch()) {
-						$oResult->AddObject(0, '', $oObject, $aShowFields, $bExtendedOutput);
+						$oResult->AddObject(0, '', $oObject, $aShowFields, RestUtils::HasRequestedExtendedOutput($sShowFields));
 					}
 					$oResult->message = "Found: ".$oObjectSet->Count();
 				}

--- a/tests/php-unit-tests/unitary-tests/webservices/RestTest.php
+++ b/tests/php-unit-tests/unitary-tests/webservices/RestTest.php
@@ -139,6 +139,158 @@ JSON;
 		$this->assertJsonStringEqualsJsonString($sExpectedJsonOuput, $sJSONOutput);
 	}
 
+
+	public function testCoreApiGet_Select2SubClasses(){
+		// Create ticket
+		$description = date('dmY H:i:s');
+		$iIdCaller = $this->CreatePerson(1)->GetKey();
+		$oUserRequest = $this->CreateSampleTicket($description, 'UserRequest', $iIdCaller);
+		$oChange = $this->CreateSampleTicket($description, 'Change', $iIdCaller);
+		$iIdUserRequest = $oUserRequest->GetKey();
+		$iIdChange = $oChange->GetKey();
+
+		$sJSONOutput = $this->CallCoreRestApi_Internally(<<<JSON
+{
+   "operation": "core/get",
+   "class": "UserRequest, Change",
+   "key": "SELECT UserRequest WHERE id=$iIdUserRequest UNION SELECT Change WHERE id=$iIdChange",
+   "output_fields": "id, description, outage"
+}
+JSON);
+
+		$sExpectedJsonOuput = <<<JSON
+{
+    "code": 0,
+    "message": "Found: 2",
+    "objects": {
+        "UserRequest::$iIdUserRequest": {
+            "class": "UserRequest",
+            "code": 0,
+            "fields": {
+                "description": "<p>$description</p>",
+                "id": "$iIdUserRequest"
+            },
+            "key": "$iIdUserRequest",
+            "message": ""
+        },       
+         "Change::$iIdChange": {
+            "class": "Change",
+            "code": 0,
+            "fields": {
+                "description": "<p>$description</p>",
+                "id": "$iIdChange",
+                "outage": "no"
+            },
+            "key": "$iIdChange",
+            "message": ""
+        }
+    }
+}
+JSON;
+		$this->assertJsonStringEqualsJsonString($sExpectedJsonOuput, $sJSONOutput);
+	}
+
+
+	public function testCoreApiGet_SelectTicketAndPerson(){
+		// Create ticket
+		$description = date('dmY H:i:s');
+		$iIdCaller = $this->CreatePerson(1)->GetKey();
+		$oUserRequest = $this->CreateSampleTicket($description, 'UserRequest', $iIdCaller);
+		$iIdUserRequest = $oUserRequest->GetKey();
+
+		$sJSONOutput = $this->CallCoreRestApi_Internally(<<<JSON
+{
+   "operation": "core/get",
+   "class": "UserRequest, Change",
+   "key": "SELECT UR, P FROM UserRequest AS UR JOIN Person AS P ON UR.caller_id = P.id WHERE UR.id=$iIdUserRequest ",
+   "output_fields": "id, title, description, name, email"
+}
+JSON);
+
+		$sExpectedJsonOuput = <<<JSON
+{
+    "code": 0,
+    "message": "Found: 1",
+    "objects": [{
+	        "UR": {
+	            "class": "UserRequest",
+	            "code": 0,
+	            "fields": {
+	                "description": "<p>$description</p>",
+	                "id": "$iIdUserRequest",                
+	                "title": "Houston, got a problem"
+	            },
+	            "key": "$iIdUserRequest",
+	            "message": ""
+	        },       
+            "P": {
+                "class": "Person",
+                "code": 0,
+                "fields": {
+                    "email": "",
+                    "id": "$iIdCaller",
+                    "name": "Person_1"
+                },
+            "key": "$iIdCaller",
+            "message": ""
+        }
+    }]
+}
+JSON;
+		$this->assertJsonStringEqualsJsonString($sExpectedJsonOuput, $sJSONOutput);
+	}
+
+	public function testCoreApiGetWithUnionAndDifferentOutputFields(){
+		// Create ticket
+		$description = date('dmY H:i:s');
+		$oUserRequest = $this->CreateSampleTicket($description);
+		$oChange = $this->CreateSampleTicket($description, 'Change');
+		$iUserRequestId = $oUserRequest->GetKey();
+		$sUserRequestRef = $oUserRequest->Get('ref');
+		$iChangeId = $oChange->GetKey();
+		$sChangeRef = $oChange->Get('ref');
+
+		$sJSONOutput = $this->CallCoreRestApi_Internally(<<<JSON
+{
+   "operation": "core/get",
+   "class": "Ticket",
+   "key": "SELECT UserRequest WHERE id=$iUserRequestId UNION SELECT Change WHERE id=$iChangeId",
+   "output_fields": "Ticket:ref;UserRequest:ref,status,origin;Change:ref,status,outage"
+}
+JSON);
+
+		$sExpectedJsonOuput = <<<JSON
+{
+    "code": 0,
+    "message": "Found: 2",
+    "objects": {
+    	"Change::$iChangeId": {
+            "class": "Change",
+            "code": 0,
+            "fields": {
+            	"outage": "no",
+                "ref": "$sChangeRef",
+                "status": "new"
+            },
+            "key": "$iChangeId",
+            "message": ""
+        },
+        "UserRequest::$iUserRequestId": {
+            "class": "UserRequest",
+            "code": 0,
+            "fields": {
+            	"origin": "phone",
+                "ref": "$sUserRequestRef",
+                "status": "new"
+            },
+            "key": "$iUserRequestId",
+            "message": ""
+        }
+    }
+}
+JSON;
+		$this->assertJsonStringEqualsJsonString($sExpectedJsonOuput, $sJSONOutput);
+	}
 	public function testCoreApiCreate()
 	{
 		// Create ticket
@@ -251,12 +403,13 @@ JSON;
 	//
 	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	private function CreateSampleTicket($description)
+	private function CreateSampleTicket($description, $sType = 'UserRequest', $iIdCaller = null)
 	{
-		$oTicket = $this->createObject('UserRequest', [
+		$oTicket = $this->createObject($sType, [
 			'org_id' => $this->getTestOrgId(),
 			"title" => "Houston, got a problem",
 			"description" => $description,
+			"caller_id" => $iIdCaller,
 		]);
 		return $oTicket;
 	}

--- a/tests/php-unit-tests/unitary-tests/webservices/RestUtilsTest.php
+++ b/tests/php-unit-tests/unitary-tests/webservices/RestUtilsTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Combodo\iTop\Test\UnitTest\Webservices;
+
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use MetaModel;
+use RestUtils;
+use Ticket;
+use UserRequest;
+
+
+class RestUtilsTest extends ItopDataTestCase
+{
+	public function testGetFieldListForSingleClass(): void
+	{
+		$aList = RestUtils::GetFieldList(Ticket::class, (object) ['output_fields' => 'ref,start_date,end_date'], 'output_fields');
+		$this->assertSame([Ticket::class => ['ref', 'start_date', 'end_date']], $aList);
+	}
+
+	public function testGetFieldListForSingleClassWithInvalidFieldNameFails(): void
+	{
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('output_fields: invalid attribute code \'something\' for class \'Ticket\'');
+		$aList = RestUtils::GetFieldList(Ticket::class, (object) ['output_fields' => 'ref,something'], 'output_fields');
+		$this->assertSame([Ticket::class => ['ref', 'start_date', 'end_date']], $aList);
+	}
+
+	public function testGetFieldListWithAsteriskOnParentClass(): void
+	{
+		$aList = RestUtils::GetFieldList(Ticket::class, (object) ['output_fields' => '*'], 'output_fields');
+		$this->assertArrayHasKey(Ticket::class, $aList);
+		$this->assertContains('operational_status', $aList[Ticket::class]);
+		$this->assertNotContains('status', $aList[Ticket::class], 'Representation of Class Ticket should not contain status, since it is defined by children');
+	}
+
+	public function testGetFieldListWithAsteriskPlusOnParentClass(): void
+	{
+		$aList = RestUtils::GetFieldList(Ticket::class, (object) ['output_fields' => '*+'], 'output_fields');
+		$this->assertArrayHasKey(Ticket::class, $aList);
+		$this->assertArrayHasKey(UserRequest::class, $aList);
+		$this->assertContains('operational_status', $aList[Ticket::class]);
+		$this->assertContains('status', $aList[UserRequest::class]);
+	}
+
+	public function testGetFieldListForMultipleClasses(): void
+	{
+		$aList = RestUtils::GetFieldList(Ticket::class, (object) ['output_fields' => 'Ticket:ref,start_date,end_date;UserRequest:ref,status'], 'output_fields');
+		$this->assertArrayHasKey(Ticket::class, $aList);
+		$this->assertArrayHasKey(UserRequest::class, $aList);
+		$this->assertContains('ref', $aList[Ticket::class]);
+		$this->assertContains('end_date', $aList[Ticket::class]);
+		$this->assertNotContains('status', $aList[Ticket::class]);
+		$this->assertContains('status', $aList[UserRequest::class]);
+		$this->assertNotContains('end_date', $aList[UserRequest::class]);
+	}
+
+	public function testGetFieldListForMultipleClassesWithInvalidFieldNameFails(): void
+	{
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('output_fields: invalid attribute code \'something\'');
+		RestUtils::GetFieldList(Ticket::class, (object) ['output_fields' => 'Ticket:ref;UserRequest:ref,something'], 'output_fields');
+	}
+
+
+	public function testGetFieldListForMultipleClassesWithInvalidFieldName(): void
+	{
+		$aList = RestUtils::GetFieldList(Ticket::class, (object) ['output_fields' => 'ref, something'], 'output_fields', false);
+		$this->assertContains('ref', $aList[Ticket::class]);
+		$this->assertNotContains('something', $aList[Ticket::class]);
+	}
+
+
+	/**
+	 * @dataProvider extendedOutputDataProvider
+	 */
+	public function testIsExtendedOutputRequest(bool $bExpected, string $sFields): void
+	{
+		$this->assertSame($bExpected, RestUtils::HasRequestedExtendedOutput($sFields));
+	}
+
+	/**
+	 * @dataProvider allFieldsOutputDataProvider
+	 */
+	public function testIsAllFieldsOutputRequest(bool $bExpected, string $sFields): void
+	{
+		$this->assertSame($bExpected, RestUtils::HasRequestedAllOutputFields($sFields));
+	}
+
+	public function extendedOutputDataProvider(): array
+	{
+		return [
+			[false, 'ref,start_date,end_date'],
+			[false, '*'],
+			[true, '*+'],
+			[false, 'Ticket:ref'],
+			[true, 'Ticket:ref;UserRequest:ref'],
+		];
+	}
+
+	public function allFieldsOutputDataProvider(): array
+	{
+		return [
+			[false, 'ref,start_date,end_date'],
+			[true, '*'],
+			[true, '*+'],
+			[false, 'Ticket:ref'],
+			[false, 'Ticket:ref;UserRequest:ref'],
+		];
+	}
+}

--- a/tests/php-unit-tests/unitary-tests/webservices/RestUtilsTest.php
+++ b/tests/php-unit-tests/unitary-tests/webservices/RestUtilsTest.php
@@ -69,7 +69,7 @@ class RestUtilsTest extends ItopDataTestCase
 		$this->assertNotContains('something', $aList[Ticket::class]);
 	}
 
-	public function extendedOutputDataProvider(): array
+	public static function extendedOutputDataProvider(): array
 	{
 		return [
 			[false, 'ref,start_date,end_date'],
@@ -88,7 +88,7 @@ class RestUtilsTest extends ItopDataTestCase
 		$this->assertSame($bExpected, RestUtils::HasRequestedExtendedOutput($sFields));
 	}
 
-	public function allFieldsOutputDataProvider(): array
+	public static function allFieldsOutputDataProvider(): array
 	{
 		return [
 			[false, 'ref,start_date,end_date'],

--- a/tests/php-unit-tests/unitary-tests/webservices/RestUtilsTest.php
+++ b/tests/php-unit-tests/unitary-tests/webservices/RestUtilsTest.php
@@ -69,23 +69,6 @@ class RestUtilsTest extends ItopDataTestCase
 		$this->assertNotContains('something', $aList[Ticket::class]);
 	}
 
-
-	/**
-	 * @dataProvider extendedOutputDataProvider
-	 */
-	public function testIsExtendedOutputRequest(bool $bExpected, string $sFields): void
-	{
-		$this->assertSame($bExpected, RestUtils::HasRequestedExtendedOutput($sFields));
-	}
-
-	/**
-	 * @dataProvider allFieldsOutputDataProvider
-	 */
-	public function testIsAllFieldsOutputRequest(bool $bExpected, string $sFields): void
-	{
-		$this->assertSame($bExpected, RestUtils::HasRequestedAllOutputFields($sFields));
-	}
-
 	public function extendedOutputDataProvider(): array
 	{
 		return [
@@ -97,6 +80,14 @@ class RestUtilsTest extends ItopDataTestCase
 		];
 	}
 
+	/**
+	 * @dataProvider extendedOutputDataProvider
+	 */
+	public function testIsExtendedOutputRequest(bool $bExpected, string $sFields): void
+	{
+		$this->assertSame($bExpected, RestUtils::HasRequestedExtendedOutput($sFields));
+	}
+
 	public function allFieldsOutputDataProvider(): array
 	{
 		return [
@@ -106,5 +97,13 @@ class RestUtilsTest extends ItopDataTestCase
 			[false, 'Ticket:ref'],
 			[false, 'Ticket:ref;UserRequest:ref'],
 		];
+	}
+
+	/**
+	 * @dataProvider allFieldsOutputDataProvider
+	 */
+	public function testIsAllFieldsOutputRequest(bool $bExpected, string $sFields): void
+	{
+		$this->assertSame($bExpected, RestUtils::HasRequestedAllOutputFields($sFields));
 	}
 }


### PR DESCRIPTION
When performing core/get with multiple return types (parent and child classes) on REST Service, you may either only return fields from the parent object or enforce return all the fields for each object (with *+).

When, for example, requesting information for Tickets of various types and also including some, but not all the custom properties in the output, you can not provide output_fields which may exist in all implementations, if it does not exist in the requested parent implementation.

The following is currently not possible:
```
{
   "operation": "core/get",
   "class": "Ticket",
   "key": "SELECT UserRequest UNION SELECT Change",
   "output_fields": "ref,status,finalclass"
}
```
This is because the "status" is not defined on "Ticket", but rather in each implementation. Querying with "*+" is possible, but then you also request, join, process and transfer a lot of data that was not required.

Proposed solution
Proposed change makes it possible to optionally define a list of output_fields for each class. You can now pass
<Class>:<output_fields>;<Class>:<output_fields>;....
```
{
   "operation": "core/get",
   "class": "Ticket",
   "key": "SELECT UserRequest UNION SELECT Change",
   "output_fields": "Ticket:ref;UserRequest:ref,status,origin;Change:ref,status,outage"
}
```
You must also provide the parents (e.g. "Ticket") output_fields, even though no object of parents type (e.g. "Ticket") could ever be returned directly.
Another solution is to pass all fields and returned classes:
```
{
   "operation": "core/get",
   "class": "UserRequest,Change",
   "key": "SELECT UserRequest UNION SELECT Change",
   "output_fields": "ref,status,origin,outage"
}
```
This 2 call return exactly the same result.

---------------------------------------------------------------
Another case:
The following is currently not possible:
```
{
   "operation": "core/get",
   "class": "Ticket",
   "key": "SELECT P, PR, F
  FROM Person AS P
  JOIN Person AS PR ON P.manager_id = PR.id
  JOIN lnkContactToFunctionalCI AS L ON L.contact_id = P.id
  JOIN FunctionalCI AS F ON L.functionalci_id = F.id",
   "output_fields": "friendlyname, email, organization_name,  move2production"
}
```
Now this kind of call return the same results as in screen


------------------------------------------------------------
This PR merges the code of https://github.com/Combodo/iTop/pull/668 + code send by a client.