### PR TITLE
:bug: N°8345 - Fix double URL encoding in search URLs

### DIFF
--- a/application/dashlet.class.inc.php
+++ b/application/dashlet.class.inc.php
@@ -2138,7 +2138,7 @@ class DashletHeaderDynamic extends Dashlet
 		$oSet = new DBObjectSet($oFilter);
 		$iCount = $oSet->Count();
 		$oAppContext = new ApplicationContext();
-		$sHyperlink = utils::GetAbsoluteUrlAppRoot().'pages/UI.php?operation=search&'.$oAppContext->GetForLink().'&filter='.rawurlencode($oFilter->serialize());
+		$sHyperlink = utils::GetAbsoluteUrlAppRoot().'pages/UI.php?operation=search&'.$oAppContext->GetForLink().'&filter='.$oFilter->serialize();
 		$oSubTitle->AddHtml('<a class="summary" href="'.$sHyperlink.'">'.Dict::Format(str_replace('_', ':', $sSubtitle), $iCount).'</a>');
 
 		return $oPanel;

--- a/application/displayblock.class.inc.php
+++ b/application/displayblock.class.inc.php
@@ -1125,7 +1125,7 @@ JS
 					}
 					$sHyperlink = utils::GetAbsoluteUrlAppRoot()
 						.'pages/UI.php?operation=search&'.$oAppContext->GetForLink()
-						.'&filter='.rawurlencode($oSingleGroupByValueFilter->serialize());
+						.'&filter='.$oSingleGroupByValueFilter->serialize();
 					$aCounts[$sStateValue] = ['link' => $sHyperlink, 'label' => $aCounts[$sStateValue]];
 				}
 			}
@@ -1232,7 +1232,7 @@ JS
 		$iCount = $this->m_oSet->Count();
 		$sClassLabel = MetaModel::GetName($sClass);
 		$sClassIconUrl = MetaModel::GetClassIcon($sClass, false);
-		$sHyperlink = utils::GetAbsoluteUrlAppRoot().'pages/UI.php?operation=search&'.$oAppContext->GetForLink().'&filter='.rawurlencode($this->m_oFilter->serialize());
+		$sHyperlink = utils::GetAbsoluteUrlAppRoot().'pages/UI.php?operation=search&'.$oAppContext->GetForLink().'&filter='.$this->m_oFilter->serialize();
 
 		$aExtraParams['query_params'] = $this->m_oFilter->GetInternalParams();
 		$aRefreshParams = [
@@ -1300,7 +1300,7 @@ JS
 				} else {
 					$aQueryParams = array();
 				}
-				$sFilter = rawurlencode($oSubsetSearch->serialize(false, $aQueryParams));
+				$sFilter = $oSubsetSearch->serialize(false, $aQueryParams);
 
 				$aData[] = array(
 					'group' => $aLabels[$iRow],
@@ -1644,9 +1644,9 @@ JS
 		$sOrderDirection = isset($aExtraParams['order_direction']) ? $aExtraParams['order_direction'] : '';
 
 		if (isset($aExtraParams['group_by_label'])) {
-			$sUrl = utils::GetAbsoluteUrlAppRoot()."pages/ajax.render.php?operation=chart&params[group_by]=$sGroupBy{$sGroupByExpr}&params[group_by_label]={$aExtraParams['group_by_label']}&params[chart_type]=$sChartType&params[currentId]=$sChartId{$iChartCounter}&params[order_direction]=$sOrderDirection&params[order_by]=$sOrderBy&params[limit]=$sLimit&params[aggregation_function]=$sAggregationFunction&params[aggregation_attribute]=$sAggregationAttr&id=$sChartId{$iChartCounter}&filter=".rawurlencode($sFilter).'&'.$sContextParam;
+			$sUrl = utils::GetAbsoluteUrlAppRoot()."pages/ajax.render.php?operation=chart&params[group_by]=$sGroupBy{$sGroupByExpr}&params[group_by_label]={$aExtraParams['group_by_label']}&params[chart_type]=$sChartType&params[currentId]=$sChartId{$iChartCounter}&params[order_direction]=$sOrderDirection&params[order_by]=$sOrderBy&params[limit]=$sLimit&params[aggregation_function]=$sAggregationFunction&params[aggregation_attribute]=$sAggregationAttr&id=$sChartId{$iChartCounter}&filter=".$sFilter.'&'.$sContextParam;
 		} else {
-			$sUrl = utils::GetAbsoluteUrlAppRoot()."pages/ajax.render.php?operation=chart&params[group_by]=$sGroupBy{$sGroupByExpr}&params[chart_type]=$sChartType&params[currentId]=$sChartId{$iChartCounter}&params[order_direction]=$sOrderDirection&params[order_by]=$sOrderBy&params[limit]=$sLimit&params[aggregation_function]=$sAggregationFunction&params[aggregation_attribute]=$sAggregationAttr&id=$sChartId{$iChartCounter}&filter=".rawurlencode($sFilter).'&'.$sContextParam;
+			$sUrl = utils::GetAbsoluteUrlAppRoot()."pages/ajax.render.php?operation=chart&params[group_by]=$sGroupBy{$sGroupByExpr}&params[chart_type]=$sChartType&params[currentId]=$sChartId{$iChartCounter}&params[order_direction]=$sOrderDirection&params[order_by]=$sOrderBy&params[limit]=$sLimit&params[aggregation_function]=$sAggregationFunction&params[aggregation_attribute]=$sAggregationAttr&id=$sChartId{$iChartCounter}&filter=".$sFilter.'&'.$sContextParam;
 		}
 
 		$oBlock->sUrl = $sUrl;
@@ -1705,7 +1705,7 @@ JS
 				$oSubsetSearch = $this->m_oFilter->DeepClone();
 				$oCondition = new BinaryExpression($oGroupByExp, '=', new ScalarExpression($sValue));
 				$oSubsetSearch->AddConditionExpression($oCondition);
-				$aURLs[] = utils::GetAbsoluteUrlAppRoot()."pages/UI.php?operation=search&format=html&filter=".rawurlencode($oSubsetSearch->serialize()).'&'.$sContextParam;
+				$aURLs[] = utils::GetAbsoluteUrlAppRoot()."pages/UI.php?operation=search&format=html&filter=".$oSubsetSearch->serialize().'&'.$sContextParam;
 			}
 			$sJSURLs = json_encode($aURLs);
 		}
@@ -1785,7 +1785,7 @@ JS
 
 		$oBlock->sCsvFile = strtolower($this->m_oFilter->GetClass()).'.csv';
 		$oBlock->sDownloadLink = utils::GetAbsoluteUrlAppRoot().'webservices/export.php?expression='.urlencode($this->m_oFilter->ToOQL(true)).'&format=csv&filename='.urlencode($oBlock->sCsvFile);
-		$oBlock->sLinkToToggle = utils::GetAbsoluteUrlAppRoot().'pages/UI.php?operation=search&'.$oAppContext->GetForLink().'&filter='.rawurlencode($this->m_oFilter->serialize()).'&format=csv';
+		$oBlock->sLinkToToggle = utils::GetAbsoluteUrlAppRoot().'pages/UI.php?operation=search&'.$oAppContext->GetForLink().'&filter='.$this->m_oFilter->serialize().'&format=csv';
 		// Pass the parameters via POST, since expression may be very long
 		$aParamsToPost = array(
 			'expression' => $this->m_oFilter->ToOQL(true),

--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -1693,7 +1693,7 @@ class utils
 		$sUrl = $sAppRootUrl
 			.'pages/UI.php?operation=search&'
 			.$oAppContext->GetForLink()
-			.'&filter='.rawurlencode($oDataTableSearchFilter->serialize());
+			.'&filter='.$oDataTableSearchFilter->serialize();
 		$sUrl .= '&aParams='.rawurlencode($sParams); // Not working... yet, cause not handled by UI.php
 
 		return $sUrl;

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -10956,7 +10956,7 @@ abstract class AttributeSet extends AttributeDBFieldVoid
 			$oAppContext = new ApplicationContext();
 			$sContext = $oAppContext->GetForLink();
 			$sUIPage = cmdbAbstractObject::ComputeStandardUIPage($oFilter->GetClass());
-			$sFilter = rawurlencode($oFilter->serialize());
+			$sFilter = $oFilter->serialize();
 			$sLink = '';
 			if ($bWithLink && $this->bDisplayLink) {
 				$sUrl = utils::GetAbsoluteUrlAppRoot()."pages/$sUIPage?operation=search&filter=".$sFilter."&{$sContext}";
@@ -12278,7 +12278,7 @@ class AttributeTagSet extends AttributeSet
 				$oAppContext = new ApplicationContext();
 				$sContext = $oAppContext->GetForLink();
 				$sUIPage = cmdbAbstractObject::ComputeStandardUIPage($oFilter->GetClass());
-				$sFilter = rawurlencode($oFilter->serialize());
+				$sFilter = $oFilter->serialize();
 
 				$sLink = '';
 				if ($bWithLink && $this->bDisplayLink) {

--- a/core/bulkchange.class.inc.php
+++ b/core/bulkchange.class.inc.php
@@ -245,7 +245,7 @@ class CellStatus_SearchIssue extends CellStatus_Issue
 	public function GetSearchLinkUrl()
 	{
 		return sprintf("UI.php?operation=search&filter=%s",
-			rawurlencode($this->sSerializedSearch ?? "")
+			$this->sSerializedSearch ?? ""
 		);
 	}
 
@@ -256,7 +256,7 @@ class CellStatus_SearchIssue extends CellStatus_Issue
 	public function GetAllowedValuesLinkUrl(): ?string
 	{
 		return sprintf("UI.php?operation=search&filter=%s",
-			rawurlencode($this->sAllowedValuesSearch ?? "")
+			$this->sAllowedValuesSearch ?? ""
 		);
 	}
 }
@@ -339,7 +339,7 @@ class CellStatus_Ambiguous extends CellStatus_Issue
 	public function GetSearchLinkUrl()
 	{
 		return sprintf("UI.php?operation=search&filter=%s",
-			rawurlencode($this->sSerializedSearch ?? "")
+			$this->sSerializedSearch ?? ""
 		);
 	}
 }

--- a/sources/Controller/AjaxRenderController.php
+++ b/sources/Controller/AjaxRenderController.php
@@ -651,7 +651,7 @@ class AjaxRenderController
 				} else {
 					$aQueryParams = array();
 				}
-				$sFilter = rawurlencode($oSubsetSearch->serialize(false, $aQueryParams));
+				$sFilter = $oSubsetSearch->serialize(false, $aQueryParams);
 
 				$aResult[] = array(
 					'group' => $aLabels[$iRow],

--- a/tests/php-unit-tests/unitary-tests/datamodels/2.x/itop-config/BulkChangeExtKeyTest.php
+++ b/tests/php-unit-tests/unitary-tests/datamodels/2.x/itop-config/BulkChangeExtKeyTest.php
@@ -202,7 +202,7 @@ class BulkChangeExtKeyTest extends ItopDataTestCase {
 		$aCsvData = [["UnexistingRackDescription"]];
 		$aExtKeys = ["org_id" => ["name" => 0], "rack_id" => ["name" => 1, "description" => 3]];
 
-		$sSearchLinkUrl = 'UI.php?operation=search&filter='.\rawurlencode('%5B%22SELECT+%60Rack%60+FROM+Rack+AS+%60Rack%60+WHERE+%28%28%60Rack%60.%60name%60+%3D+%3Aname%29+AND+%28%60Rack%60.%60description%60+%3D+%3Adescription%29%29%22%2C%7B%22name%22%3A%22UnexistingRack%22%2C%22description%22%3A%22UnexistingRackDescription%22%7D%2C%5B%5D%5D');
+		$sSearchLinkUrl = 'UI.php?operation=search&filter=%5B%22SELECT+%60Rack%60+FROM+Rack+AS+%60Rack%60+WHERE+%28%28%60Rack%60.%60name%60+%3D+%3Aname%29+AND+%28%60Rack%60.%60description%60+%3D+%3Adescription%29%29%22%2C%7B%22name%22%3A%22UnexistingRack%22%2C%22description%22%3A%22UnexistingRackDescription%22%7D%2C%5B%5D%5D';
 		$this->performBulkChangeTest(
 			"No match for value 'UnexistingRack UnexistingRackDescription'",
 			"Some possible 'Rack' value(s): RackTest1 RackTest1Desc, RackTest2 RackTest2Desc, RackTest3 RackTest3Desc...",
@@ -226,7 +226,7 @@ class BulkChangeExtKeyTest extends ItopDataTestCase {
 	public function performBulkChangeTest($sExpectedDisplayableValue, $sExpectedDescription, $oOrg, $bIsRackReconKey,
 		$aAdditionalCsvData=null, $aExtKeys=null, $sSearchLinkUrl=null, $sError="Object not found") {
 		if ($sSearchLinkUrl===null){
-			$sSearchLinkUrl = 'UI.php?operation=search&filter='.rawurlencode('%5B%22SELECT+%60Rack%60+FROM+Rack+AS+%60Rack%60+WHERE+%28%60Rack%60.%60name%60+%3D+%3Aname%29%22%2C%7B%22name%22%3A%22UnexistingRack%22%7D%2C%5B%5D%5D');
+			$sSearchLinkUrl = 'UI.php?operation=search&filter=%5B%22SELECT+%60Rack%60+FROM+Rack+AS+%60Rack%60+WHERE+%28%60Rack%60.%60name%60+%3D+%3Aname%29%22%2C%7B%22name%22%3A%22UnexistingRack%22%7D%2C%5B%5D%5D';
 		}
 		if (is_null($oOrg)){
 			$iOrgId = $this->getTestOrgId();


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | No
| Type of change?                                               | Bug fix


## Symptom (bug)
Symptom only appears on some webservers, it seems to be an edge case. But the cause and fix seem legit.

When trying to open a backoffice URL pointing to a search page, the following error occurs everytime:
```
Service Unavailable
The server is temporarily unable to service your request due to maintenance downtime or capacity problems. Please try again later.
```

It happens when the URL is generated by:
  * A dashlet (badge, dynamic, pie chart, bar chart, objects list)
  * An objects list (search page, linkset, ...)
  * An error during CSV import

Unfortunately, I can't find a more explicit error message. There is nothing in iTop's nor Apache's error logs. 🫤


## Reproduction procedure (bug)
I can't find a reproduction procedure that works everywhere. It only happens on my ionos webserver on which I don't have access to the Apache / PHP configuration. 😭😭😭

1. Go on http://mbc.itop.molkobain.com/pages/UI.php
2. Log with admin / admin
3. Click on the first "objects list" dashlet subtitle "Total: 1 objects."
4. See the error occurring

_P.S: Mind that I patched the badge and dynamic dashlets code in order to verify cause / fix._


## Cause (bug)
As this only happens on my ionos webservers (but on all 3 of them, with different iTop instances / versions), I don't know what the system cause is.

Nonetheless, there is a issue with how search URLs are generated in the backoffice. If you look at the `filter` param, you'll see that it is URL encoded **twice**, hence the 4 hexa characters after the `%`.
```
http://mbc.itop.molkobain.com/pages/UI.php?operation=search&&filter=%255B%2522SELECT%2B%2560Rack%2560%2BFROM%2BRack%2BAS%2B%2560Rack%2560%2BWHERE%2B1%2522%252C%255B%255D%252C%255B%255D%255D&aParams=%7B%22table_id%22%3A%22DashletCUSTOM_WelcomeMenuPage_ID_row1_col0_16%22%7D
```

Why is it encoded twice?
  * First time occurs when serializing the filter in `\DBSearch::serialize()`
  * Second time occurs when building the URL manually, some parts of the code do something like `rawurlencode($oFilter->serialize())`

Changes seem to have been done during the development of the 3.0 and its UI refacto. The complexity of this refacto and its multiple iterations could explain the mixup.


## Proposed solution (bug and enhancement)
  * Rely on the encoding done by `\DBSearch::serialize()`
  * Remove `rawurlencode()` when `\DBSearch::serialize()` is used (e.g. `rawurlencode($oFilter->serialize())`)

Mind that in some places, something like `rawurlencode($oFilter->ToOQL())` is used. It could be replaced by `$oFilter->serialize()` for better robustness ([Example](https://github.com/Combodo/iTop/blob/support/3.2/application/displayblock.class.inc.php#L1713)). I have **not** made these changes, but I'll be happy to if that what you want.


## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge
- [ ] Check with Combodo if they would like a unit test or if E2E is preferrable, and discuss how they would like it to be done
