### PR TITLE
N°8575 - chore(auth-ldap): Prepare for php 8.3 deprecation

### DIFF
--- a/datamodels/2.x/authent-ldap/datamodel.authent-ldap.xml
+++ b/datamodels/2.x/authent-ldap/datamodel.authent-ldap.xml
@@ -68,8 +68,7 @@
 		$sServer = $this->Get('ldap_server');
 		if (empty($sServer))
 		{
-			$sLDAPHost = MetaModel::GetModuleSetting('authent-ldap', 'host', 'localhost');
-			$iLDAPPort = MetaModel::GetModuleSetting('authent-ldap', 'port', 389);
+			$sURI = MetaModel::GetModuleSetting('authent-ldap', 'uri', 'ldap://localhost');
 
 			$sDefaultLDAPUser = MetaModel::GetModuleSetting('authent-ldap', 'default_user', '');
 			$sDefaultLDAPPwd = MetaModel::GetModuleSetting('authent-ldap', 'default_pwd', '');
@@ -90,8 +89,7 @@
 				return false;
 			}
 			$aServerParams = $aServers[$sServer];
-			$sLDAPHost = isset($aServerParams['host']) ? $aServerParams['host'] : 'localhost';
-			$iLDAPPort = isset($aServerParams['port']) ? $aServerParams['port'] : 389;
+			$sURI = $aServerParams['uri'] ?? 'ldap://localhost';
 			$sDefaultLDAPUser = isset($aServerParams['default_user']) ? $aServerParams['default_user'] : '';
 			$sDefaultLDAPPwd = isset($aServerParams['default_pwd']) ? $aServerParams['default_pwd'] : '';
 			$bLDAPStartTLS = isset($aServerParams['start_tls']) ? $aServerParams['start_tls'] : false;
@@ -101,10 +99,10 @@
 			$bDebug = isset($aServerParams['debug']) ? $aServerParams['debug'] : false;
 		}
 
-		$hDS = @ldap_connect($sLDAPHost, $iLDAPPort);
+		$hDS = @ldap_connect($sURI);
 		if ($hDS === false)
 		{
-			$this->LogIssue($bDebug, "ldap_authentication: can not connect to the LDAP server '$sLDAPHost' (port: $iLDAPPort). Check the configuration file config-itop.php.");
+			$this->LogIssue($bDebug, "ldap_authentication: can not connect to the LDAP server '$sURI'. Check the configuration file config-itop.php.");
 			return false;
 		}
 		if (array_key_exists(LDAP_OPT_DEBUG_LEVEL, $aOptions))
@@ -186,7 +184,7 @@
 		else
 		{
 			// Trace: invalid default user for LDAP initial binding
-			$this->LogIssue($bDebug, "ldap_authentication: cannot bind to the LDAP server '$sLDAPHost' (port: $iLDAPPort), user='$sDefaultLDAPUser', pwd='****'. Error: '".ldap_error($hDS)."'. Check the configuration file config-itop.php.");
+			$this->LogIssue($bDebug, "ldap_authentication: cannot bind to the LDAP server '$sURI', user='$sDefaultLDAPUser', pwd='****'. Error: '".ldap_error($hDS)."'. Check the configuration file config-itop.php.");
 			return false;
 		}
 	}]]></code>

--- a/datamodels/2.x/authent-ldap/module.authent-ldap.php
+++ b/datamodels/2.x/authent-ldap/module.authent-ldap.php
@@ -43,8 +43,7 @@ SetupWebPage::AddModule(
 		// Default settings
 		//
 		'settings' => array(
-			'host' => 'localhost', // host or IP address of your LDAP server
-			'port' => 389,		  // LDAP port (std: 389)
+			'uri' => 'ldap://localhost', // URI with host or IP address of your LDAP server
 			'default_user' => '', // User and password used for initial "Anonymous" bind to LDAP
 			'default_pwd' => '',  // Leave both blank, if anonymous (read-only) bind is allowed
 			'base_dn' => 'dc=yourcompany,dc=com', // Base DN for User queries, adjust it to your LDAP schema
@@ -74,6 +73,27 @@ class AuthentLDAPInstaller extends ModuleInstallerAPI
 		$sUserTable = MetaModel::DBGetTable('User');
 		$sSQL = "insert into $sUserLDAPTable (id) select U.id from $sUserTable as U left join $sUserLDAPTable as L on U.id = L.id where U.finalclass='UserLDAP' and isnull(L.id);";
 		CMDBSource::Query($sSQL);
+	}
+
+	public static function BeforeWritingConfig(Config $oConfiguration)
+	{
+		$sURI = $oConfiguration->GetModuleSetting('authent-ldap', 'uri');
+		if (empty($sURI)) {
+			$sLDAPHost = MetaModel::GetModuleSetting('authent-ldap', 'host', 'localhost');
+			$iLDAPPort = MetaModel::GetModuleSetting('authent-ldap', 'port', 389);
+			$sURI = preg_match('#^ldaps?://#i', $sLDAPHost) ? $sLDAPHost : 'ldap://'.$sLDAPHost.':'.$iLDAPPort;
+			$oConfiguration->SetModuleSetting('authent-ldap', 'uri', $sURI);
+		}
+
+		$aServers = $oConfiguration->GetModuleSetting('authent-ldap', 'servers', []);
+		foreach ($aServers as &$aServer) {
+			if (!array_key_exists($aServer, 'uri')) {
+				$sLDAPHost = $aServerParams['host'] ?? 'localhost';
+				$iLDAPPort = $aServerParams['port'] ?? 389;
+				$aServer['uri'] = preg_match('#^ldaps?://#i', $sLDAPHost) ? $sLDAPHost : 'ldap://'.$sLDAPHost.':'.$iLDAPPort;
+			}
+		}
+		$oConfiguration->SetModuleSetting('authent-ldap', 'servers', $aServers);
 	}
 }
 


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Enhancement

## Objective

According to [the docs](https://www.php.net/manual/en/function.ldap-connect.php), the signature `ldap_connect(?string $host = null, int $port = 389)` is deprecated as of PHP 8.3.0.

## Proposed solution

Introduce new `uri` module setting and provide migration to be able to use the preferred way of `ldap_connect`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?
