### PR TITLE
Feature/8399 portal attachments on stimulus

### DIFF
--- a/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Form/ObjectFormManager.php
@@ -359,7 +359,8 @@ class ObjectFormManager extends FormManager
 		foreach ($this->aFieldsAtts as $sAttCode => $iFieldFlags)
 		{
 			// handle plugins fields
-			if(array_key_exists($sAttCode, $this->aExtraData)
+			if($this->sMode !== 'apply_stimulus'
+				&& array_key_exists($sAttCode, $this->aExtraData)
 				&& array_key_exists('plugin', $this->aExtraData[$sAttCode])){
 				$sPluginName = $this->aExtraData[$sAttCode]['plugin'];
 				switch($sPluginName){
@@ -713,7 +714,8 @@ class ObjectFormManager extends FormManager
 
 		// fallback Checking if the instance has attachments
 		// (in case attachment is not explicitly declared in layout)
-		if (class_exists('Attachment') && class_exists('AttachmentPlugIn')
+		if ($this->sMode !== 'apply_stimulus'
+			&& class_exists('Attachment') && class_exists('AttachmentPlugIn')
 			&& !$this->IsPluginInitialized(AttachmentPlugIn::class)
 			&& AttachmentPlugIn::IsAttachmentAllowedForObject($this->oObject)){
 			$this->AddAttachmentField($this->oForm, 'attachments_plugin', $this->aExtraData);


### PR DESCRIPTION
## Base information
[https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=8399&&login_again=1749042764665](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=8399&&login_again=1749042764665)


## Symptom (bug) / Objective (enhancement)
Portal transition forms show unwanted attachments

## Reproduction procedure (bug)
1. On iTop 3.2.1
2. Create a request in portal
3. Resolve it from console
4. Re-open it on portal

You can see a form with attachment and noting else

## Cause (bug)
This feature have been added in iTop 3.2.1.
It'a add attachments if they are handled by class.

## Proposed solution (bug and enhancement)
Do not show attachment when we are in a transition form.


## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand digging in the code?
