### PR TITLE
fix: N°8522 - check if org id is null when filtering

### DIFF
--- a/core/userrights.class.inc.php
+++ b/core/userrights.class.inc.php
@@ -142,7 +142,7 @@ abstract class UserRightsAddOnAPI
 		$oFilter  = new DBObjectSearch($sClass);
 		$oListExpr = ListExpression::FromScalars($aAllowedOrgs);
 
-		$oNullCondition = new BinaryExpression($oExpression, 'IS', new ScalarExpression(null));
+		$oNullCondition = new FunctionExpression('ISNULL', [$oExpression]);
 		$oInCondition = new BinaryExpression($oExpression, 'IN', $oListExpr);
 		$oCondition = $oNullCondition->LogOr($oInCondition);
 		$oFilter->AddConditionExpression($oCondition);

--- a/core/userrights.class.inc.php
+++ b/core/userrights.class.inc.php
@@ -142,7 +142,9 @@ abstract class UserRightsAddOnAPI
 		$oFilter  = new DBObjectSearch($sClass);
 		$oListExpr = ListExpression::FromScalars($aAllowedOrgs);
 
-		$oCondition = new BinaryExpression($oExpression, 'IN', $oListExpr);
+		$oNullCondition = new BinaryExpression($oExpression, 'IS', new ScalarExpression(null));
+		$oInCondition = new BinaryExpression($oExpression, 'IN', $oListExpr);
+		$oCondition = $oNullCondition->LogOr($oInCondition);
 		$oFilter->AddConditionExpression($oCondition);
 
 		if ($this->HasSharing())

--- a/tests/php-unit-tests/unitary-tests/core/OQLTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/OQLTest.php
@@ -502,50 +502,46 @@ SELECT
 		];
 	}
 
-	public function testOQLAllowedOrg()
+	private function GivenVMAndLicence(int $iVmOrgId, ?int $iLicenceOrgId): int
 	{
-		$sOrgId = $this->GivenObjectInDB('Organization', [
-			'name' => 'Test organization',
-			'status' => 'active'
-		]);
-
 		$iOsFamilyId = $this->GivenObjectInDB('OSFamily', [
-			'name' => 'Test OS Family'
+			'name' => 'Test OS Family',
 		]);
 
 		$iOsVersionId = $this->GivenObjectInDB('OSVersion', [
-			'name' => 'Test OS Version',
-			'osfamily_id' => $iOsFamilyId
+			'name'        => 'Test OS Version',
+			'osfamily_id' => $iOsFamilyId,
 		]);
 
-		$iOsLicenceId = $this->GivenObjectInDB('OSLicence', [
-			'name' => 'Test OS Licence',
+		$iOSLicenceId = $this->GivenObjectInDB('OSLicence', [
+			'name'         => 'Test OS Licence',
 			'osversion_id' => $iOsVersionId,
-			'org_id' => $sOrgId
+			'org_id'       => $iLicenceOrgId,
 		]);
 
 		$iVClusterId = $this->GivenObjectInDB('Hypervisor', [
-			'name' => 'Test Hypervisor',
-			'org_id' => $sOrgId
+			'name'   => 'Test Hypervisor',
+			'org_id' => $iVmOrgId,
 		]);
 
-		$iVmWithOsLicenceId = $this->GivenObjectInDB('VirtualMachine', [
-			'name' => 'Test VM with OS Licence',
-			'org_id' => $sOrgId,
+		return $this->GivenObjectInDB('VirtualMachine', [
+			'name'           => 'Test VM with OS Licence',
+			'org_id'         => $iVmOrgId,
 			'virtualhost_id' => $iVClusterId,
-			'oslicence_id' => $iOsLicenceId
+			'oslicence_id'   => $iOSLicenceId,
 		]);
+	}
 
-		$iVmWithoutOsLicenceId = $this->GivenObjectInDB('VirtualMachine', [
-			'name' => 'Test VM without OS Licence',
-			'org_id' => $sOrgId,
-			'virtualhost_id' => $iVClusterId
-		]);
+	public function testMultiColumnQueryBehaviorWithOrganizationRestrictions()
+	{
+		$sAllowedOrgId = $this->GivenObjectInDB('Organization', ['name' => 'Test organization']);
+		$sForbiddenOrgId = $this->GivenObjectInDB('Organization', ['name' => 'Test organization not allowed']);
 
-		$sLoginUserWithoutAllowedOrg = $this->GivenUserInDB('azerty', ['Configuration Manager']);
-		$sLoginUserWithAllowedOrg = $this->GivenUserRestrictedToAnOrganizationInDB($sOrgId, 3);
+		$iVmWithOsLicenceAllowed = $this->GivenVMAndLicence($sAllowedOrgId, $sAllowedOrgId);
+		$iVmWithOsLicenceForbidden = $this->GivenVMAndLicence($sAllowedOrgId, $sForbiddenOrgId);
+		$iVmWithoutOsLicence = $this->GivenVMAndLicence($sAllowedOrgId, null);
 
-		$aUsersLogin = [$sLoginUserWithoutAllowedOrg, $sLoginUserWithAllowedOrg];
+		$sLoginUserWithAllowedOrg = $this->GivenUserRestrictedToAnOrganizationInDB($sAllowedOrgId, 3);
 
 		$sQuery = <<<OQL
 			SELECT VM, OSL
@@ -553,24 +549,43 @@ SELECT
 			JOIN OSLicence AS OSL ON VM.oslicence_id = OSL.id
 		OQL;
 
+		UserRights::Login($sLoginUserWithAllowedOrg);
 
-		foreach ($aUsersLogin as $sLogin) {
-			if (!UserRights::Login($sLogin)) {
-				self::fail("Could not log in with user $sLogin");
-			}
+		$oDbObjectSearch = DBObjectSearch::FromOQL($sQuery);
 
-			$oDbObjectSearch = DBObjectSearch::FromOQL($sQuery);
+		$oSet = new DBObjectSet($oDbObjectSearch);
 
-			$oSet = new DBObjectSet($oDbObjectSearch);
-			$i = 0;
-			while ($oVM = $oSet->Fetch()) {
-				if ($oVM->GetKey() === $iVmWithOsLicenceId || ($oVM->GetKey() === $iVmWithoutOsLicenceId)) {
-					$i++;
-				}
-			}
-			$sDisplayNameInError = ($sLogin === $sLoginUserWithAllowedOrg) ? "$sLogin (with allowed org)" : "$sLogin (without allowed org)";
-			self::assertEquals(2, $i, "The user $sDisplayNameInError should see 2 VMs (cf. PR #727)");
-			UserRights::Logoff();
-		}
+		$aQueryResult = $oSet->ToArray();
+		$this->assertArrayHasKey($iVmWithOsLicenceAllowed, $aQueryResult, 'The VM with OS Licence in allowed org should be found');
+		$this->assertArrayNotHasKey($iVmWithOsLicenceForbidden, $aQueryResult, 'The VM with OS Licence in forbidden org should NOT be found');
+		$this->assertArrayHasKey($iVmWithoutOsLicence, $aQueryResult, 'The VM without OS Licence should be found (cf. #727)');
+		UserRights::Logoff();
+	}
+
+	public function testMultiColumnQueryBehaviorWithoutOrganizationRestrictions()
+	{
+		$sOrgId = $this->GivenObjectInDB('Organization', ['name' => 'Test organization']);
+
+		$iVmWithOsLicence = $this->GivenVMAndLicence($sOrgId, $sOrgId);
+		$iVmWithoutOsLicence = $this->GivenVMAndLicence($sOrgId, null);
+
+		$sLoginUserWithNoRestriction = $this->GivenUserInDB('azerty', ['Configuration Manager']);
+
+		$sQuery = <<<OQL
+			SELECT VM, OSL
+			FROM VirtualMachine AS VM
+			JOIN OSLicence AS OSL ON VM.oslicence_id = OSL.id
+		OQL;
+
+		UserRights::Login($sLoginUserWithNoRestriction);
+
+		$oDbObjectSearch = DBObjectSearch::FromOQL($sQuery);
+
+		$oSet = new DBObjectSet($oDbObjectSearch);
+
+		$aQueryResult = $oSet->ToArray();
+		$this->assertArrayHasKey($iVmWithOsLicence, $aQueryResult, 'The VM with OS Licence should be found');
+		$this->assertArrayHasKey($iVmWithoutOsLicence, $aQueryResult, 'The VM without OS Licence should be found');
+		UserRights::Logoff();
 	}
 }

--- a/tests/php-unit-tests/unitary-tests/core/OQLTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/OQLTest.php
@@ -504,45 +504,43 @@ SELECT
 
 	public function testOQLAllowedOrg()
 	{
-		$oOrg = MetaModel::NewObject('Organization');
-		$oOrg->Set('name', 'Test organization');
-		$oOrg->Set('status', 'active');
-		$oOrg->DBInsert();
-		$sOrgId = $oOrg->GetKey();
+		$sOrgId = $this->GivenObjectInDB('Organization', [
+			'name' => 'Test organization',
+			'status' => 'active'
+		]);
 
-		$oOsFamily = MetaModel::NewObject('OSFamily');
-		$oOsFamily->Set('name', 'Test OS Family');
-		$oOsFamily->DBInsert();
+		$iOsFamilyId = $this->GivenObjectInDB('OSFamily', [
+			'name' => 'Test OS Family'
+		]);
 
-		$oOsVersion = MetaModel::NewObject('OSVersion');
-		$oOsVersion->Set('name', 'Test OS Version');
-		$oOsVersion->Set('osfamily_id', $oOsFamily->GetKey());
-		$oOsVersion->DBInsert();
+		$iOsVersionId = $this->GivenObjectInDB('OSVersion', [
+			'name' => 'Test OS Version',
+			'osfamily_id' => $iOsFamilyId
+		]);
 
-		$oOsLicence = MetaModel::NewObject('OSLicence');
-		$oOsLicence->Set('name', 'Test OS Licence');
-		$oOsLicence->Set('osversion_id', $oOsVersion->GetKey());
-		$oOsLicence->Set('org_id', $sOrgId);
-		$oOsLicence->DBInsert();
+		$iOsLicenceId = $this->GivenObjectInDB('OSLicence', [
+			'name' => 'Test OS Licence',
+			'osversion_id' => $iOsVersionId,
+			'org_id' => $sOrgId
+		]);
 
-		$oVCluster = MetaModel::NewObject('Hypervisor');
-		$oVCluster->Set('name', 'Test Hypervisor');
-		$oVCluster->Set('org_id', $sOrgId);
-		$oVCluster->DBInsert();
+		$iVClusterId = $this->GivenObjectInDB('Hypervisor', [
+			'name' => 'Test Hypervisor',
+			'org_id' => $sOrgId
+		]);
 
-		$oVmWithOsLicence = MetaModel::NewObject('VirtualMachine');
-		$oVmWithOsLicence->Set('name', 'Test VM with OS Licence');
-		$oVmWithOsLicence->Set('org_id', $sOrgId);
-		$oVmWithOsLicence->Set('virtualhost_id', $oVCluster->GetKey());
-		$oVmWithOsLicence->Set('oslicence_id', $oOsLicence->GetKey());
-		$oVmWithOsLicence->DBInsert();
+		$iVmWithOsLicenceId = $this->GivenObjectInDB('VirtualMachine', [
+			'name' => 'Test VM with OS Licence',
+			'org_id' => $sOrgId,
+			'virtualhost_id' => $iVClusterId,
+			'oslicence_id' => $iOsLicenceId
+		]);
 
-		$oVmWithoutOsLicence = MetaModel::NewObject('VirtualMachine');
-		$oVmWithoutOsLicence->Set('name', 'Test VM without OS Licence');
-		$oVmWithoutOsLicence->Set('org_id', $sOrgId);
-		$oVmWithoutOsLicence->Set('virtualhost_id', $oVCluster->GetKey());
-		$oVmWithoutOsLicence->DBInsert();
-
+		$iVmWithoutOsLicenceId = $this->GivenObjectInDB('VirtualMachine', [
+			'name' => 'Test VM without OS Licence',
+			'org_id' => $sOrgId,
+			'virtualhost_id' => $iVClusterId
+		]);
 
 		$sLoginUserWithoutAllowedOrg = $this->GivenUserInDB('azerty', ['Configuration Manager']);
 		$sLoginUserWithAllowedOrg = $this->GivenUserRestrictedToAnOrganizationInDB($sOrgId, 3);
@@ -566,7 +564,7 @@ SELECT
 			$oSet = new DBObjectSet($oDbObjectSearch);
 			$i = 0;
 			while ($oVM = $oSet->Fetch()) {
-				if ($oVM->GetKey() === $oVmWithOsLicence->GetKey() || ($oVM->GetKey() === $oVmWithoutOsLicence->GetKey())) {
+				if ($oVM->GetKey() === $iVmWithOsLicenceId || ($oVM->GetKey() === $iVmWithoutOsLicenceId)) {
 					$i++;
 				}
 			}

--- a/tests/php-unit-tests/unitary-tests/core/OQLTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/OQLTest.php
@@ -13,12 +13,14 @@ namespace Combodo\iTop\Test\UnitTest\Core;
 use CMDBSource;
 use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
 use DBObjectSearch;
+use DBObjectSet;
 use DBSearch;
 use Exception;
 use MetaModel;
 use OqlInterpreter;
 use QueryBuilderContext;
 use SQLObjectQueryBuilder;
+use UserRights;
 use utils;
 
 class OQLTest extends ItopDataTestCase
@@ -498,5 +500,79 @@ SELECT
 ) AS _union_alderaan_",
 			],
 		];
+	}
+
+	public function testOQLAllowedOrg()
+	{
+		$oOrg = MetaModel::NewObject('Organization');
+		$oOrg->Set('name', 'Test organization');
+		$oOrg->Set('status', 'active');
+		$oOrg->DBInsert();
+		$sOrgId = $oOrg->GetKey();
+
+		$oOsFamily = MetaModel::NewObject('OSFamily');
+		$oOsFamily->Set('name', 'Test OS Family');
+		$oOsFamily->DBInsert();
+
+		$oOsVersion = MetaModel::NewObject('OSVersion');
+		$oOsVersion->Set('name', 'Test OS Version');
+		$oOsVersion->Set('osfamily_id', $oOsFamily->GetKey());
+		$oOsVersion->DBInsert();
+
+		$oOsLicence = MetaModel::NewObject('OSLicence');
+		$oOsLicence->Set('name', 'Test OS Licence');
+		$oOsLicence->Set('osversion_id', $oOsVersion->GetKey());
+		$oOsLicence->Set('org_id', $sOrgId);
+		$oOsLicence->DBInsert();
+
+		$oVCluster = MetaModel::NewObject('Hypervisor');
+		$oVCluster->Set('name', 'Test Hypervisor');
+		$oVCluster->Set('org_id', $sOrgId);
+		$oVCluster->DBInsert();
+
+		$oVmWithOsLicence = MetaModel::NewObject('VirtualMachine');
+		$oVmWithOsLicence->Set('name', 'Test VM with OS Licence');
+		$oVmWithOsLicence->Set('org_id', $sOrgId);
+		$oVmWithOsLicence->Set('virtualhost_id', $oVCluster->GetKey());
+		$oVmWithOsLicence->Set('oslicence_id', $oOsLicence->GetKey());
+		$oVmWithOsLicence->DBInsert();
+
+		$oVmWithoutOsLicence = MetaModel::NewObject('VirtualMachine');
+		$oVmWithoutOsLicence->Set('name', 'Test VM without OS Licence');
+		$oVmWithoutOsLicence->Set('org_id', $sOrgId);
+		$oVmWithoutOsLicence->Set('virtualhost_id', $oVCluster->GetKey());
+		$oVmWithoutOsLicence->DBInsert();
+
+
+		$sLoginUserWithoutAllowedOrg = $this->GivenUserInDB('azerty', ['Configuration Manager']);
+		$sLoginUserWithAllowedOrg = $this->GivenUserRestrictedToAnOrganizationInDB($sOrgId, 3);
+
+		$aUsersLogin = [$sLoginUserWithoutAllowedOrg, $sLoginUserWithAllowedOrg];
+
+		$sQuery = <<<OQL
+			SELECT VM, OSL
+			FROM VirtualMachine AS VM
+			JOIN OSLicence AS OSL ON VM.oslicence_id = OSL.id
+		OQL;
+
+
+		foreach ($aUsersLogin as $sLogin) {
+			if (!UserRights::Login($sLogin)) {
+				self::fail("Could not log in with user $sLogin");
+			}
+
+			$oDbObjectSearch = DBObjectSearch::FromOQL($sQuery);
+
+			$oSet = new DBObjectSet($oDbObjectSearch);
+			$i = 0;
+			while ($oVM = $oSet->Fetch()) {
+				if ($oVM->GetKey() === $oVmWithOsLicence->GetKey() || ($oVM->GetKey() === $oVmWithoutOsLicence->GetKey())) {
+					$i++;
+				}
+			}
+			$sDisplayNameInError = ($sLogin === $sLoginUserWithAllowedOrg) ? "$sLogin (with allowed org)" : "$sLogin (without allowed org)";
+			self::assertEquals(2, $i, "The user $sDisplayNameInError should see 2 VMs (cf. PR #727)");
+			UserRights::Logoff();
+		}
 	}
 }


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Bug fix 


## Symptom 

When querying objects with optional relationships (resulting in LEFT JOINs) where org_id-based access restrictions apply, the query incorrectly filters out rows where the joined object is NULL, effectively converting LEFT JOINs into INNER JOINs.

For example, with the query:
```sql
SELECT VM, OSL
FROM VirtualMachine AS VM
JOIN OSLicence AS OSL ON VM.oslicence_id = OSL.id
```

When `OSLicence` is an optional field for `VirtualMachine` (LEFT JOIN), VMs without an assigned OSLicence should still appear in results with NULL values for the OSL columns. However, for users with organization restrictions, these VMs are completely filtered out. This is because the resulting SQL statement contains this condition: `OSL_Licence.org_id IN ('3', '2', ...)))`, which evaluates to `NULL IN ('3','2',...)`.

This means users with organization restrictions see fewer results than they should; they only see VMs that have an OSLicence assigned, missing all VMs without licenses.

## Reproduction procedure 

1. On iTop 3.2.1-1
2. With PHP 8.1.33
3. Create a user with specific allowed organizations (e.g., org_id 2 and 71)
4. Create several VirtualMachines, some with `oslicence_id` set and some without
5. Execute the OQL query: `SELECT VM, OSL FROM VirtualMachine AS VM JOIN OSLicence AS OSL ON VM.oslicence_id = OSL.id`
6. Only VMs with an assigned OSLicence appear in results (acts like INNER JOIN)
7. Switch to a user with no organization restrictions (empty allowed orgs)
8. Execute the same query - now VMs without OSLicence also appear with NULL values for OSL fields (proper LEFT JOIN behavior)

## Cause
The `MakeSelectFilter` method in `core/userrights.class.inc.php` generates a condition that only checks if `org_id IN (allowed_orgs)`. For LEFT JOINs where the joined object can be NULL, this incorrectly filters out valid rows.

The generated WHERE clause before the fix:
```sql
WHERE (`VM_FunctionalCI`.`org_id` IN ('3', '2', '7')) 
  AND (`OSL_Licence`.`org_id` IN ('3', '2', '7'))
```

When `OSL_Licence` is NULL (no license assigned), `OSL_Licence`.`org_id` is also NULL, and `NULL IN ('3', '2', '7')` returns false, removing the entire row from results.

## Proposed solution 

Modified the organization filter condition in `MakeSelectFilter` (core/userrights.class.inc.php:145-154) to explicitly handle NULL values:

```php
// Create IS NULL condition
$oNullCondition = new BinaryExpression($oExpression, 'IS', new ScalarExpression(null));

// Create IN condition
$oInCondition = new BinaryExpression($oExpression, 'IN', $oListExpr);

// Combine with OR: field IS NULL OR field IN (allowed_orgs)
$oCondition = $oNullCondition->LogOr($oInCondition);

$oFilter->AddConditionExpression($oCondition);
```

This now generates the corrected SQL:
```sql
WHERE ((`VM_FunctionalCI`.`org_id` IS NULL) OR (`VM_FunctionalCI`.`org_id` IN ('3', '2', '7'))) 
  AND ((`OSL_Licence`.`org_id` IS NULL) OR (`OSL_Licence`.`org_id` IN ('3', '2', '7')))
```

This preserves LEFT JOIN semantics by allowing rows where the joined object is NULL, while still enforcing organization restrictions for non-NULL values. 

I would like feedback on this PR before attempting to write unit tests (if required).


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?

