### PR TITLE
N°8419 - Improve Setup process by avoiding the update of the attachment table when contact_id is already set

### DIFF
--- a/datamodels/2.x/itop-attachments/module.itop-attachments.php
+++ b/datamodels/2.x/itop-attachments/module.itop-attachments.php
@@ -201,7 +201,7 @@ SQL;
 			}
 			SetupLog::Info("Initializing attachment/item_org_id - $iUpdated records have been adjusted");
 
-			if (MetaModel::GetAttributeDef('Attachment', 'contact_id') instanceof AttributeExternalKey) {
+			if (MetaModel::GetAttributeDef('Attachment', 'contact_id') instanceof AttributeExternalKey && version_compare($sPreviousVersion, '3.2.0', '<')) {
 				SetupLog::Info("Upgrading itop-attachment from '$sPreviousVersion' to '$sCurrentVersion'. Starting with 3.2.0, contact_id will be added into the DB...");
 				$sUserTableName = MetaModel::DBGetTable('User');
 				$sUserFieldContactId = MetaModel::GetAttributeDef('User', 'contactid')->Get('sql');


### PR DESCRIPTION
## Symptom (bug) / Objective (enhancement)
Setup process is quite long with big database containing lot of attachments.

## Reproduction procedure (bug)
Launch a setup with lot of Attachments.

## Cause (bug)
When adding the feature:
 https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=6619&c[menu]=SearchBugs
The setup launch attachments process compatibility each time.

## Proposed solution (bug and enhancement)
Only launch the compatibility process when the setup is done on older databases version than 3.2.0

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand digging in the code?
