### PR TITLE
N°8570 - :bug: Allow @ as part of url

### DIFF
--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -8165,7 +8165,7 @@ class AttributeURL extends AttributeString
 	 * @since 3.0.3 moved from Config to AttributeURL constant
 	 */
 	public const DEFAULT_VALIDATION_PATTERN = /** @lang RegExp */
-		'(https?|ftp)\://([a-zA-Z0-9+!*(),;?&=\$_.-]+(\:[a-zA-Z0-9+!*(),;?&=\$_.-]+)?@)?([a-zA-Z0-9-.]{3,})(\:[0-9]{2,5})?(/([a-zA-Z0-9:%+\$_-]\.?)+)*/?(\?[a-zA-Z+&\$_.-][a-zA-Z0-9;:[\]@&%=+/\$_.,-]*)?(#[a-zA-Z0-9_.-][a-zA-Z0-9+\$_.-]*)?';
+		'(https?|ftp)\://([a-zA-Z0-9+!*(),;?&=\$_.-]+(\:[a-zA-Z0-9+!*(),;?&=\$_.-]+)?@)?([a-zA-Z0-9-.]{3,})(\:[0-9]{2,5})?(/([a-zA-Z0-9:%@+\$_-]\.?)+)*/?(\?[a-zA-Z+&\$_.-][a-zA-Z0-9;:[\]@&%=+/\$_.,-]*)?(#[a-zA-Z0-9_.-][a-zA-Z0-9+\$_.-]*)?';
 
 	/**
 	 * Useless constructor, but if not present PHP 7.4.0/7.4.1 is crashing :( (N°2329)


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | No
| Type of change?                                               | Bug fix 


## Symptom (bug) / Objective (enhancement)
<!--
If it's a bug
  - Explain the symptom in details
  - If possible put error messages, logs or screenshots (you can paste image directly in this editor).

If it's an enhancement
  - Describe what is blocking you, what is the objective with as much details as possible.
  - Add screenshots if it's related to UI.
-->

Some type of URL is not parsed correctly by the url_validation_pattern, like this:

https://calendar.example.com/book/meetingroom42@acme-corp.com/


## Reproduction procedure (bug)

Paste the given example to a text field in itop and look at the rendered output. The link will stop right before the at-sign.


## Cause (bug)

The DEFAULT_VALIDATION_PATTERN does not allow the @ sign as part of the URL


## Proposed solution (bug and enhancement)

Add the @ sign to the regex. 
According to RFC 3986 – Uniform Resource Identifier (URI): Generic Syntax, the @ character is a valid character within path segments of a URI. Specifically, it is part of the allowed pchar set and does not need to be percent-encoded (%40) when used in the path component — as long as it is not part of the userinfo or authority sections.

## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?

