### PR TITLE
doc: Complete the version history

### DIFF
--- a/itop-version-history.md
+++ b/itop-version-history.md
@@ -94,11 +94,11 @@ gitGraph
     checkout support/2.7
     commit id: "2024-09-28" tag: "2.7.11"
     checkout support/2.7
-    commit id: "2025-02-25" tag: "2.7.12"
+    commit id: "2025-02-25a" tag: "2.7.12"
     checkout support/3.1
-    commit id: "2025-02-25 " tag: "3.1.3"
+    commit id: "2025-02-25b" tag: "3.1.3"
     checkout support/3.2
-    commit id: "2025-02-25  " tag: "3.2.1"
+    commit id: "2025-02-25c" tag: "3.2.1"
 ```
 
 To learn more, check the [iTop community versions history on the official wiki](https://www.itophub.io/wiki/page?id=latest:release:start).

--- a/itop-version-history.md
+++ b/itop-version-history.md
@@ -95,11 +95,11 @@ gitGraph
     checkout support/2.7
     commit id: "2024-09-28" tag: "2.7.11"
     checkout support/2.7
-    commit id: "2025-02-25a" tag: "2.7.12"
+    commit id: "2025-02-25" tag: "2.7.12"
     checkout support/3.1
-    commit id: "2025-02-25b" tag: "3.1.3"
+    commit id: "2025-02-25 " tag: "3.1.3"
     checkout support/3.2
-    commit id: "2025-02-25c" tag: "3.2.1"
+    commit id: "2025-02-25  " tag: "3.2.1"
     commit id: "2025-04-08" tag: "3.2.1-1"
     commit id: "2025-08-19" tag: "3.2.2-1"
 ```

--- a/itop-version-history.md
+++ b/itop-version-history.md
@@ -86,13 +86,13 @@ gitGraph
     commit id: "2024-01-17a" tag: "2.7.10"
     checkout support/3.0
     commit id: "2024-01-17b" tag: "3.0.4"
-    checkout support/2.7
-    commit id: "2024-09-28" tag: "2.7.11"
-    checkout support/3.1
-    commit id: "2024-09-27" tag: "3.1.2"
     checkout support/3.2
     commit id: "2024-06-25" tag: "3.2.0-beta1" type: REVERSE
     commit id: "2024-08-07" tag: "3.2.0"
+    checkout support/3.1
+    commit id: "2024-09-27" tag: "3.1.2"
+    checkout support/2.7
+    commit id: "2024-09-28" tag: "2.7.11"
     checkout support/2.7
     commit id: "2025-02-25" tag: "2.7.12"
     checkout support/3.1

--- a/itop-version-history.md
+++ b/itop-version-history.md
@@ -89,6 +89,7 @@ gitGraph
     checkout support/3.2
     commit id: "2024-06-25" tag: "3.2.0-beta1" type: REVERSE
     commit id: "2024-08-07" tag: "3.2.0"
+    commit id: "2024-09-13" tag: "3.2.0-2"
     checkout support/3.1
     commit id: "2024-09-27" tag: "3.1.2"
     checkout support/2.7
@@ -99,6 +100,8 @@ gitGraph
     commit id: "2025-02-25b" tag: "3.1.3"
     checkout support/3.2
     commit id: "2025-02-25c" tag: "3.2.1"
+    commit id: "2025-04-08" tag: "3.2.1-1"
+    commit id: "2025-08-19" tag: "3.2.2-1"
 ```
 
 To learn more, check the [iTop community versions history on the official wiki](https://www.itophub.io/wiki/page?id=latest:release:start).


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | https://github.com/Combodo/iTop/commit/463869b89d199902212fe9292aa3f8c9dec83480
| Type of change?                                               | Documentation

## Objective

Keep revision history up to date.


## Proposed solution

I think a gantt chart would be more practical, both for maintainers (clean code) and users (easy to view when a certain version was released/supported).

If accepted, I'm willing to do the complete conversion up to the version requested. Find hereunder an example of how it would look like up to 2.7 LTS.

```mermaid
gantt
    dateFormat  YYYY-MM-DD
    section 2.7 (LTS)
        2.7.0-beta  :done, 2019-12-18, 2020-01-29
        2.7.0-beta2 :done, 2020-01-29, 2020-04-01
        2.7.0-1     :done, 2020-04-01, 2020-05-20
        2.7.0-2     :done, 2020-05-20, 2020-06-26
        2.7.1       :done, 2020-06-26, 2020-11-10
        2.7.2-1     :done, 2020-11-10, 2020-12-09
        2.7.3       :done, 2020-12-09, 2021-03-31
        2.7.4       :done, 2021-03-31, 2021-07-05
        2.7.5-1     :done, 2021-07-05, 2021-12-17
        2.7.6       :done, 2021-12-17, 2022-07-11
        2.7.7       :done, 2022-07-11, 2022-12-28
        2.7.8       :done, 2022-12-28, 2023-08-10
        2.7.9       :done, 2023-08-10, 2024-01-17
        2.7.10      :done, 2024-01-17, 2024-09-28
        2.7.11      :done, 2024-09-28, 2025-02-25
        2.7.12      :done, 2025-02-25, 2025-09-01
    section 3.0 (STS)
        3.0.0-beta  :done, 2021-04-06, 2021-07-06
        3.0.0-beta2 :done, 2021-07-06, 2021-09-15
        3.0.0-beta4 :done, 2021-09-15, 2021-10-12
        3.0.0-beta5 :done, 2021-10-12, 2022-01-12
        3.0.0       :done, 2022-01-12, 2022-05-04
        3.0.1       :done, 2022-05-04, 2022-09-14
        3.0.2-1     :done, 2022-09-14, 2023-04-12
        3.0.3       :done, 2023-04-12, 2024-01-01
    section 3.1 (STS)
        3.1.0-beta :done, 2023-06-19, 2023-07-26
        3.1.0-1    :done, 2023-07-26, 2023-08-09
        3.1.0-2    :done, 2023-08-09, 2023-12-20
        3.1.1      :done, 2023-12-20, 2024-09-27
        3.1.2      :done, 2024-09-27, 2025-02-25
        3.1.3      :done, 2025-02-25, 2025-04-01
    section 3.2 (LTS)
        3.2.0-beta1 :done,   2024-06-25, 2024-08-07
        3.2.0       :done,   2024-08-07, 2024-09-13
        3.2.0-2     :done,   2024-09-13, 2025-02-25
        3.2.1       :done,   2025-02-25, 2025-04-08
        3.2.1-1     :done,   2025-04-08, 2025-08-19
        3.2.2-1     :active, 2025-08-19, until today
        3.2.x       : after today, 2027-01-01

```