### PR TITLE
N°4058 - Setup failed when added an encrypted field due to default value NULL non SODIUM compatible

### DIFF
--- a/core/simplecrypt.class.inc.php
+++ b/core/simplecrypt.class.inc.php
@@ -130,7 +130,15 @@ class SimpleCrypt
      */
     function Decrypt($key, $string)
     {
-        return $this->oEngine->Decrypt($key,$string);
+		try{
+			return $this->oEngine->Decrypt($key,$string);
+		} catch(\Exception $e){
+			if (strlen($string)==0){
+				IssueLog::Error("Cannot decrypt empty/null value", null, ['msg' => $e->getMessage(), 'stack' => $e->getTraceAsString()]);
+				return $string;
+			}
+			throw $e;
+		}
     }
 
     /**

--- a/core/simplecrypt.class.inc.php
+++ b/core/simplecrypt.class.inc.php
@@ -134,7 +134,7 @@ class SimpleCrypt
 			return $this->oEngine->Decrypt($key,$string);
 		} catch(\Exception $e){
 			if (strlen($string)==0){
-				IssueLog::Error("Cannot decrypt empty/null value", null, ['msg' => $e->getMessage(), 'stack' => $e->getTraceAsString()]);
+				IssueLog::Warning("Cannot decrypt empty/null value", null, ['msg' => $e->getMessage(), 'stack' => $e->getTraceAsString()]);
 				return $string;
 			}
 			throw $e;

--- a/tests/php-unit-tests/unitary-tests/core/SympleCryptTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/SympleCryptTest.php
@@ -1,0 +1,55 @@
+<?php
+/*!
+ * @copyright   Copyright (C) 2010-2024 Combodo SAS
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\Test\UnitTest\Core;
+
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use ormPassword;
+use Utils;
+
+/**
+ * Tests of the ormPassword class
+ */
+class ormPasswordTest extends ItopDataTestCase
+{
+
+	/**
+	 * @param $sToHashValues
+	 * @param $sToHashSalt
+	 * @param $sHashAlgo
+	 * @param $sExpectedHash
+	 *
+	 * @throws \ConfigException
+	 * @throws \CoreException
+	 * @dataProvider HashProvider
+	 */
+	public function testCheckHash($sToHashValues, $sToHashSalt, $sHashAlgo, $sExpectedHash)
+	{
+		$prevHashAlgo = utils::GetConfig()->GetPasswordHashAlgo($sHashAlgo);
+		utils::GetConfig()->SetPasswordHashAlgo($sHashAlgo);
+		$oPassword1 = new ormPassword($sExpectedHash, $sToHashSalt);
+		static::assertTrue($oPassword1->CheckPassword($sToHashValues));
+		utils::GetConfig()->SetPasswordHashAlgo($prevHashAlgo);
+	}
+
+	public function HashProvider()
+	{
+		return array(
+			'Bcrypt' => array(
+				'admin',
+				'',
+				PASSWORD_BCRYPT,
+				'$2y$10$P6yqXv/0pT4e9kfN6d95jOKX4KR5Il.N0vRLc2DoZoycwnU9mcnia'
+			),
+			'sha256 (legacy)' => array(
+				'admin',
+				'salt',
+				'sha256',
+				'2bb7998496899acdd8137fad3a44faf96a84a03d7f230ce42e97cd17c7ae429e'
+			),
+		);
+	}
+}

--- a/tests/php-unit-tests/unitary-tests/core/SympleCryptTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/SympleCryptTest.php
@@ -7,49 +7,30 @@
 namespace Combodo\iTop\Test\UnitTest\Core;
 
 use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
-use ormPassword;
-use Utils;
+use SodiumException;
 
 /**
  * Tests of the ormPassword class
  */
-class ormPasswordTest extends ItopDataTestCase
+class SympleCryptTest extends ItopDataTestCase
 {
-
-	/**
-	 * @param $sToHashValues
-	 * @param $sToHashSalt
-	 * @param $sHashAlgo
-	 * @param $sExpectedHash
-	 *
-	 * @throws \ConfigException
-	 * @throws \CoreException
-	 * @dataProvider HashProvider
-	 */
-	public function testCheckHash($sToHashValues, $sToHashSalt, $sHashAlgo, $sExpectedHash)
+	public function testDecryptWithNullValue()
 	{
-		$prevHashAlgo = utils::GetConfig()->GetPasswordHashAlgo($sHashAlgo);
-		utils::GetConfig()->SetPasswordHashAlgo($sHashAlgo);
-		$oPassword1 = new ormPassword($sExpectedHash, $sToHashSalt);
-		static::assertTrue($oPassword1->CheckPassword($sToHashValues));
-		utils::GetConfig()->SetPasswordHashAlgo($prevHashAlgo);
+		$oSimpleCrypt = new \SimpleCrypt("Sodium");
+		$this->assertEquals(null, $oSimpleCrypt->Decrypt("dd", null));
 	}
 
-	public function HashProvider()
+	public function testDecryptWithEmptyValue()
 	{
-		return array(
-			'Bcrypt' => array(
-				'admin',
-				'',
-				PASSWORD_BCRYPT,
-				'$2y$10$P6yqXv/0pT4e9kfN6d95jOKX4KR5Il.N0vRLc2DoZoycwnU9mcnia'
-			),
-			'sha256 (legacy)' => array(
-				'admin',
-				'salt',
-				'sha256',
-				'2bb7998496899acdd8137fad3a44faf96a84a03d7f230ce42e97cd17c7ae429e'
-			),
-		);
+		$oSimpleCrypt = new \SimpleCrypt("Sodium");
+		$this->assertEquals('', $oSimpleCrypt->Decrypt("dd", ""));
 	}
+
+	public function testDecrypNonDecryptableValue()
+	{
+		$this->expectException(SodiumException::class);
+		$oSimpleCrypt = new \SimpleCrypt("Sodium");
+		$this->assertEquals('', $oSimpleCrypt->Decrypt("dd", "gabuzomeu"));
+	}
+
 }


### PR DESCRIPTION
** Symptom**:
Itop setup fails when adding encrypted fields without any default value. in AfterDbCreation step, the application tries to decrypt field value with an invalid value (null/empty). 

`2021-06-02 17:56:20 | Error   | An exception occurred: nonce size should be SODIUM_CRYPTO_SECRETBOX_NONCEBYTES bytes at line 330 in file /var/www/html/core/simplecrypt.class.inc.php | SetupLog`

Fixing it in production could be really painfull and is seen as quite unfriendly...

