### PR TITLE
🐛 N°8838 - fix testing mysqldump custom path

### DIFF
--- a/setup/backup.class.inc.php
+++ b/setup/backup.class.inc.php
@@ -595,13 +595,13 @@ EOF;
 			$sMySQLCommand = $sCmd;
 		} else {
 			$sMySQLBinDir = escapeshellcmd($sMySQLBinDir);
-			$sMySQLCommand = '"'.$sMySQLBinDir.'/$sCmd"';
+			$sMySQLCommand = $sMySQLBinDir.'/'.$sCmd;
 			if (!file_exists($sMySQLCommand)) {
 				throw new BackupException("$sCmd not found in $sMySQLBinDir");
 			}
 		}
 
-		return $sMySQLCommand;
+		return '"'.$sMySQLCommand.'"';
 	}
 }
 


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | bug #8838
| Type of change?                                               | Bug fix


## Symptom (bug)
Regression: testing of a correct custom path to mysqldump fails with error 'mysqldump not found in ...'.
<img width="552" height="206" alt="image" src="https://github.com/user-attachments/assets/5c6588d3-ef20-4d25-b73f-0e6c65ad830c" />


## Reproduction procedure (bug)
1. On iTop 3.2.2-1
2. With PHP 8.1.33 or 8.3.12
3. Set a valid custom path to mysqldump command in parameter 'mysql_bindir' of 'itop-backup' module configuration
```
'itop-backup' => array (
		'mysql_bindir' => '/opt/local/bin/',
```
4. access backup status page (${ITOP-app_root_url}/pages/exec.php?exec_module=itop-backup&exec_page=status.php)
5. iTop fails to find mysqldump command even if it is present and with appropriate rx rights on path and file.


## Cause (bug)
commit "N°8379 - fix backup issue" introduced a security test on content of parameter 'mysql_bindir' of 'itop-backup' module configuration, but with incorrect quoting : double quote are added to the command before testing it exist, but file_exists() doesn't need and doesn't interpret these quotes and fails to find the file.

Still, quoting is needed before returing the command for system call to properly handle cases where the path contains spaces or other characters shell would interpret as separators.

## Proposed solution (bug and enhancement)
postpone quoting the command so that file_exist() can have a unquotted command to test

## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance (linux and MacOS darwin)
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge
- [ ] test on a iTop instance running on Windows
- [ ] consider rebase to support/3.2
- [ ] consider adding unit tests
