### PR TITLE
Add few APIs to ease tests

### DIFF
--- a/tests/php-static-analysis/config/php-includes/set-php-version-from-process.php
+++ b/tests/php-static-analysis/config/php-includes/set-php-version-from-process.php
@@ -1,10 +1,11 @@
 <?php
+
 /*
  * @copyright   Copyright (C) 2010-2023 Combodo SARL
  * @license     http://opensource.org/licenses/AGPL-3.0
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 /**
  * This file is only here to allow setting a specific PHP version to run the analysis for without

--- a/tests/php-unit-tests/integration-tests/itop-hub-connector/AjaxPageTest.php
+++ b/tests/php-unit-tests/integration-tests/itop-hub-connector/AjaxPageTest.php
@@ -28,14 +28,14 @@ class AjaxPageTest extends ItopDataTestCase
 		$iLastCompilation = filemtime(APPROOT.'env-production');
 
 		// When
-		$sOutput = $this->CallItopUrl(
-			"/pages/exec.php?exec_module=itop-hub-connector&exec_page=ajax.php",
+		$sOutput = $this->CallItopUri(
+			"pages/exec.php?exec_module=itop-hub-connector&exec_page=ajax.php",
 			[
 				'auth_user' => $sLogin,
 				'auth_pwd' => self::AUTHENTICATION_PASSWORD,
 				'operation' => 	"compile",
 				'authent' => self::AUTHENTICATION_TOKEN,
-			]
+			],
 		);
 
 		// Then
@@ -52,27 +52,5 @@ class AjaxPageTest extends ItopDataTestCase
 
 		clearstatcache();
 		$this->assertGreaterThan($iLastCompilation, filemtime(APPROOT.'env-production'), 'The env-production directory should have been rebuilt');
-	}
-
-	protected function CallItopUrl($sUri, ?array $aPostFields = null, bool $bXDebugEnabled = false)
-	{
-		$ch = curl_init();
-		if ($bXDebugEnabled) {
-			curl_setopt($ch, CURLOPT_COOKIE, 'XDEBUG_SESSION=phpstorm');
-		}
-
-		$sUrl = \MetaModel::GetConfig()->Get('app_root_url')."/$sUri";
-		var_dump($sUrl);
-		curl_setopt($ch, CURLOPT_URL, $sUrl);
-		curl_setopt($ch, CURLOPT_POST, 1);// set post data to true
-		curl_setopt($ch, CURLOPT_POSTFIELDS, $aPostFields);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
-		$sOutput = curl_exec($ch);
-		//echo "$sUrl error code:".curl_error($ch);
-		curl_close($ch);
-
-		return $sOutput;
 	}
 }

--- a/tests/php-unit-tests/legacy-tests/display_cache_content.php
+++ b/tests/php-unit-tests/legacy-tests/display_cache_content.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright (C) 2013-2024 Combodo SAS
  *
@@ -24,19 +25,15 @@
 require_once('../../../approot.inc.php');
 require_once(APPROOT.'application/startup.inc.php');
 
-
 $sEnvironment = MetaModel::GetEnvironmentId();
-$aEntries = array();
+$aEntries = [];
 $aCacheUserData = apc_cache_info_compat();
-if (is_array($aCacheUserData) && isset($aCacheUserData['cache_list']))
-{
+if (is_array($aCacheUserData) && isset($aCacheUserData['cache_list'])) {
 	$sPrefix = 'itop-'.$sEnvironment.'-query-cache-';
 
-	foreach($aCacheUserData['cache_list'] as $i => $aEntry)
-	{
+	foreach ($aCacheUserData['cache_list'] as $i => $aEntry) {
 		$sEntryKey = array_key_exists('info', $aEntry) ? $aEntry['info'] : $aEntry['key'];
-		if (strpos($sEntryKey, $sPrefix) === 0)
-		{
+		if (strpos($sEntryKey, $sPrefix) === 0) {
 			$aEntries[] = $sEntryKey;
 		}
 	}
@@ -44,52 +41,39 @@ if (is_array($aCacheUserData) && isset($aCacheUserData['cache_list']))
 
 echo "<pre>";
 
-if (empty($aEntries))
-{
+if (empty($aEntries)) {
 	echo "No Data";
 	return;
 }
 
 $sKey = $aEntries[0];
 $result = apc_fetch($sKey);
-if (!is_object($result))
-{
+if (!is_object($result)) {
 	return;
 }
 $oSQLQuery = $result;
 
 echo "NB Tables before;NB Tables after;";
-foreach($oSQLQuery->m_aContextData as $sField => $oValue)
-{
+foreach ($oSQLQuery->m_aContextData as $sField => $oValue) {
 	echo $sField.';';
 }
 echo "\n";
 
 sort($aEntries);
 
-foreach($aEntries as $sKey)
-{
+foreach ($aEntries as $sKey) {
 	$result = apc_fetch($sKey);
-	if (is_object($result))
-	{
+	if (is_object($result)) {
 		$oSQLQuery = $result;
-		if (isset($oSQLQuery->m_aContextData))
-		{
+		if (isset($oSQLQuery->m_aContextData)) {
 			echo $oSQLQuery->m_iOriginalTableCount.";".$oSQLQuery->CountTables().';';
-			foreach($oSQLQuery->m_aContextData as $oValue)
-			{
-				if (is_array($oValue))
-				{
+			foreach ($oSQLQuery->m_aContextData as $oValue) {
+				if (is_array($oValue)) {
 					$sVal = json_encode($oValue);
-				}
-				else
-				{
-					if (empty($oValue))
-					{
+				} else {
+					if (empty($oValue)) {
 						$sVal = '';
-					}
-					else
-					{
+					} else {
 						$sVal = $oValue;
 					}
 				}
@@ -101,4 +85,3 @@ foreach($aEntries as $sKey)
 }
 
 echo "</pre>";
-

--- a/tests/php-unit-tests/src/BaseTestCase/ItopDataTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopDataTestCase.php
@@ -18,6 +18,7 @@ use ArchivedObjectException;
 use CMDBObject;
 use CMDBSource;
 use Combodo\iTop\Service\Events\EventService;
+use Config;
 use Contact;
 use DBObject;
 use DBObjectSet;
@@ -64,6 +65,9 @@ abstract class ItopDataTestCase extends ItopTestCase
 	// For cleanup
 	private $aCreatedObjects = [];
 	private $aEventListeners = [];
+
+	protected ?string $sConfigTmpBackupFile = null;
+	protected ?Config $oiTopConfig = null;
 
 	/**
 	 * @var bool When testing with silo, there are some cache we need to update on tearDown. Doing it all the time will cost too much, so it's opt-in !
@@ -184,6 +188,8 @@ abstract class ItopDataTestCase extends ItopTestCase
 		}
 
 		CMDBObject::SetCurrentChange(null);
+
+		$this->RestoreConfiguration();
 
 		parent::tearDown();
 	}
@@ -1434,4 +1440,35 @@ abstract class ItopDataTestCase extends ItopTestCase
 		$oObject->Set($sStopwatchAttCode, $oStopwatch);
 	}
 
+	protected function BackupConfiguration(): void
+	{
+		$sConfigPath = MetaModel::GetConfig()->GetLoadedFile();
+		clearstatcache();
+		echo sprintf("rights via ls on %s:\n %s \n", $sConfigPath, exec("ls -al $sConfigPath"));
+		$sFilePermOutput = substr(sprintf('%o', fileperms('/etc/passwd')), -4);
+		echo sprintf("rights via fileperms on %s:\n %s \n", $sConfigPath, $sFilePermOutput);
+
+		$this->sConfigTmpBackupFile = tempnam(sys_get_temp_dir(), "config_");
+		MetaModel::GetConfig()->WriteToFile($this->sConfigTmpBackupFile);
+		$this->oiTopConfig = new Config($sConfigPath);
+	}
+
+	protected function RestoreConfiguration(): void
+	{
+		if (is_null($this->sConfigTmpBackupFile) || ! is_file($this->sConfigTmpBackupFile)) {
+			return;
+		}
+
+		if (is_null($this->oiTopConfig)) {
+			return;
+		}
+
+		//put config back
+		$sConfigPath = $this->oiTopConfig->GetLoadedFile();
+		@chmod($sConfigPath, 0770);
+		$oConfig = new Config($this->sConfigTmpBackupFile);
+		$oConfig->WriteToFile($sConfigPath);
+		@chmod($sConfigPath, 0440);
+		@unlink($this->sConfigTmpBackupFile);
+	}
 }

--- a/tests/php-unit-tests/src/BaseTestCase/ItopDataTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopDataTestCase.php
@@ -123,6 +123,8 @@ abstract class ItopDataTestCase extends ItopTestCase
 	{
 		parent::setUp();
 
+		\IssueLog::Error($this->getName());
+		
 		$this->PrepareEnvironment();
 
 		if (static::USE_TRANSACTION) {

--- a/tests/php-unit-tests/src/BaseTestCase/ItopDataTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopDataTestCase.php
@@ -124,7 +124,7 @@ abstract class ItopDataTestCase extends ItopTestCase
 		parent::setUp();
 
 		\IssueLog::Error($this->getName());
-		
+
 		$this->PrepareEnvironment();
 
 		if (static::USE_TRANSACTION) {

--- a/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
@@ -14,6 +14,7 @@ use ReflectionMethod;
 use SetupUtils;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
+
 use const DEBUG_BACKTRACE_IGNORE_ARGS;
 
 /**

--- a/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
@@ -10,11 +10,10 @@ namespace Combodo\iTop\Test\UnitTest;
 use CMDBSource;
 use DeprecatedCallsLog;
 use MySQLTransactionNotClosedException;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use ReflectionMethod;
 use SetupUtils;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpKernel\KernelInterface;
-
 use const DEBUG_BACKTRACE_IGNORE_ARGS;
 
 /**
@@ -149,7 +148,6 @@ abstract class ItopTestCase extends KernelTestCase
 	protected function setUp(): void
 	{
 		parent::setUp();
-		\IssueLog::Error($this->getName());
 
 		// Hack - Required the first time the Portal kernel is booted on a newly installed iTop
 		$_ENV['COMBODO_PORTAL_BASE_ABSOLUTE_PATH'] = __DIR__.'/../../../../../env-production/itop-portal-base/portal/public/';

--- a/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
@@ -37,7 +37,7 @@ abstract class ItopTestCase extends KernelTestCase
 	public const DISABLE_DEPRECATEDCALLSLOG_ERRORHANDLER = true;
 	public static $DEBUG_UNIT_TEST = false;
 	protected static $aBackupStaticProperties = [];
-	public ?array $aLastCurlGetInfo=null;
+	public ?array $aLastCurlGetInfo = null;
 	/**
 	 * @link https://docs.phpunit.de/en/9.6/annotations.html#preserveglobalstate PHPUnit `preserveGlobalState` annotation documentation
 	 *
@@ -675,7 +675,7 @@ abstract class ItopTestCase extends KernelTestCase
 		//\IssueLog::Info("$sUrl error code:", null, ['error' => curl_error($ch)]);
 
 		$info = curl_getinfo($ch);
-		$this->aLastCurlGetInfo=$info;
+		$this->aLastCurlGetInfo = $info;
 		$sErrorMsg = curl_error($ch);
 		$iErrorCode = curl_errno($ch);
 		curl_close($ch);

--- a/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
@@ -28,6 +28,7 @@ use const DEBUG_BACKTRACE_IGNORE_ARGS;
 abstract class ItopTestCase extends KernelTestCase
 {
 	public const TEST_LOG_DIR = 'test';
+	protected array $aFileToClean = [];
 
 	/**
 	 * @var bool
@@ -36,7 +37,7 @@ abstract class ItopTestCase extends KernelTestCase
 	public const DISABLE_DEPRECATEDCALLSLOG_ERRORHANDLER = true;
 	public static $DEBUG_UNIT_TEST = false;
 	protected static $aBackupStaticProperties = [];
-
+	public ?array $aLastCurlGetInfo=null;
 	/**
 	 * @link https://docs.phpunit.de/en/9.6/annotations.html#preserveglobalstate PHPUnit `preserveGlobalState` annotation documentation
 	 *
@@ -148,6 +149,7 @@ abstract class ItopTestCase extends KernelTestCase
 	protected function setUp(): void
 	{
 		parent::setUp();
+		\IssueLog::Error($this->getName());
 
 		// Hack - Required the first time the Portal kernel is booted on a newly installed iTop
 		$_ENV['COMBODO_PORTAL_BASE_ABSOLUTE_PATH'] = __DIR__.'/../../../../../env-production/itop-portal-base/portal/public/';
@@ -173,6 +175,15 @@ abstract class ItopTestCase extends KernelTestCase
 				CMDBSource::Query('ROLLBACK');
 			}
 			throw new MySQLTransactionNotClosedException('Some DB transactions were opened but not closed ! Fix the code by adding ROLLBACK or COMMIT statements !', []);
+		}
+
+		foreach ($this->aFileToClean as $sPath) {
+			if (is_file($sPath)) {
+				@unlink($sPath);
+				continue;
+			}
+
+			SetupUtils::tidydir($sPath);
 		}
 	}
 
@@ -630,5 +641,53 @@ abstract class ItopTestCase extends KernelTestCase
 		}
 		fclose($handle);
 		return array_reverse($aLines);
+	}
+
+	/**
+	* @param $sUrl
+	* @param array|null $aPostFields
+	* @param array|null $aCurlOptions
+	* @param $bXDebugEnabled
+	* @return string
+	 */
+	protected function CallItopUrl($sUrl, ?array $aPostFields = [], ?array $aCurlOptions = [], $bXDebugEnabled = false): string
+	{
+		$ch = curl_init();
+		if ($bXDebugEnabled) {
+			curl_setopt($ch, CURLOPT_COOKIE, "XDEBUG_SESSION=phpstorm");
+		}
+
+		curl_setopt($ch, CURLOPT_URL, $sUrl);
+		curl_setopt($ch, CURLOPT_POST, 1);// set post data to true
+		if (!is_array($aPostFields)) {
+			var_dump($aPostFields);
+		}
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $aPostFields);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		// Force disable of certificate check as most of dev / test env have a self-signed certificate
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+
+		var_dump($aCurlOptions);
+		curl_setopt_array($ch, $aCurlOptions);
+
+		$sOutput = curl_exec($ch);
+		//\IssueLog::Info("$sUrl error code:", null, ['error' => curl_error($ch)]);
+
+		$info = curl_getinfo($ch);
+		$this->aLastCurlGetInfo=$info;
+		$sErrorMsg = curl_error($ch);
+		$iErrorCode = curl_errno($ch);
+		curl_close($ch);
+
+		\IssueLog::Info(__METHOD__, null, ['url' => $sUrl, 'error' => $sErrorMsg, 'error_code' => $iErrorCode, 'post_fields' => $aPostFields, 'info' => $info]);
+
+		return $sOutput;
+	}
+
+	protected function CallItopUri(string $sUri, ?array $aPostFields = [], ?array $aCurlOptions = [], $bXDebugEnabled = false): string
+	{
+		$sUrl = \MetaModel::GetConfig()->Get('app_root_url')."/$sUri";
+		return $this->CallItopUrl($sUrl, $aPostFields, $aCurlOptions, $bXDebugEnabled);
 	}
 }

--- a/tests/php-unit-tests/unitary-tests/application/LoginTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/LoginTest.php
@@ -7,7 +7,6 @@ use MetaModel;
 
 class LoginTest extends ItopDataTestCase
 {
-	protected $sConfigTmpBackupFile;
 	protected $sConfigPath;
 	protected $sLoginMode;
 

--- a/tests/php-unit-tests/unitary-tests/application/query/QueryTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/query/QueryTest.php
@@ -172,34 +172,11 @@ class QueryTest extends ItopDataTestCase
 	{
 		// compute request url
 		$url = 	$oQuery->GetExportUrl();
-
-		// open curl
-		$curl = curl_init();
-
-		// curl options
-		curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-		curl_setopt($curl, CURLOPT_USERPWD, self::USER.':'.self::PASSWORD);
-		curl_setopt($curl, CURLOPT_URL, $url);
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-		// Force disable of certificate check as most of dev / test env have a self-signed certificate
-		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
-		curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
-
-		// execute curl
-		$result = curl_exec($curl);
-		if (curl_errno($curl)) {
-			$info = curl_getinfo($curl);
-			var_export($info);
-			var_dump([
-				'url' => $url,
-				'app_root_url:' => MetaModel::GetConfig()->Get('app_root_url'),
-				'GetAbsoluteUrlAppRoot:' => \utils::GetAbsoluteUrlAppRoot(),
-			]);
-		}
-		// close curl
-		curl_close($curl);
-
-		return $result;
+		$aCurlOptions = [
+			CURLOPT_HTTPAUTH => CURLAUTH_BASIC,
+			CURLOPT_USERPWD => self::USER.':'.self::PASSWORD,
+		];
+		return $this->CallItopUrl($url, [], $aCurlOptions);
 	}
 
 	/** @inheritDoc */

--- a/tests/php-unit-tests/unitary-tests/webservices/CliResetSessionTest.php
+++ b/tests/php-unit-tests/unitary-tests/webservices/CliResetSessionTest.php
@@ -12,10 +12,8 @@ class CliResetSessionTest extends ItopDataTestCase
 	public const USE_TRANSACTION = false;
 
 	private $sCookieFile = "";
-	private $sUrl;
 	private $sLogin;
 	private $sPassword = "Iuytrez9876543ç_è-(";
-	protected $sConfigTmpBackupFile;
 
 	/**
 	 * @throws Exception
@@ -24,15 +22,12 @@ class CliResetSessionTest extends ItopDataTestCase
 	{
 		parent::setUp();
 
-		$this->sConfigTmpBackupFile = tempnam(sys_get_temp_dir(), "config_");
-		MetaModel::GetConfig()->WriteToFile($this->sConfigTmpBackupFile);
+		$this->BackupConfiguration();
 
 		$this->sLogin = "rest-user-".date('dmYHis');
 		$this->CreateTestOrganization();
 
 		$this->sCookieFile = tempnam(sys_get_temp_dir(), 'jsondata_');
-
-		$this->sUrl = \MetaModel::GetConfig()->Get('app_root_url');
 
 		$oRestProfile = \MetaModel::GetObjectFromOQL("SELECT URP_Profiles WHERE name = :name", ['name' => 'REST Services User'], true);
 		$oAdminProfile = \MetaModel::GetObjectFromOQL("SELECT URP_Profiles WHERE name = :name", ['name' => 'Administrator'], true);
@@ -46,16 +41,6 @@ class CliResetSessionTest extends ItopDataTestCase
 	protected function tearDown(): void
 	{
 		parent::tearDown();
-
-		if (! is_null($this->sConfigTmpBackupFile) && is_file($this->sConfigTmpBackupFile)) {
-			//put config back
-			$sConfigPath = MetaModel::GetConfig()->GetLoadedFile();
-			@chmod($sConfigPath, 0770);
-			$oConfig = new Config($this->sConfigTmpBackupFile);
-			$oConfig->WriteToFile($sConfigPath);
-			@chmod($sConfigPath, 0444);
-			unlink($this->sConfigTmpBackupFile);
-		}
 
 		if (!empty($this->sCookieFile)) {
 			unlink($this->sCookieFile);
@@ -150,26 +135,18 @@ class CliResetSessionTest extends ItopDataTestCase
 	 */
 	private function SendHTTPRequestWithCookies($sUri, $aPostFields, $sForcedLoginMode = null): string
 	{
-		$ch = curl_init();
-
-		curl_setopt($ch, CURLOPT_COOKIEJAR, $this->sCookieFile);
-		curl_setopt($ch, CURLOPT_COOKIEFILE, $this->sCookieFile);
-
-		$sUrl = "$this->sUrl/$sUri";
 		if (!is_null($sForcedLoginMode)) {
-			$sUrl .= "?login_mode=$sForcedLoginMode";
+			$sUri .= "?login_mode=$sForcedLoginMode";
 		}
-		curl_setopt($ch, CURLOPT_URL, $sUrl);
-		curl_setopt($ch, CURLOPT_POST, 1);// set post data to true
-		curl_setopt($ch, CURLOPT_POSTFIELDS, $aPostFields);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-		curl_setopt($ch, CURLOPT_HEADER, 1);
-		// Force disable of certificate check as most of dev / test env have a self-signed certificate
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
 
-		$sResponse = curl_exec($ch);
+		$aCurlOptions = [
+			CURLOPT_COOKIEJAR => $this->sCookieFile,
+			CURLOPT_COOKIEFILE => $this->sCookieFile,
+			CURLOPT_HEADER => 1,
+		];
+
+		$sResponse = $this->CallItopUri($sUri, $aPostFields, $aCurlOptions);
+		var_dump($this->aLastCurlGetInfo);
 		/** $sResponse example
 		 *  "HTTP/1.1 200 OK
 		Date: Wed, 07 Jun 2023 05:00:40 GMT
@@ -177,16 +154,15 @@ class CliResetSessionTest extends ItopDataTestCase
 		Set-Cookie: itop-2e83d2e9b00e354fdc528621cac532ac=q7ldcjq0rvbn33ccr9q8u8e953; path=/
 		 */
 		//var_dump($sResponse);
-		$iHeaderSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+		$iHeaderSize = $this->aLastCurlGetInfo['header_size'] ?? 0;
 		$sBody = substr($sResponse, $iHeaderSize);
 
 		//$iHttpCode = intval(curl_getinfo($ch, CURLINFO_HTTP_CODE));
 		if (preg_match('/HTTP.* (\d*) /', $sResponse, $aMatches)) {
 			$sHttpCode = $aMatches[1];
 		} else {
-			$sHttpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+			$sHttpCode = $this->aLastCurlGetInfo['http_code'] ?? -1;
 		}
-		curl_close($ch);
 
 		$this->assertEquals(200, $sHttpCode, "The test logic assumes that the HTTP request is correctly handled");
 		return $sBody;

--- a/tests/php-unit-tests/unitary-tests/webservices/RestTest.php
+++ b/tests/php-unit-tests/unitary-tests/webservices/RestTest.php
@@ -17,7 +17,6 @@ class RestTest extends ItopDataTestCase
 	public const USE_TRANSACTION = false;
 	public const CREATE_TEST_ORG = false;
 
-	private static $sUrl;
 	private static $sLogin;
 	private static $sPassword = "Iuytrez9876543ç_è-(";
 
@@ -44,7 +43,6 @@ class RestTest extends ItopDataTestCase
 	{
 		parent::setUp();
 
-		static::$sUrl = MetaModel::GetConfig()->Get('app_root_url');
 		static::$sLogin = "rest-user-".date('dmYHis');
 
 		$this->CreateTestOrganization();
@@ -297,16 +295,7 @@ JSON;
 			$aPostFields['callback'] = $sCallbackName;
 		}
 
-		curl_setopt($ch, CURLOPT_URL, static::$sUrl."/webservices/rest.php");
-		curl_setopt($ch, CURLOPT_POST, 1);// set post data to true
-		curl_setopt($ch, CURLOPT_POSTFIELDS, $aPostFields);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		// Force disable of certificate check as most of dev / test env have a self-signed certificate
-		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
-
-		$sJson = curl_exec($ch);
-		curl_close($ch);
+		$sJson = $this->CallItopUri('webservices/rest.php', $aPostFields);
 
 		if (!is_null($sTmpFile)) {
 			unlink($sTmpFile);


### PR DESCRIPTION
Add few usefull APIs to ease iTop testing among:
- cleanuping in tearDown
- calling iTop from HTTP easily
- logging via IssueLog when starting a test
- backuping/restoring conf in setup/teardown