### PR TITLE
N°9337 - Update .htaccess to include 'ico' file type

### DIFF
--- a/lib/.htaccess
+++ b/lib/.htaccess
@@ -5,7 +5,7 @@
 # Apache 2.4
 <ifModule mod_authz_core.c>
 Require all denied
-	<FilesMatch ".+\.(css|scss|js|map|png|bmp|gif|jpe?g|svg|tiff|woff2?|ttf|eot)$">
+	<FilesMatch ".+\.(css|scss|js|map|ico|png|bmp|gif|jpe?g|svg|tiff|woff2?|ttf|eot)$">
 	    Require all granted
 	</FilesMatch>
 </ifModule>
@@ -14,7 +14,7 @@ Require all denied
 <ifModule !mod_authz_core.c>
 deny from all
 Satisfy All
-	<FilesMatch ".+\.(css|scss|js|map|png|bmp|gif|jpe?g|svg|tiff|woff2?|ttf|eot)$">
+	<FilesMatch ".+\.(css|scss|js|map|ico|png|bmp|gif|jpe?g|svg|tiff|woff2?|ttf|eot)$">
 	    Order Allow,Deny
 	    Allow from all
 	</FilesMatch>


### PR DESCRIPTION
Allow for .ico files coming from a customized branding extension to be displayed as favicon in the browser.

<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | No
| Type of change?                                               | Bug fix 


## Symptom (bug) 
<!---->
  - The XML Datamodel for creating extensions allows since iTop 3.2.0 to include favicons (main_favicon, portal_favicon and login_favicon)
  - The .ico file format is the original and commonly used file format for favicons
  - However, files with this extension are currently not shown on iTop instances running on Apache with recommended security settings applied.


## Reproduction procedure (bug)
<!---->
1. create an extensions that includes .ico files and place a reference to these files in the <branding> section, under <main_favicon>, <portal_favicon> and/or <login_favicon>.
2. Install this extension on iTop  3.2.2-1-17851 (installed on a LAMP stack)
4. With PHP 8.3.6
5. Login and observe the .ico file is not displayed and as a fallback the default iTop favicon is displayed.


## Cause (bug)
<!---->
For iTop instances served by Apache, the current .htaccess file in env-production prevent .ico files (located in env-production/branding) to be displayed by the browser as favicon, 
This is due to the statement: <FilesMatch ".+\.(css|scss|js|map|png|bmp|gif|jpe?g|svg|tiff|woff2?|ttf|eot)$">



## Proposed solution (bug and enhancement)
<!---->
I replaced both occurences of the statement <FilesMatch ".+\.(css|scss|js|map|png|bmp|gif|jpe?g|svg|tiff|woff2?|ttf|eot)$"> with <FilesMatch ".+\.(css|scss|js|map|ico|png|bmp|gif|jpe?g|svg|tiff|woff2?|ttf|eot)$">


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [X] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge
<!---->
Confirm that this .htaccess file is also to be copied to the env-production folder during setup of iTop.
I did not write a unit test, as there is no code to test here. The .htaccess file is a configuration file used by Apache.


