### PR TITLE
Issue/9057 super user cannot run collectors

### DIFF
--- a/datamodels/2.x/itop-profiles-itil/datamodel.itop-profiles-itil.xml
+++ b/datamodels/2.x/itop-profiles-itil/datamodel.itop-profiles-itil.xml
@@ -186,6 +186,7 @@
       <group id="AdminSysReadOnly" _delta="define">
         <classes>
           <class id="ItopFenceLogin"/>
+          <class id="ModuleInstallation"/>
         </classes>
       </group>
       <group id="AdminSys" _delta="define">

--- a/setup/moduleinstallation.class.inc.php
+++ b/setup/moduleinstallation.class.inc.php
@@ -31,7 +31,7 @@ class ModuleInstallation extends DBObject
 	{
 		$aParams =
 		[
-			"category"            => "core,view_in_gui",
+			"category"            => "core,view_in_gui,grant_by_profile",
 			"key_type"            => "autoincrement",
 			'name_attcode'        => ['name', 'version'],
 			"state_attcode"       => "",


### PR DESCRIPTION
## Pull request overview

This PR attempts to address an issue where SuperUser cannot run collectors as it requires to get objects from the ModuleInstallation class.

**Changes:**
- Added `grant_by_profile` category to ModuleInstallation class and added it to the AdminSysReadOnly group for SuperUser profile

### Reviewed changes

| File | Description |
| ---- | ----------- |
| setup/moduleinstallation.class.inc.php | Adds `grant_by_profile` category to make ModuleInstallation subject to profile-based permissions |
| datamodels/2.x/itop-profiles-itil/datamodel.itop-profiles-itil.xml | Adds ModuleInstallation to AdminSysReadOnly group;  |



