### PR TITLE
N°8681 - PHP 8.1: Fix deprecated notice for null value passed to preg_match_all()

### DIFF
--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -4259,6 +4259,9 @@ class AttributeText extends AttributeString
 
 	public static function RenderWikiHtml($sText, $bWikiOnly = false)
 	{
+		// N°8681 - Ensure to have a string value
+		$sText = $sText ?? '';
+
 		if (!$bWikiOnly) {
 			$sPattern = '/'.str_replace('/', '\/', utils::GetConfig()->Get('url_validation_pattern')).'/i';
 			if (preg_match_all(

--- a/core/inlineimage.class.inc.php
+++ b/core/inlineimage.class.inc.php
@@ -266,6 +266,9 @@ class InlineImage extends DBObject
 	 */
 	public static function FixUrls($sHtml)
 	{
+		// N°8681 - Ensure to have a string value
+		$sHtml = $sHtml ?? '';
+
 		$aNeedles = [];
 		$aReplacements = [];
 		// Find img tags with an attribute data-img-id

--- a/tests/php-unit-tests/unitary-tests/core/AttributeDefinitionTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/AttributeDefinitionTest.php
@@ -13,13 +13,6 @@ class AttributeDefinitionTest extends ItopDataTestCase
 {
 	public const CREATE_TEST_ORG = true;
 
-	protected function setUp(): void
-	{
-		parent::setUp();
-		require_once(APPROOT.'core/attributedef.class.inc.php');
-
-	}
-
 	public function testGetImportColumns()
 	{
 		$oAttributeDefinition = MetaModel::GetAttributeDef("ApplicationSolution", "status");

--- a/tests/php-unit-tests/unitary-tests/core/AttributeTextTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/AttributeTextTest.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * @copyright   Copyright (C) 2010-2026 Combodo SAS
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\Test\UnitTest\Core;
+
+use AttributeText;
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+
+class AttributeTextTest extends ItopDataTestCase
+{
+	protected \Organization $oTestOrganizationForAttributeText;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->oTestOrganizationForAttributeText = $this->CreateOrganization('Test for AttributeTextTest');
+	}
+
+	/**
+     * @covers AttributeText::RenderWikiHtml
+     */
+    public function testRenderWikiHtml_nonWikiUrlVariants()
+    {
+        // String value
+        $input = 'This hyperlink https://combodo.com should be in an anchor tag.';
+        $expected = 'This hyperlink <a href="https://combodo.com">https://combodo.com</a> should be in an anchor tag.';
+        $this->assertEquals($expected, AttributeText::RenderWikiHtml($input));
+
+        // Empty string value
+        $this->assertEquals('', AttributeText::RenderWikiHtml(''));
+
+        // Null value
+        $this->assertEquals('', AttributeText::RenderWikiHtml(null));
+    }
+
+    /**
+     * @covers AttributeText::RenderWikiHtml
+     */
+    public function testRenderWikiHtml_bWikiOnlyAbsentOrFalse_shouldTransformBothRegularAndWikiHyperlinks()
+    {
+        $input = 'A regular hyperlink https://combodo.com and a wiki hyperlink to an existing object [[Organization:'.$this->oTestOrganizationForAttributeText->GetKey().']]';
+
+		// bWikiOnly default value
+        $result = AttributeText::RenderWikiHtml($input);
+        $this->assertStringContainsString('<a href="https://combodo.com">', $result);
+        $this->assertStringContainsString('class="object-ref-link"', $result);
+
+		// bWikiOnly = false
+        $result = AttributeText::RenderWikiHtml($input, false);
+        $this->assertStringContainsString('<a href="https://combodo.com">', $result);
+        $this->assertStringContainsString('class="object-ref-link"', $result);
+    }
+
+    /**
+     * @covers AttributeText::RenderWikiHtml
+     */
+    public function testRenderWikiHtml_bWikiOnlyToTrue_shouldNotTransformRegularHyperlinkButTransformWikiHyperlink()
+    {
+        $input = 'A regular hyperlink https://combodo.com and a wiki hyperlink to an existing object [[Organization:'.$this->oTestOrganizationForAttributeText->GetKey().']]';
+        $result = AttributeText::RenderWikiHtml($input, true);
+        $this->assertStringNotContainsString('<a href="https://combodo.com">', $result);
+        $this->assertStringContainsString('class="object-ref-link"', $result);
+    }
+
+    /**
+     * @covers AttributeText::RenderWikiHtml
+     */
+    public function testRenderWikiHtml_shouldTransformWikiHyperlinkForExistingObjectsOnly()
+    {
+        $input = 'A wiki hyperlink to a non existing object [[Organization:123456789]]  and a wiki hyperlink to an existing object [[Organization:'.$this->oTestOrganizationForAttributeText->GetKey().']]';
+        $result = AttributeText::RenderWikiHtml($input);
+        $this->assertStringContainsString('wiki_broken_link', $result);
+        $this->assertStringContainsString('class="object-ref-link"', $result);
+    }
+}

--- a/tests/php-unit-tests/unitary-tests/core/AttributeTextTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/AttributeTextTest.php
@@ -25,9 +25,9 @@ class AttributeTextTest extends ItopDataTestCase
     public function testRenderWikiHtml_nonWikiUrlVariants()
     {
         // String value
-        $input = 'This hyperlink https://combodo.com should be in an anchor tag.';
-        $expected = 'This hyperlink <a href="https://combodo.com">https://combodo.com</a> should be in an anchor tag.';
-        $this->assertEquals($expected, AttributeText::RenderWikiHtml($input));
+        $sInput = 'This hyperlink https://combodo.com should be in an anchor tag.';
+        $sExpected = 'This hyperlink <a href="https://combodo.com">https://combodo.com</a> should be in an anchor tag.';
+        $this->assertEquals($sExpected, AttributeText::RenderWikiHtml($sInput));
 
         // Empty string value
         $this->assertEquals('', AttributeText::RenderWikiHtml(''));
@@ -41,17 +41,17 @@ class AttributeTextTest extends ItopDataTestCase
      */
     public function testRenderWikiHtml_bWikiOnlyAbsentOrFalse_shouldTransformBothRegularAndWikiHyperlinks()
     {
-        $input = 'A regular hyperlink https://combodo.com and a wiki hyperlink to an existing object [[Organization:'.$this->oTestOrganizationForAttributeText->GetKey().']]';
+        $sInput = 'A regular hyperlink https://combodo.com and a wiki hyperlink to an existing object [[Organization:'.$this->oTestOrganizationForAttributeText->GetKey().']]';
 
 		// bWikiOnly default value
-        $result = AttributeText::RenderWikiHtml($input);
-        $this->assertStringContainsString('<a href="https://combodo.com">', $result);
-        $this->assertStringContainsString('class="object-ref-link"', $result);
+        $sResult = AttributeText::RenderWikiHtml($sInput);
+        $this->assertStringContainsString('<a href="https://combodo.com">', $sResult);
+        $this->assertStringContainsString('class="object-ref-link"', $sResult);
 
 		// bWikiOnly = false
-        $result = AttributeText::RenderWikiHtml($input, false);
-        $this->assertStringContainsString('<a href="https://combodo.com">', $result);
-        $this->assertStringContainsString('class="object-ref-link"', $result);
+        $sResult = AttributeText::RenderWikiHtml($sInput, false);
+        $this->assertStringContainsString('<a href="https://combodo.com">', $sResult);
+        $this->assertStringContainsString('class="object-ref-link"', $sResult);
     }
 
     /**
@@ -59,10 +59,10 @@ class AttributeTextTest extends ItopDataTestCase
      */
     public function testRenderWikiHtml_bWikiOnlyToTrue_shouldNotTransformRegularHyperlinkButTransformWikiHyperlink()
     {
-        $input = 'A regular hyperlink https://combodo.com and a wiki hyperlink to an existing object [[Organization:'.$this->oTestOrganizationForAttributeText->GetKey().']]';
-        $result = AttributeText::RenderWikiHtml($input, true);
-        $this->assertStringNotContainsString('<a href="https://combodo.com">', $result);
-        $this->assertStringContainsString('class="object-ref-link"', $result);
+        $sInput = 'A regular hyperlink https://combodo.com and a wiki hyperlink to an existing object [[Organization:'.$this->oTestOrganizationForAttributeText->GetKey().']]';
+        $sResult = AttributeText::RenderWikiHtml($sInput, true);
+        $this->assertStringNotContainsString('<a href="https://combodo.com">', $sResult);
+        $this->assertStringContainsString('class="object-ref-link"', $sResult);
     }
 
     /**
@@ -70,9 +70,9 @@ class AttributeTextTest extends ItopDataTestCase
      */
     public function testRenderWikiHtml_shouldTransformWikiHyperlinkForExistingObjectsOnly()
     {
-        $input = 'A wiki hyperlink to a non existing object [[Organization:123456789]]  and a wiki hyperlink to an existing object [[Organization:'.$this->oTestOrganizationForAttributeText->GetKey().']]';
-        $result = AttributeText::RenderWikiHtml($input);
-        $this->assertStringContainsString('wiki_broken_link', $result);
-        $this->assertStringContainsString('class="object-ref-link"', $result);
+        $sInput = 'A wiki hyperlink to a non existing object [[Organization:123456789]]  and a wiki hyperlink to an existing object [[Organization:'.$this->oTestOrganizationForAttributeText->GetKey().']]';
+        $sResult = AttributeText::RenderWikiHtml($sInput);
+        $this->assertStringContainsString('wiki_broken_link', $sResult);
+        $this->assertStringContainsString('class="object-ref-link"', $sResult);
     }
 }

--- a/tests/php-unit-tests/unitary-tests/core/InlineImageTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/InlineImageTest.php
@@ -59,4 +59,43 @@ class InlineImageTest extends ItopDataTestCase
 			],
 		];
 	}
+
+	/**
+	 * @covers InlineImage::FixUrls
+	 */
+	public function testFixUrls_shouldReturnAnEmptyStringIfNullOrEmptyStringPassed()
+	{
+		$sResult = InlineImage::FixUrls(null);
+		$this->assertEquals('', $sResult);
+
+		$sResult = InlineImage::FixUrls('');
+		$this->assertEquals('', $sResult);
+	}
+
+	/**
+	 * @covers InlineImage::FixUrls
+	 */
+	public function testFixUrls_shouldReturnUnchangedValueIfValueContainsNoImage()
+	{
+		$sHtml = '<div><p>Texte sans image</p></div>';
+		$sResult = InlineImage::FixUrls($sHtml);
+		$this->assertEquals($sHtml, $sResult);
+	}
+
+	/**
+	 * @covers InlineImage::FixUrls
+	 */
+	public function testFixUrls_shouldReplaceImagesSrcWithCurrentAppRootUrlAndSecret()
+	{
+		$sHtml = <<<HTML
+<div>
+	<img src="/images/test1.png" data-img-id="123" data-img-secret="abc" />
+	<img src="/images/test2.png" data-img-id="456" data-img-secret="def" />
+</div>
+HTML;
+		$sResult = InlineImage::FixUrls($sHtml);
+		$this->assertStringContainsString('<img', $sResult);
+		$this->assertStringContainsString(\utils::EscapeHtml(\utils::GetAbsoluteUrlAppRoot().INLINEIMAGE_DOWNLOAD_URL.'123&s=abc'), $sResult);
+		$this->assertStringContainsString(\utils::EscapeHtml(\utils::GetAbsoluteUrlAppRoot().INLINEIMAGE_DOWNLOAD_URL.'456&s=def'), $sResult);
+	}
 }


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N°8681
| Type of change?                                               | Bug fix


## Symptom (bug)
```
Deprecated Passing null to parameter #2 ($subject) of type string is deprecated in core/attributedef.class.inc.php on line 4469
Deprecated Passing null to parameter #2 ($subject) of type string is deprecated in core/inlineimage.cIass.inc.php on line 291
```


## Reproduction procedure (bug)
1. On iTop 3.2.2
2. With PHP 8.1.0
3. With a particular customization ??

I could not find how to reproduce locally what we witnessed on the customer's instance...


## Cause (bug)
**Shallow cause:**
In `AttributeText::GetAsHTML()`, `$sValue` seems to be `null` in some cases, which when passed to `AttributeText::RenderWikiHtml()` and `InlineImage::FixUrls()` will be passed to `preg_match_all()` in the `$subject` parameter that as of PHP 8.1 only supports `string` values.

**Root cause:**
How we happen to pass `null` in `AttributeText::GetAsHTML()` remains a mystery for now.

## Proposed solution (bug and enhancement)
Even though we can't find where the `null` comes from, we can harden the `AttributeText::RenderWikiHtml()` and `InlineImage::FixUrls()` methods so they convert `null` values to `string`. Minimizing the risk of regression while fixing the issue.

During the merge into 3.3 branch, I suggest to also change the `AttributeText::RenderWikiHtml()` and `InlineImage::FixUrls()` methods  prototype to type the relevant parameter to `string|null`.


## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge
