### PR TITLE
N°8851 N°8854 - PHP 8.4: Fix explicit nullable in functions parameters + replace trigger_error() usage with E_USER_ERROR

### DIFF
--- a/application/cmdbabstract.class.inc.php
+++ b/application/cmdbabstract.class.inc.php
@@ -6037,7 +6037,7 @@ JS
 	 * @return void
 	 * @since 3.1.0
 	 */
-	final public function AddAttributeFlags(string $sAttCode, int $iFlags, string $sTargetState = '', string $sReason = null): void
+	final public function AddAttributeFlags(string $sAttCode, int $iFlags, string $sTargetState = '', ?string $sReason = null): void
 	{
 		if (!isset($this->aAttributesFlags[$sTargetState])) {
 			$this->aAttributesFlags[$sTargetState] = [];
@@ -6060,7 +6060,7 @@ JS
 	 * @return void
 	 * @since 3.1.0
 	 */
-	final public function ForceAttributeFlags(string $sAttCode, int $iFlags, string $sTargetState = '', string $sReason = null): void
+	final public function ForceAttributeFlags(string $sAttCode, int $iFlags, string $sTargetState = '', ?string $sReason = null): void
 	{
 		if (!isset($this->aAttributesFlags[$sTargetState])) {
 			$this->aAttributesFlags[$sTargetState] = [];
@@ -6101,7 +6101,7 @@ JS
 	 * @return void
 	 * @since 3.1.0
 	 */
-	final public function AddInitialAttributeFlags(string $sAttCode, int $iFlags, string $sReason = null)
+	final public function AddInitialAttributeFlags(string $sAttCode, int $iFlags, ?string $sReason = null)
 	{
 		if (!isset($this->aInitialAttributesFlags)) {
 			$this->aInitialAttributesFlags = [];
@@ -6123,7 +6123,7 @@ JS
 	 * @return void
 	 * @since 3.1.0
 	 */
-	final public function ForceInitialAttributeFlags(string $sAttCode, int $iFlags, string $sReason = null)
+	final public function ForceInitialAttributeFlags(string $sAttCode, int $iFlags, ?string $sReason = null)
 	{
 		if (!isset($this->aInitialAttributesFlags)) {
 			$this->aInitialAttributesFlags = [];

--- a/application/newsroomprovider.class.inc.php
+++ b/application/newsroomprovider.class.inc.php
@@ -34,7 +34,7 @@ interface iNewsroomProvider
 	 * @param User $oUser The user for who to check if the provider is applicable.
 	 * return bool
 	 */
-	public function IsApplicable(User $oUser = null);
+	public function IsApplicable(?User $oUser = null);
 
 	/**
 	 * The human readable (localized) label for this provider
@@ -139,7 +139,7 @@ abstract class NewsroomProviderBase implements iNewsroomProvider
 	 */
 	abstract public function GetViewAllURL();
 
-	public function IsApplicable(User $oUser = null)
+	public function IsApplicable(?User $oUser = null)
 	{
 		return false;
 	}

--- a/application/query.class.inc.php
+++ b/application/query.class.inc.php
@@ -151,7 +151,7 @@ abstract class Query extends cmdbAbstractObject
 	 * @return string|null
 	 * @since 3.1.0
 	 */
-	abstract public function GetExportUrl(array $aValues = null): ?string;
+	abstract public function GetExportUrl(?array $aValues = null): ?string;
 
 	/**
 	 * Update last export information.
@@ -227,7 +227,7 @@ class QueryOQL extends Query
 	}
 
 	/** @inheritdoc */
-	public function GetExportUrl(array $aValues = null): ?string
+	public function GetExportUrl(?array $aValues = null): ?string
 	{
 		try {
 			// retrieve attributes

--- a/application/utils.inc.php
+++ b/application/utils.inc.php
@@ -1284,7 +1284,7 @@ class utils
 	 * @throws \CoreException
 	 * @throws \Exception
 	 */
-	public static function ExecITopScript(string $sScriptName, array $aArguments, string $sAuthUser = null, string $sAuthPwd = null)
+	public static function ExecITopScript(string $sScriptName, array $aArguments, ?string $sAuthUser = null, ?string $sAuthPwd = null)
 	{
 		$aDisabled = explode(', ', ini_get('disable_functions'));
 		if (in_array('exec', $aDisabled)) {
@@ -1374,7 +1374,7 @@ class utils
 	 * @return string A path to a folder into which any module can store cache data
 	 * The corresponding folder is created or cleaned upon code compilation
 	 */
-	public static function GetCachePath(string $sEnvironment = null): string
+	public static function GetCachePath(?string $sEnvironment = null): string
 	{
 		if (is_null($sEnvironment)) {
 			$sEnvironment = MetaModel::GetEnvironment();

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -912,7 +912,7 @@ abstract class AttributeDefinition
 		return call_user_func($sComputeFunc);
 	}
 
-	abstract public function GetDefaultValue(DBObject $oHostObject = null);
+	abstract public function GetDefaultValue(?DBObject $oHostObject = null);
 
 	//
 	// To be overloaded in subclasses
@@ -1476,7 +1476,7 @@ class AttributeDashboard extends AttributeDefinition
 		return "";
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return null;
 	}
@@ -1622,7 +1622,7 @@ class AttributeLinkedSet extends AttributeDefinition
 	 * @throws \CoreException
 	 * @throws \CoreWarning
 	 */
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		if ($oHostObject === null) {
 			return null;
@@ -2639,7 +2639,7 @@ class AttributeDBFieldVoid extends AttributeDefinition
 		return $this->Get("sql");
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return $this->MakeRealValue("", $oHostObject);
 	}
@@ -2728,7 +2728,7 @@ class AttributeDBField extends AttributeDBFieldVoid
 		return array_merge(parent::ListExpectedParams(), ["default_value", "is_null_allowed"]);
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return $this->MakeRealValue($this->Get("default_value"), $oHostObject);
 	}
@@ -2917,7 +2917,7 @@ class AttributeObjectKey extends AttributeDBFieldVoid
 		return "INT(11)".($bFullSpec ? " DEFAULT 0" : "");
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return 0;
 	}
@@ -3649,7 +3649,7 @@ class AttributeClass extends AttributeString
 		parent::__construct($sCode, $aParams);
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		$sDefault = parent::GetDefaultValue($oHostObject);
 		if (!$this->IsNullAllowed() && $this->IsNull($sDefault)) {
@@ -3843,7 +3843,7 @@ class AttributeFinalClass extends AttributeString
 		$this->m_sValue = $sValue;
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return $this->m_sValue;
 	}
@@ -4730,7 +4730,7 @@ class AttributeCaseLog extends AttributeLongText
 		}
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return new ormCaseLog();
 	}
@@ -6128,7 +6128,7 @@ class AttributeDateTime extends AttributeDBField
 		return $iUnixSeconds;
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		$sDefaultValue = $this->Get('default_value');
 		if (utils::IsNotNullOrEmptyString($sDefaultValue)) {
@@ -6812,7 +6812,7 @@ class AttributeExternalKey extends AttributeDBFieldVoid
 		return $this->GetOptional('display_style', 'select');
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return 0;
 	}
@@ -7547,7 +7547,7 @@ class AttributeExternalField extends AttributeDefinition
 		return $oExtAttDef->GetSQLExpr();
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		$oExtAttDef = $this->GetExtAttDef();
 
@@ -7910,12 +7910,12 @@ class AttributeBlob extends AttributeDefinition
 		return true;
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return new ormDocument('', '', '');
 	}
 
-	public function IsNullAllowed(DBObject $oHostObject = null)
+	public function IsNullAllowed(?DBObject $oHostObject = null)
 	{
 		return $this->GetOptional("is_null_allowed", false);
 	}
@@ -8295,7 +8295,7 @@ class AttributeImage extends AttributeBlob
 		return $oDoc;
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return new ormDocument('', '', '');
 	}
@@ -8481,7 +8481,7 @@ class AttributeStopWatch extends AttributeDefinition
 		return true;
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return $this->NewStopWatch();
 	}
@@ -9348,7 +9348,7 @@ class AttributeSubItem extends AttributeDefinition
 		return false;
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return null;
 	}
@@ -9566,7 +9566,7 @@ class AttributeOneWayPassword extends AttributeDefinition implements iAttributeN
 		return true;
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return "";
 	}
@@ -10146,7 +10146,7 @@ abstract class AttributeSet extends AttributeDBFieldVoid
 		return true;
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return null;
 	}
@@ -11359,7 +11359,7 @@ class AttributeTagSet extends AttributeSet
 		return new ormTagSet(MetaModel::GetAttributeOrigin($this->GetHostClass(), $this->GetCode()), $this->GetCode(), $this->GetMaxItems());
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		$oTagSet =  new ormTagSet(MetaModel::GetAttributeOrigin($this->GetHostClass(), $this->GetCode()), $this->GetCode(), $this->GetMaxItems());
 		$oTagSet->SetValues([]);
@@ -11867,7 +11867,7 @@ class AttributeFriendlyName extends AttributeDefinition
 		$this->m_sValue = $sValue;
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return $this->m_sValue;
 	}
@@ -12030,7 +12030,7 @@ class AttributeRedundancySettings extends AttributeDBField
 		return 20;
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		$sRet = 'disabled';
 		if ($this->Get('enabled')) {
@@ -12466,7 +12466,7 @@ class AttributeCustomFields extends AttributeDefinition
 		return false;
 	} // See ReadValue...
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return new ormCustomFieldsValue($oHostObject, $this->GetCode());
 	}
@@ -13053,7 +13053,7 @@ class AttributeObsolescenceFlag extends AttributeBoolean
 		return null;
 	}
 
-	public function GetDefaultValue(DBObject $oHostObject = null)
+	public function GetDefaultValue(?DBObject $oHostObject = null)
 	{
 		return $this->MakeRealValue(false, $oHostObject);
 	}

--- a/core/bulkchange.class.inc.php
+++ b/core/bulkchange.class.inc.php
@@ -199,7 +199,7 @@ class CellStatus_SearchIssue extends CellStatus_Issue
 	 * @param null $sAllowedValues : used for additional message that provides allowed values $sAllowedValues for current class
 	 * @param string|null $sAllowedValuesSearch : used to search all allowed values
 	 */
-	public function __construct($sSerializedSearch, $sReason, $sClass = null, $sAllowedValues = null, string $sAllowedValuesSearch = null)
+	public function __construct($sSerializedSearch, $sReason, $sClass = null, $sAllowedValues = null, ?string $sAllowedValuesSearch = null)
 	{
 		parent::__construct(null, null, $sReason);
 		$this->sSerializedSearch = $sSerializedSearch;
@@ -873,7 +873,7 @@ class BulkChange
 		return $aResults;
 	}
 
-	protected function CreateObject(&$aResult, $iRow, $aRowData, CMDBChange $oChange = null)
+	protected function CreateObject(&$aResult, $iRow, $aRowData, ?CMDBChange $oChange = null)
 	{
 		$oTargetObj = MetaModel::NewObject($this->m_sClass);
 
@@ -962,7 +962,7 @@ class BulkChange
 	 * @throws \MySQLException
 	 * @throws \MySQLHasGoneAwayException
 	 */
-	protected function UpdateObject(&$aResult, $iRow, $oTargetObj, $aRowData, CMDBChange $oChange = null)
+	protected function UpdateObject(&$aResult, $iRow, $oTargetObj, $aRowData, ?CMDBChange $oChange = null)
 	{
 		$aResult[$iRow] = $this->PrepareObject($oTargetObj, $aRowData, $aErrors);
 
@@ -1005,7 +1005,7 @@ class BulkChange
 	 *
 	 * @throws \BulkChangeException
 	 */
-	protected function UpdateMissingObject(&$aResult, $iRow, $oTargetObj, CMDBChange $oChange = null)
+	protected function UpdateMissingObject(&$aResult, $iRow, $oTargetObj, ?CMDBChange $oChange = null)
 	{
 		$aResult[$iRow] = $this->PrepareMissingObject($oTargetObj, $aErrors);
 
@@ -1040,7 +1040,7 @@ class BulkChange
 		}
 	}
 
-	public function Process(CMDBChange $oChange = null)
+	public function Process(?CMDBChange $oChange = null)
 	{
 		if ($oChange) {
 			CMDBObject::SetCurrentChange($oChange);

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -2569,7 +2569,7 @@ abstract class DBObject implements iDisplay
 	 *
 	 * @see \RestUtils::FindObjectFromKey for the same check in the REST endpoint
 	 */
-	final public function CheckChangedExtKeysValues(callable $oIsObjectLoadableCallback = null)
+	final public function CheckChangedExtKeysValues(?callable $oIsObjectLoadableCallback = null)
 	{
 		if (is_null($oIsObjectLoadableCallback)) {
 			$oIsObjectLoadableCallback = function ($sClass, $sId) {
@@ -3729,7 +3729,7 @@ abstract class DBObject implements iDisplay
 	 * @throws \MySQLException
 	 * @throws \OQLException
 	 */
-	private function ActivateOnObjectUpdateTriggers(?DBObject $oObject, array $aAttributes = null): void
+	private function ActivateOnObjectUpdateTriggers(?DBObject $oObject, ?array $aAttributes = null): void
 	{
 		if (is_null($oObject)) {
 			return;

--- a/core/dbsearch.class.php
+++ b/core/dbsearch.class.php
@@ -724,7 +724,7 @@ abstract class DBSearch
 	 *
 	 * @throws OQLException
 	 */
-	public static function FromOQL($sQuery, $aParams = null, ModelReflection $oMetaModel = null)
+	public static function FromOQL($sQuery, $aParams = null, ?ModelReflection $oMetaModel = null)
 	{
 		if (empty($sQuery)) {
 			return null;

--- a/core/designdocument.class.inc.php
+++ b/core/designdocument.class.inc.php
@@ -453,7 +453,7 @@ class DesignElement extends \DOMElement
 	 * @throws Exception
 	 * @since 3.1.2 3.2.0 N°6974
 	 */
-	public static function _FindNode(DOMNode $oParent, DesignElement $oRefNode, string $sSearchId = null): ?DesignElement
+	public static function _FindNode(DOMNode $oParent, DesignElement $oRefNode, ?string $sSearchId = null): ?DesignElement
 	{
 		$oNodes = self::_FindNodes($oParent, $oRefNode, $sSearchId);
 		if ($oNodes instanceof DOMNodeList) {
@@ -477,7 +477,7 @@ class DesignElement extends \DOMElement
 	 * @return \DOMNodeList|false|mixed
 	 * @since 3.1.2 3.2.0 N°6974
 	 */
-	public static function _FindNodes(DOMNode $oParent, DesignElement $oRefNode, string $sSearchId = null)
+	public static function _FindNodes(DOMNode $oParent, DesignElement $oRefNode, ?string $sSearchId = null)
 	{
 		if ($oParent instanceof DOMDocument) {
 			$oDoc = $oParent->firstChild->ownerDocument;

--- a/core/displayablegraph.class.inc.php
+++ b/core/displayablegraph.class.inc.php
@@ -632,7 +632,7 @@ class DisplayableGroupNode extends DisplayableNode
 		$this->aObjects = [];
 	}
 
-	public function AddObject(DBObject $oObj = null)
+	public function AddObject(?DBObject $oObj = null)
 	{
 		if (is_object($oObj)) {
 			$sPrevClass = $this->GetObjectClass();

--- a/core/oql/build/PHP/ParserGenerator/Data.php
+++ b/core/oql/build/PHP/ParserGenerator/Data.php
@@ -1656,7 +1656,7 @@ class PHP_ParserGenerator_Data
     function emit_code($out, PHP_ParserGenerator_Rule $rp, &$lineno)
     {
         $linecnt = 0;
-        
+
         /* Generate code to do the reduce action */
         if ($rp->code) {
             $this->tplt_linedir($out, $rp->line, $this->filename);

--- a/core/oql/oql-parser.php
+++ b/core/oql/oql-parser.php
@@ -1094,7 +1094,7 @@ static public $yy_action = array(
     function yy_find_shift_action($iLookAhead)
     {
         $stateno = $this->yystack[$this->yyidx]->stateno;
-     
+
         /* if ($this->yyidx < 0) return self::YY_NO_ACTION;  */
         if (!isset(self::$yy_shift_ofst[$stateno])) {
             // no shift actions
@@ -1781,7 +1781,7 @@ throw new OQLParserParseFailureException($this->m_sSourceQuery, $this->m_iLine, 
     function yy_syntax_error($yymajor, $TOKEN)
     {
 #line 25 "..\oql-parser.y"
- 
+
 throw new OQLParserSyntaxErrorException($this->m_sSourceQuery, $this->m_iLine, $this->m_iCol, $this->tokenName($yymajor), $TOKEN);
 #line 1793 "..\oql-parser.php"
     }
@@ -1820,7 +1820,7 @@ throw new OQLParserSyntaxErrorException($this->m_sSourceQuery, $this->m_iLine, $
 //        $yyact;            /* The parser action. */
 //        $yyendofinput;     /* True if we are at the end of input */
         $yyerrorhit = 0;   /* True if yymajor has invoked an error */
-        
+
         /* (re)initialize the parser, if necessary */
         if ($this->yyidx === null || $this->yyidx < 0) {
             /* if ($yymajor == 0) return; // not sure why this was here... */
@@ -1833,7 +1833,7 @@ throw new OQLParserSyntaxErrorException($this->m_sSourceQuery, $this->m_iLine, $
             array_push($this->yystack, $x);
         }
         $yyendofinput = ($yymajor==0);
-        
+
         if (self::$yyTraceFILE) {
             fprintf(
                 self::$yyTraceFILE,
@@ -1842,7 +1842,7 @@ throw new OQLParserSyntaxErrorException($this->m_sSourceQuery, $this->m_iLine, $
                 self::$yyTokenName[$yymajor]
             );
         }
-        
+
         do {
             $yyact = $this->yy_find_shift_action($yymajor);
             if ($yymajor < self::YYERRORSYMBOL
@@ -2016,7 +2016,7 @@ class OQLParser extends OQLParserRaw
 		$this->m_sSourceQuery = $sQuery;
 		// no constructor - parent::__construct();
 	}
-	
+
 	public function doParse($token, $value, $iCurrPosition = 0)
 	{
 		$this->m_iColPrev = $this->m_iCol;
@@ -2030,7 +2030,7 @@ class OQLParser extends OQLParserRaw
 		$this->doParse(0, 0);
 		return $this->my_result;
 	}
-	
+
 	public function __destruct()
 	{
 		// Bug in the original destructor, causing an infinite loop !

--- a/core/ormcaselog.class.inc.php
+++ b/core/ormcaselog.class.inc.php
@@ -370,7 +370,7 @@ class ormCaseLog
 	/**
 	 * Produces an HTML representation, aimed at being used within the iTop framework
 	 */
-	public function GetAsHTML(WebPage $oP = null, $bEditMode = false, $aTransfoHandler = null)
+	public function GetAsHTML(?WebPage $oP = null, $bEditMode = false, $aTransfoHandler = null)
 	{
 		$bPrintableVersion = (utils::ReadParam('printable', '0') == '1');
 

--- a/core/ormlinkset.class.inc.php
+++ b/core/ormlinkset.class.inc.php
@@ -93,7 +93,7 @@ class ormLinkSet implements iDBObjectSetIterator, Iterator, SeekableIterator
 	 * @param DBObjectSet|null $oOriginalSet
 	 * @throws Exception
 	 */
-	public function __construct($sHostClass, $sAttCode, DBObjectSet $oOriginalSet = null)
+	public function __construct($sHostClass, $sAttCode, ?DBObjectSet $oOriginalSet = null)
 	{
 		$this->sHostClass = $sHostClass;
 		$this->sAttCode = $sAttCode;

--- a/datamodels/2.x/itop-backup/dbrestore.class.inc.php
+++ b/datamodels/2.x/itop-backup/dbrestore.class.inc.php
@@ -24,7 +24,7 @@ class DBRestore extends DBBackup
 	/** @var string */
 	private $sDBUser;
 
-	public function __construct(\Config $oConfig = null)
+	public function __construct(?\Config $oConfig = null)
 	{
 		parent::__construct($oConfig);
 

--- a/datamodels/2.x/itop-hub-connector/hubnewsroomprovider.class.inc.php
+++ b/datamodels/2.x/itop-hub-connector/hubnewsroomprovider.class.inc.php
@@ -18,7 +18,7 @@ class HubNewsroomProvider extends NewsroomProviderBase
 	 * {@inheritDoc}
 	 * @see NewsroomProviderBase::IsApplicable()
 	 */
-	public function IsApplicable(User $oUser = null)
+	public function IsApplicable(?User $oUser = null)
 	{
 		if ($oUser !== null) {
 			return UserRights::IsAdministrator($oUser);

--- a/datamodels/2.x/itop-portal-base/portal/src/DataCollector/PortalCollector.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/DataCollector/PortalCollector.php
@@ -27,7 +27,7 @@ class PortalCollector extends AbstractDataCollector
 	}
 
 	/** @inheritdoc  */
-	public function collect(Request $request, Response $response, Throwable $exception = null): void
+	public function collect(Request $request, Response $response, ?Throwable $exception = null): void
 	{
 		$oRegister = $this->oTemplatesProviderService->GetRegister();
 		$aTemplatesDefinitions = $oRegister->GetTemplatesDefinitions();

--- a/datamodels/2.x/itop-portal-base/portal/src/Helper/ObjectFormHandlerHelper.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Helper/ObjectFormHandlerHelper.php
@@ -129,7 +129,7 @@ class ObjectFormHandlerHelper
 	 * @throws \OQLException
 	 * @throws \Exception
 	 */
-	public function HandleForm(Request $oRequest, $sMode, $sObjectClass, $sObjectId = null, array $aFormProperties = null)
+	public function HandleForm(Request $oRequest, $sMode, $sObjectClass, $sObjectId = null, ?array $aFormProperties = null)
 	{
 		$aFormData = [];
 		$sOperation = $this->oRequestManipulator->ReadParam('operation', '');

--- a/datamodels/2.x/itop-portal-base/portal/src/Twig/AppVariable.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Twig/AppVariable.php
@@ -40,7 +40,7 @@ class AppVariable implements ArrayAccess
 	/** @var DecoratedAppVariable */
 	private $decorated;
 
-	public function __construct(DecoratedAppVariable $decorated, ContainerInterface $container = null)
+	public function __construct(DecoratedAppVariable $decorated, ?ContainerInterface $container = null)
 	{
 		$this->decorated = $decorated;
 		$this->container = $container;

--- a/datamodels/2.x/itop-portal-base/portal/src/Twig/TemplatesTwigExtension.php
+++ b/datamodels/2.x/itop-portal-base/portal/src/Twig/TemplatesTwigExtension.php
@@ -57,7 +57,7 @@ class TemplatesTwigExtension extends AbstractExtension
 	 * @return string the template path
 	 * @throws \ReflectionException
 	 */
-	public function GetTemplate(string $sId, string $sProviderClass = self::DEFAULT_PROVIDER_CLASS, object $oProviderInstance = null): string
+	public function GetTemplate(string $sId, string $sProviderClass = self::DEFAULT_PROVIDER_CLASS, ?object $oProviderInstance = null): string
 	{
 		if ($oProviderInstance === null) {
 			return $this->oTemplatesService->GetTemplatePath($sProviderClass, $sId);

--- a/setup/backup.class.inc.php
+++ b/setup/backup.class.inc.php
@@ -152,7 +152,7 @@ class DBBackup
 	 * @return string Name of the backup file WITHOUT the file extension (eg. `.tar.gz`)
 	 * @since 3.1.0 N°5279 Add $oDateTime parameter
 	 */
-	public function MakeName(string $sNameSpec = "__DB__-%Y-%m-%d", DateTime $oDateTime = null)
+	public function MakeName(string $sNameSpec = "__DB__-%Y-%m-%d", ?DateTime $oDateTime = null)
 	{
 		if ($oDateTime === null) {
 			$oDateTime = new DateTime();

--- a/setup/compiler.class.inc.php
+++ b/setup/compiler.class.inc.php
@@ -38,7 +38,7 @@ class DOMFormatException extends Exception
 	 * @param $previous
 	 * @param DesignElement|null $node DOMNode causing the DOMFormatException
 	 */
-	public function __construct($message, $code = 0, $previous = null, DesignElement $node = null)
+	public function __construct($message, $code = 0, $previous = null, ?DesignElement $node = null)
 	{
 		if ($node !== null) {
 			$message .= ' ('.MFDocument::GetItopNodePath($node).' at line '.$node->getLineNo().')';
@@ -930,7 +930,7 @@ EOF
 	 *
 	 * @since 3.0.0 Add param. $bAddQuotes to be equivalent to {@see self::GetMandatoryPropString} and allow retrieving property without surrounding single quotes
 	 */
-	protected function GetPropString($oNode, string $sTag, string $sDefault = null, bool $bAddQuotes = true)
+	protected function GetPropString($oNode, string $sTag, ?string $sDefault = null, bool $bAddQuotes = true)
 	{
 		$val = $oNode->GetChildText($sTag);
 		if (is_null($val)) {

--- a/setup/modelfactory.class.inc.php
+++ b/setup/modelfactory.class.inc.php
@@ -2399,7 +2399,7 @@ class MFDocument extends \Combodo\iTop\DesignDocument
 	 */
 	// Return type union is not supported by PHP 7.4, we can remove the following PHP attribute and add the return type once iTop min PHP version is PHP 8.0+
 	#[\ReturnTypeWillChange]
-	public function saveXML(DOMNode $node = null, $options = 0)
+	public function saveXML(?DOMNode $node = null, $options = 0)
 	{
 		$oRootNode = $this->firstChild;
 		if (!$oRootNode) {

--- a/sources/Application/Helper/CKEditorHelper.php
+++ b/sources/Application/Helper/CKEditorHelper.php
@@ -126,7 +126,7 @@ class CKEditorHelper
 	 *
 	 * @return string|null
 	 */
-	public static function PrepareCKEditorValueTextEncodingForTextarea(string $sValue = null): ?string
+	public static function PrepareCKEditorValueTextEncodingForTextarea(?string $sValue = null): ?string
 	{
 		if ($sValue === null) {
 			return null;
@@ -145,7 +145,7 @@ class CKEditorHelper
 	 *
 	 * @return void
 	 */
-	public static function ConfigureCKEditorElementForWebPage(WebPage $oPage, string $sInputElementId, string $sInitialValue = null, bool $bWithMentions = false, array $aOverloadConfiguration = []): void
+	public static function ConfigureCKEditorElementForWebPage(WebPage $oPage, string $sInputElementId, ?string $sInitialValue = null, bool $bWithMentions = false, array $aOverloadConfiguration = []): void
 	{
 		// link CKEditor JS files
 		foreach (static::GetJSFilesRelPathsForCKEditor() as $sFile) {
@@ -187,7 +187,7 @@ class CKEditorHelper
 	 *
 	 * @return void
 	 */
-	public static function ConfigureCKEditorElementForRenderingOutput(RenderingOutput $oOutput, string $sInputElementId, string $sInitialValue = null, bool $bWithMentions = false, bool $bAddJSFiles = true, array $aOverloadConfiguration = []): void
+	public static function ConfigureCKEditorElementForRenderingOutput(RenderingOutput $oOutput, string $sInputElementId, ?string $sInitialValue = null, bool $bWithMentions = false, bool $bAddJSFiles = true, array $aOverloadConfiguration = []): void
 	{
 		// link CKEditor JS files
 		if ($bAddJSFiles) {
@@ -282,7 +282,7 @@ HTML;
 	 * @throws \ConfigException
 	 * @throws \CoreException
 	 */
-	public static function GetDOMSanitizerForCKEditor(DOMSanitizer $oSanitizer = null): array
+	public static function GetDOMSanitizerForCKEditor(?DOMSanitizer $oSanitizer = null): array
 	{
 		if ($oSanitizer === null) {
 			/* @var $oSanitizer DOMSanitizer */

--- a/sources/Application/Newsroom/iTopNewsroomProvider.php
+++ b/sources/Application/Newsroom/iTopNewsroomProvider.php
@@ -18,7 +18,7 @@ use User;
  */
 class iTopNewsroomProvider extends NewsroomProviderBase
 {
-	public function IsApplicable(User $oUser = null)
+	public function IsApplicable(?User $oUser = null)
 	{
 		return true;
 	}

--- a/sources/Application/Status/Status.php
+++ b/sources/Application/Status/Status.php
@@ -16,7 +16,7 @@ class Status
 	 * @throws \DictExceptionUnknownLanguage
 	 * @throws \MySQLException
 	 */
-	public function __construct(Config $oConfig = null)
+	public function __construct(?Config $oConfig = null)
 	{
 		$this->StatusStartup($oConfig);
 	}
@@ -74,7 +74,7 @@ class Status
 	 * @throws \DictExceptionUnknownLanguage
 	 * @throws \MySQLException
 	 */
-	private function StatusStartup(Config $oConfig = null)
+	private function StatusStartup(?Config $oConfig = null)
 	{
 		$this->StatusCheckConfigFile();
 

--- a/sources/Application/UI/Base/Component/Button/Button.php
+++ b/sources/Application/UI/Base/Component/Button/Button.php
@@ -96,7 +96,7 @@ class Button extends UIBlock
 	 * @param string $sJsCode
 	 * @param string $sOnClickJsCode
 	 */
-	public function __construct(string $sLabel, string $sId = null, string $sTooltip = '', string $sIconClass = '', string $sActionType = self::DEFAULT_ACTION_TYPE, string $sColorScheme = self::DEFAULT_COLOR_SCHEME, string $sJsCode = '', string $sOnClickJsCode = '')
+	public function __construct(string $sLabel, ?string $sId = null, string $sTooltip = '', string $sIconClass = '', string $sActionType = self::DEFAULT_ACTION_TYPE, string $sColorScheme = self::DEFAULT_COLOR_SCHEME, string $sJsCode = '', string $sOnClickJsCode = '')
 	{
 		// We only use resource ID (not sanitized) on button for now, but this might be reworked back into \UIBlock if needed
 		if (!is_null($sId)) {

--- a/sources/Application/UI/Base/Component/Button/ButtonJS.php
+++ b/sources/Application/UI/Base/Component/Button/ButtonJS.php
@@ -67,7 +67,7 @@ class ButtonJS extends Button
 	 */
 	public function __construct(
 		string $sLabel,
-		string $sId = null,
+		?string $sId = null,
 		string $sName = '',
 		string $sValue = '',
 		string $sType = self::DEFAULT_TYPE,

--- a/sources/Application/UI/Base/Component/Button/ButtonUIBlockFactory.php
+++ b/sources/Application/UI/Base/Component/Button/ButtonUIBlockFactory.php
@@ -55,7 +55,7 @@ class ButtonUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Button\Button
 	 */
-	public static function MakeNeutral(string $sLabel, string $sName = null, ?string $sId = null)
+	public static function MakeNeutral(string $sLabel, ?string $sName = null, ?string $sId = null)
 	{
 		$oButton = new ButtonJS($sLabel, $sId);
 		$oButton->SetActionType(Button::ENUM_ACTION_TYPE_REGULAR)
@@ -81,8 +81,8 @@ class ButtonUIBlockFactory extends AbstractUIBlockFactory
 	 */
 	public static function MakeForPrimaryAction(
 		string $sLabel,
-		string $sName = null,
-		string $sValue = null,
+		?string $sName = null,
+		?string $sValue = null,
 		bool $bIsSubmit = false,
 		?string $sId = null
 	) {
@@ -102,8 +102,8 @@ class ButtonUIBlockFactory extends AbstractUIBlockFactory
 	 */
 	public static function MakeForSecondaryAction(
 		string $sLabel,
-		string $sName = null,
-		string $sValue = null,
+		?string $sName = null,
+		?string $sValue = null,
 		bool $bIsSubmit = false,
 		?string $sId = null
 	) {
@@ -123,8 +123,8 @@ class ButtonUIBlockFactory extends AbstractUIBlockFactory
 	 */
 	public static function MakeForPositiveAction(
 		string $sLabel,
-		string $sName = null,
-		string $sValue = null,
+		?string $sName = null,
+		?string $sValue = null,
 		bool $bIsSubmit = false,
 		?string $sId = null
 	) {
@@ -145,8 +145,8 @@ class ButtonUIBlockFactory extends AbstractUIBlockFactory
 	 */
 	public static function MakeForDestructiveAction(
 		string $sLabel,
-		string $sName = null,
-		string $sValue = null,
+		?string $sName = null,
+		?string $sValue = null,
 		bool $bIsSubmit = false,
 		?string $sId = null
 	) {
@@ -178,8 +178,8 @@ class ButtonUIBlockFactory extends AbstractUIBlockFactory
 	 */
 	public static function MakeAlternativeNeutral(
 		string $sLabel,
-		string $sName = null,
-		string $sValue = null,
+		?string $sName = null,
+		?string $sValue = null,
 		bool $bIsSubmit = false,
 		?string $sId = null
 	) {
@@ -208,8 +208,8 @@ class ButtonUIBlockFactory extends AbstractUIBlockFactory
 	 */
 	public static function MakeForAlternativePrimaryAction(
 		string $sLabel,
-		string $sName = null,
-		string $sValue = null,
+		?string $sName = null,
+		?string $sValue = null,
 		bool $bIsSubmit = false,
 		?string $sId = null
 	) {
@@ -237,8 +237,8 @@ class ButtonUIBlockFactory extends AbstractUIBlockFactory
 	 */
 	public static function MakeForAlternativeSecondaryAction(
 		string $sLabel,
-		string $sName = null,
-		string $sValue = null,
+		?string $sName = null,
+		?string $sValue = null,
 		bool $bIsSubmit = false,
 		?string $sId = null
 	) {
@@ -266,8 +266,8 @@ class ButtonUIBlockFactory extends AbstractUIBlockFactory
 	 */
 	public static function MakeForAlternativeValidationAction(
 		string $sLabel,
-		string $sName = null,
-		string $sValue = null,
+		?string $sName = null,
+		?string $sValue = null,
 		bool $bIsSubmit = false,
 		?string $sId = null
 	) {
@@ -295,8 +295,8 @@ class ButtonUIBlockFactory extends AbstractUIBlockFactory
 	 */
 	public static function MakeForAlternativeDestructiveAction(
 		string $sLabel,
-		string $sName = null,
-		string $sValue = null,
+		?string $sName = null,
+		?string $sValue = null,
 		bool $bIsSubmit = false,
 		?string $sId = null
 	) {
@@ -323,9 +323,9 @@ class ButtonUIBlockFactory extends AbstractUIBlockFactory
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Button\Button
 	 */
 	public static function MakeForCancel(
-		string $sLabel = null,
-		string $sName = null,
-		string $sValue = null,
+		?string $sLabel = null,
+		?string $sName = null,
+		?string $sValue = null,
 		bool $bIsSubmit = false,
 		?string $sId = null
 	) {
@@ -356,8 +356,8 @@ class ButtonUIBlockFactory extends AbstractUIBlockFactory
 	public static function MakeIconAction(
 		string $sIconClasses,
 		string $sTooltipText = '',
-		string $sName = null,
-		string $sValue = null,
+		?string $sName = null,
+		?string $sValue = null,
 		bool $bIsSubmit = false,
 		?string $sId = null
 	) {
@@ -483,8 +483,8 @@ class ButtonUIBlockFactory extends AbstractUIBlockFactory
 		string $sLabel,
 		string $sColor,
 		string $sActionType,
-		string $sValue = null,
-		string $sName = null,
+		?string $sValue = null,
+		?string $sName = null,
 		bool $bIsSubmit = false,
 		?string $sId = null
 	) {
@@ -528,7 +528,7 @@ class ButtonUIBlockFactory extends AbstractUIBlockFactory
 		string $sURL,
 		string $sColor,
 		string $sActionType,
-		string $sTarget = null,
+		?string $sTarget = null,
 		?string $sId = null
 	) {
 		$oButton = new ButtonURL($sLabel, $sURL, $sId, $sTarget);

--- a/sources/Application/UI/Base/Component/Button/ButtonURL.php
+++ b/sources/Application/UI/Base/Component/Button/ButtonURL.php
@@ -67,7 +67,7 @@ class ButtonURL extends Button
 	public function __construct(
 		string $sLabel,
 		string $sURL,
-		string $sId = null,
+		?string $sId = null,
 		string $sTarget = self::DEFAULT_TARGET,
 		string $sTooltip = '',
 		string $sIconClass = '',

--- a/sources/Application/UI/Base/Component/Dashlet/DashletContainer.php
+++ b/sources/Application/UI/Base/Component/Dashlet/DashletContainer.php
@@ -14,7 +14,7 @@ class DashletContainer extends UIContentBlock
 	public const BLOCK_CODE = 'ibo-dashlet';
 	public const DEFAULT_HTML_TEMPLATE_REL_PATH = 'base/layouts/content-block/layout';
 
-	public function __construct(string $sId = null, array $aContainerClasses = [])
+	public function __construct(?string $sId = null, array $aContainerClasses = [])
 	{
 		parent::__construct($sId, $aContainerClasses);
 

--- a/sources/Application/UI/Base/Component/Dashlet/DashletFactory.php
+++ b/sources/Application/UI/Base/Component/Dashlet/DashletFactory.php
@@ -22,12 +22,12 @@ class DashletFactory
 		return new DashletBadge($sClassIconUrl, $sHyperlink, $iCount, $sClassLabel, $sCreateActionUrl, $sCreateActionLabel, $aRefreshParams);
 	}
 
-	public static function MakeForDashletHeaderStatic(string $sTitle, string $sIconUrl, string $sId = null): DashletHeaderStatic
+	public static function MakeForDashletHeaderStatic(string $sTitle, string $sIconUrl, ?string $sId = null): DashletHeaderStatic
 	{
 		return new DashletHeaderStatic($sTitle, $sIconUrl, $sId);
 	}
 
-	public static function MakeForDashletPlainText(string $sText, string $sId = null): DashletPlainText
+	public static function MakeForDashletPlainText(string $sText, ?string $sId = null): DashletPlainText
 	{
 		return new DashletPlainText($sText, $sId);
 	}

--- a/sources/Application/UI/Base/Component/Dashlet/DashletHeaderStatic.php
+++ b/sources/Application/UI/Base/Component/Dashlet/DashletHeaderStatic.php
@@ -33,7 +33,7 @@ class DashletHeaderStatic extends DashletContainer
 	 * @param string $sIconUrl
 	 * @param string|null $sId
 	 */
-	public function __construct(string $sTitle, string $sIconUrl, string $sId = null)
+	public function __construct(string $sTitle, string $sIconUrl, ?string $sId = null)
 	{
 		parent::__construct($sId);
 

--- a/sources/Application/UI/Base/Component/Dashlet/DashletPlainText.php
+++ b/sources/Application/UI/Base/Component/Dashlet/DashletPlainText.php
@@ -29,7 +29,7 @@ class DashletPlainText extends DashletContainer
 	 *
 	 * @param string $sText
 	 */
-	public function __construct(string $sText, string $sId = null)
+	public function __construct(string $sText, ?string $sId = null)
 	{
 		parent::__construct($sId);
 

--- a/sources/Application/UI/Base/Component/DataTable/DataTableUIBlockFactory.php
+++ b/sources/Application/UI/Base/Component/DataTable/DataTableUIBlockFactory.php
@@ -855,7 +855,7 @@ JS;
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Layout\UIContentBlock
 	 */
-	public static function MakeForStaticData(string $sTitle, array $aColumns, array $aData, ?string $sId = null, array $aExtraParams = [], string $sFilter = "", array $aOptions = [], array $aRowActions = null)
+	public static function MakeForStaticData(string $sTitle, array $aColumns, array $aData, ?string $sId = null, array $aExtraParams = [], string $sFilter = "", array $aOptions = [], ?array $aRowActions = null)
 	{
 		$oBlock = new UIContentBlock();
 		if ($sTitle != "") {
@@ -896,7 +896,7 @@ JS;
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\DataTable\StaticTable\FormTable\FormTable
 	 */
-	public static function MakeForForm(string $sRef, array $aColumns, array $aData = [], string $sFilter = '', array $aRowActions = null)
+	public static function MakeForForm(string $sRef, array $aColumns, array $aData = [], string $sFilter = '', ?array $aRowActions = null)
 	{
 		$oTable = new FormTable("datatable_".$sRef);
 		$oTable->SetRef($sRef);

--- a/sources/Application/UI/Base/Component/DataTable/StaticTable/StaticTable.php
+++ b/sources/Application/UI/Base/Component/DataTable/StaticTable/StaticTable.php
@@ -67,7 +67,7 @@ class StaticTable extends UIContentBlock
 	 */
 	private $aOptions;
 
-	public function __construct(string $sId = null, array $aContainerCSSClasses = [], array $aExtraParams = [])
+	public function __construct(?string $sId = null, array $aContainerCSSClasses = [], array $aExtraParams = [])
 	{
 		parent::__construct($sId, $aContainerCSSClasses);
 		$this->aColumns = [];

--- a/sources/Application/UI/Base/Component/Field/Field.php
+++ b/sources/Application/UI/Base/Component/Field/Field.php
@@ -57,7 +57,7 @@ class Field extends UIContentBlock
 	/** @var string */
 	protected $sComments;
 
-	public function __construct(string $sLabel, UIBlock $oValue = null, ?string $sId = null)
+	public function __construct(string $sLabel, ?UIBlock $oValue = null, ?string $sId = null)
 	{
 		parent::__construct($sId);
 		$this->sLabel = $sLabel;

--- a/sources/Application/UI/Base/Component/FieldBadge/FieldBadge.php
+++ b/sources/Application/UI/Base/Component/FieldBadge/FieldBadge.php
@@ -19,7 +19,7 @@ class FieldBadge extends UIContentBlock
 	// Overloaded constants
 	public const BLOCK_CODE = 'ibo-field-badge';
 
-	public function __construct(string $sId = null, array $aContainerClasses = [])
+	public function __construct(?string $sId = null, array $aContainerClasses = [])
 	{
 		parent::__construct($sId, $aContainerClasses);
 	}

--- a/sources/Application/UI/Base/Component/Form/Form.php
+++ b/sources/Application/UI/Base/Component/Form/Form.php
@@ -25,7 +25,7 @@ class Form extends UIContentBlock
 	/** @var string */
 	protected $sAction;
 
-	public function __construct(string $sId = null)
+	public function __construct(?string $sId = null)
 	{
 		parent::__construct($sId);
 		$this->sOnSubmitJsCode = null;

--- a/sources/Application/UI/Base/Component/Form/FormUIBlockFactory.php
+++ b/sources/Application/UI/Base/Component/Form/FormUIBlockFactory.php
@@ -30,7 +30,7 @@ class FormUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Form\Form An HTML form in which you can add UIBlocks
 	 */
-	public static function MakeStandard(string $sId = null)
+	public static function MakeStandard(?string $sId = null)
 	{
 		return new Form($sId);
 	}

--- a/sources/Application/UI/Base/Component/Input/FileSelect/FileSelect.php
+++ b/sources/Application/UI/Base/Component/Input/FileSelect/FileSelect.php
@@ -26,7 +26,7 @@ class FileSelect extends UIBlock
 	/** @var bool */
 	private $bShowFilename;
 
-	public function __construct(string $sName, string $sId = null)
+	public function __construct(string $sName, ?string $sId = null)
 	{
 		parent::__construct($sId);
 		$this->sName = $sName;

--- a/sources/Application/UI/Base/Component/Input/FileSelect/FileSelectUIBlockFactory.php
+++ b/sources/Application/UI/Base/Component/Input/FileSelect/FileSelectUIBlockFactory.php
@@ -31,7 +31,7 @@ class FileSelectUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Input\FileSelect\FileSelect A styled file input selector
 	 */
-	public static function MakeStandard(string $sName, string $sId = null)
+	public static function MakeStandard(string $sName, ?string $sId = null)
 	{
 		return new FileSelect($sName, $sId);
 	}

--- a/sources/Application/UI/Base/Component/Input/Set/DataProvider/AjaxDataProviderForOQL.php
+++ b/sources/Application/UI/Base/Component/Input/Set/DataProvider/AjaxDataProviderForOQL.php
@@ -36,7 +36,7 @@ class AjaxDataProviderForOQL extends AjaxDataProvider
 	 * @param string|null $sWizardHelperJsVarName Wizard helper name
 	 * @param array $aFieldsToLoad Array of fields to load
 	 */
-	public function __construct(string $sObjectClass, string $sOql, string $sWizardHelperJsVarName = null, array $aFieldsToLoad = [])
+	public function __construct(string $sObjectClass, string $sOql, ?string $sWizardHelperJsVarName = null, array $aFieldsToLoad = [])
 	{
 		parent::__construct('object.search', [
 			'object_class'   => $sObjectClass,

--- a/sources/Application/UI/Base/Component/Input/Set/Set.php
+++ b/sources/Application/UI/Base/Component/Input/Set/Set.php
@@ -107,7 +107,7 @@ class Set extends AbstractInput
 	 *
 	 * @param string|null $sId Block identifier
 	 */
-	public function __construct(string $sId = null)
+	public function __construct(?string $sId = null)
 	{
 		parent::__construct($sId);
 

--- a/sources/Application/UI/Base/Component/Input/Set/SetUIBlockFactory.php
+++ b/sources/Application/UI/Base/Component/Input/Set/SetUIBlockFactory.php
@@ -138,7 +138,7 @@ class SetUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Input\Set\Set
 	 */
-	public static function MakeForOQL(string $sId, string $sObjectClass, string $sOql, string $sWizardHelperJsVarName = null, array $aFieldsToLoad = [], ?string $sGroupField = null, string $sName = ''): Set
+	public static function MakeForOQL(string $sId, string $sObjectClass, string $sOql, ?string $sWizardHelperJsVarName = null, array $aFieldsToLoad = [], ?string $sGroupField = null, string $sName = ''): Set
 	{
 		// Create set ui block
 		$oSetUIBlock = new Set($sId);

--- a/sources/Application/UI/Base/Component/Modal/DoNotShowAgainOptionBlock.php
+++ b/sources/Application/UI/Base/Component/Modal/DoNotShowAgainOptionBlock.php
@@ -36,7 +36,7 @@ class DoNotShowAgainOptionBlock extends UIContentBlock
 	 *
 	 * @param string|null $sId
 	 */
-	public function __construct(string $sId = null)
+	public function __construct(?string $sId = null)
 	{
 		parent::__construct($sId, ['ibo-modal-option--do-not-show-again']);
 

--- a/sources/Application/UI/Base/Component/Panel/PanelUIBlockFactory.php
+++ b/sources/Application/UI/Base/Component/Panel/PanelUIBlockFactory.php
@@ -48,7 +48,7 @@ class PanelUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Panel\Panel
 	 */
-	public static function MakeNeutral(string $sTitle, string $sSubTitle = null)
+	public static function MakeNeutral(string $sTitle, ?string $sSubTitle = null)
 	{
 		$oPanel = new Panel($sTitle);
 		if (!is_null($sSubTitle)) {
@@ -68,7 +68,7 @@ class PanelUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Panel\Panel
 	 */
-	public static function MakeForInformation(string $sTitle, string $sSubTitle = null)
+	public static function MakeForInformation(string $sTitle, ?string $sSubTitle = null)
 	{
 		$oPanel = new Panel($sTitle);
 		if (!is_null($sSubTitle)) {
@@ -88,7 +88,7 @@ class PanelUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Panel\Panel
 	 */
-	public static function MakeForSuccess(string $sTitle, string $sSubTitle = null)
+	public static function MakeForSuccess(string $sTitle, ?string $sSubTitle = null)
 	{
 		$oPanel = new Panel($sTitle);
 		if (!is_null($sSubTitle)) {
@@ -108,7 +108,7 @@ class PanelUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Panel\Panel
 	 */
-	public static function MakeForWarning(string $sTitle, string $sSubTitle = null)
+	public static function MakeForWarning(string $sTitle, ?string $sSubTitle = null)
 	{
 		$oPanel = new Panel($sTitle);
 		if (!is_null($sSubTitle)) {
@@ -128,7 +128,7 @@ class PanelUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Panel\Panel
 	 */
-	public static function MakeForDanger(string $sTitle, string $sSubTitle = null)
+	public static function MakeForDanger(string $sTitle, ?string $sSubTitle = null)
 	{
 		$oPanel = new Panel($sTitle);
 		if (!is_null($sSubTitle)) {
@@ -148,7 +148,7 @@ class PanelUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Panel\Panel
 	 */
-	public static function MakeForFailure(string $sTitle, string $sSubTitle = null)
+	public static function MakeForFailure(string $sTitle, ?string $sSubTitle = null)
 	{
 		$oPanel = new Panel($sTitle);
 		if (!is_null($sSubTitle)) {
@@ -168,7 +168,7 @@ class PanelUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Panel\Panel
 	 */
-	public static function MakeWithBrandingPrimaryColor(string $sTitle, string $sSubTitle = null)
+	public static function MakeWithBrandingPrimaryColor(string $sTitle, ?string $sSubTitle = null)
 	{
 		$oPanel = new Panel($sTitle);
 		if (!is_null($sSubTitle)) {
@@ -188,7 +188,7 @@ class PanelUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Panel\Panel
 	 */
-	public static function MakeWithBrandingSecondaryColor(string $sTitle, string $sSubTitle = null)
+	public static function MakeWithBrandingSecondaryColor(string $sTitle, ?string $sSubTitle = null)
 	{
 		$oPanel = new Panel($sTitle);
 		if (!is_null($sSubTitle)) {
@@ -209,7 +209,7 @@ class PanelUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Panel\Panel
 	 */
-	public static function MakeForClass(string $sClass, string $sTitle, string $sSubTitle = null)
+	public static function MakeForClass(string $sClass, string $sTitle, ?string $sSubTitle = null)
 	{
 		$oPanel = new Panel($sTitle);
 		if (!is_null($sSubTitle)) {

--- a/sources/Application/UI/Base/Component/Toolbar/Separator/ToolbarSeparatorUIBlockFactory.php
+++ b/sources/Application/UI/Base/Component/Toolbar/Separator/ToolbarSeparatorUIBlockFactory.php
@@ -31,7 +31,7 @@ class ToolbarSeparatorUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Toolbar\Separator\VerticalSeparator
 	 */
-	public static function MakeVertical(string $sId = null)
+	public static function MakeVertical(?string $sId = null)
 	{
 		return new VerticalSeparator($sId);
 	}

--- a/sources/Application/UI/Base/Component/Toolbar/Toolbar.php
+++ b/sources/Application/UI/Base/Component/Toolbar/Toolbar.php
@@ -20,7 +20,7 @@ class Toolbar extends UIContentBlock
 	public const BLOCK_CODE = 'ibo-toolbar';
 	public const DEFAULT_HTML_TEMPLATE_REL_PATH = 'base/components/toolbar/layout';
 
-	public function __construct(string $sId = null, array $aContainerClasses = [])
+	public function __construct(?string $sId = null, array $aContainerClasses = [])
 	{
 		parent::__construct($sId, $aContainerClasses);
 	}

--- a/sources/Application/UI/Base/Component/Toolbar/ToolbarSpacer/ToolbarSpacerUIBlockFactory.php
+++ b/sources/Application/UI/Base/Component/Toolbar/ToolbarSpacer/ToolbarSpacerUIBlockFactory.php
@@ -30,7 +30,7 @@ class ToolbarSpacerUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Toolbar\ToolbarSpacer\ToolbarSpacer
 	 */
-	public static function MakeStandard(string $sId = null)
+	public static function MakeStandard(?string $sId = null)
 	{
 		return new ToolbarSpacer($sId);
 	}

--- a/sources/Application/UI/Base/Component/Toolbar/ToolbarUIBlockFactory.php
+++ b/sources/Application/UI/Base/Component/Toolbar/ToolbarUIBlockFactory.php
@@ -30,7 +30,7 @@ class ToolbarUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Toolbar\Toolbar
 	 */
-	public static function MakeForAction(string $sId = null)
+	public static function MakeForAction(?string $sId = null)
 	{
 		return new Toolbar($sId, ['ibo-toolbar--action']);
 	}
@@ -42,7 +42,7 @@ class ToolbarUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Toolbar\Toolbar
 	 */
-	public static function MakeStandard(string $sId = null, array $aContainerClasses = [])
+	public static function MakeStandard(?string $sId = null, array $aContainerClasses = [])
 	{
 		return new Toolbar($sId, $aContainerClasses);
 	}
@@ -54,7 +54,7 @@ class ToolbarUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Toolbar\Toolbar
 	 */
-	public static function MakeForButton(string $sId = null, array $aContainerClasses = [])
+	public static function MakeForButton(?string $sId = null, array $aContainerClasses = [])
 	{
 		return new Toolbar($sId, array_merge($aContainerClasses, ['ibo-toolbar--button']));
 	}

--- a/sources/Application/UI/Base/Layout/ActivityPanel/CaseLogEntryForm/CaseLogEntryForm.php
+++ b/sources/Application/UI/Base/Layout/ActivityPanel/CaseLogEntryForm/CaseLogEntryForm.php
@@ -62,7 +62,7 @@ class CaseLogEntryForm extends UIContentBlock
 	 * @param \DBObject $oObject
 	 * @param string|null $sId
 	 */
-	public function __construct(DBObject $oObject, string $sAttCode, string $sId = null)
+	public function __construct(DBObject $oObject, string $sAttCode, ?string $sId = null)
 	{
 		parent::__construct($sId);
 		$this->oObject = $oObject;

--- a/sources/Application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
+++ b/sources/Application/UI/Base/Layout/NavigationMenu/NavigationMenu.php
@@ -107,7 +107,7 @@ class NavigationMenu extends UIBlock implements iKeyboardShortcut
 	public function __construct(
 		ApplicationContext $oAppContext,
 		PopoverMenu $oUserMenu,
-		NewsroomMenu $oNewsroomMenu = null,
+		?NewsroomMenu $oNewsroomMenu = null,
 		?string $sId = null
 	) {
 		parent::__construct($sId);

--- a/sources/Application/UI/Base/Layout/TopBar/TopBar.php
+++ b/sources/Application/UI/Base/Layout/TopBar/TopBar.php
@@ -59,9 +59,9 @@ class TopBar extends UIBlock
 	 */
 	public function __construct(
 		$sId = null,
-		QuickCreate $oQuickCreate = null,
-		GlobalSearch $oGlobalSearch = null,
-		Breadcrumbs $oBreadcrumbs = null
+		?QuickCreate $oQuickCreate = null,
+		?GlobalSearch $oGlobalSearch = null,
+		?Breadcrumbs $oBreadcrumbs = null
 	) {
 		parent::__construct($sId);
 

--- a/sources/Application/UI/Base/Layout/UIContentBlock.php
+++ b/sources/Application/UI/Base/Layout/UIContentBlock.php
@@ -41,7 +41,7 @@ class UIContentBlock extends UIBlock implements iUIContentBlock
 	 * @param string|null $sId
 	 * @param array       $aContainerClasses Array of additional CSS classes
 	 */
-	public function __construct(string $sId = null, array $aContainerClasses = [])
+	public function __construct(?string $sId = null, array $aContainerClasses = [])
 	{
 		parent::__construct($sId);
 

--- a/sources/Application/UI/Base/Layout/UIContentBlockUIBlockFactory.php
+++ b/sources/Application/UI/Base/Layout/UIContentBlockUIBlockFactory.php
@@ -34,7 +34,7 @@ class UIContentBlockUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Layout\UIContentBlock
 	 */
-	public static function MakeStandard(string $sId = null, array $aContainerClasses = [])
+	public static function MakeStandard(?string $sId = null, array $aContainerClasses = [])
 	{
 		return new UIContentBlock($sId, $aContainerClasses);
 	}
@@ -49,7 +49,7 @@ class UIContentBlockUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Layout\UIContentBlock
 	 */
-	public static function MakeForCode(string $sCode, string $sId = null)
+	public static function MakeForCode(string $sCode, ?string $sId = null)
 	{
 		$sCode = str_replace("\n", '<br>', \utils::HtmlEntities($sCode));
 
@@ -65,7 +65,7 @@ class UIContentBlockUIBlockFactory extends AbstractUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Layout\UIContentBlock
 	 */
-	public static function MakeForPreformatted(string $sCode, string $sId = null)
+	public static function MakeForPreformatted(string $sCode, ?string $sId = null)
 	{
 		$sCode = '<pre>'.\utils::HtmlEntities($sCode).'</pre>';
 

--- a/sources/Application/UI/Base/UIException.php
+++ b/sources/Application/UI/Base/UIException.php
@@ -12,7 +12,7 @@ use Throwable;
 
 class UIException extends Exception
 {
-	public function __construct(iUIBlock $oBlock, string $message = "", int $code = 0, Throwable $previous = null)
+	public function __construct(iUIBlock $oBlock, string $message = "", int $code = 0, ?Throwable $previous = null)
 	{
 		parent::__construct($oBlock->GetId().': '.$message, $code, $previous);
 	}

--- a/sources/Application/UI/Links/AbstractBlockLinkSetViewTable.php
+++ b/sources/Application/UI/Links/AbstractBlockLinkSetViewTable.php
@@ -139,7 +139,7 @@ abstract class AbstractBlockLinkSetViewTable extends UIContentBlock
 	 * @throws \ArchivedObjectException
 	 * @throws \CoreException
 	 */
-	public function GetDictionaryEntry(string $sKey, DBObject $oDBObject = null)
+	public function GetDictionaryEntry(string $sKey, ?DBObject $oDBObject = null)
 	{
 		return $this->oAttDef->SearchSpecificLabel(
 			$sKey,

--- a/sources/Application/UI/Links/Set/LinkSetUIBlockFactory.php
+++ b/sources/Application/UI/Links/Set/LinkSetUIBlockFactory.php
@@ -51,7 +51,7 @@ class LinkSetUIBlockFactory extends SetUIBlockFactory
 	 *
 	 * @return \Combodo\iTop\Application\UI\Base\Component\Input\Set\Set
 	 */
-	public static function MakeForLinkSet(string $sId, AttributeLinkedSet $oAttDef, iDBObjectSetIterator $oDbObjectSet, string $sWizardHelperJsVarName, DBObject $oHostDbObject = null): Set
+	public static function MakeForLinkSet(string $sId, AttributeLinkedSet $oAttDef, iDBObjectSetIterator $oDbObjectSet, string $sWizardHelperJsVarName, ?DBObject $oHostDbObject = null): Set
 	{
 		$sTargetClass = LinkSetModel::GetTargetClass($oAttDef);
 		$sTargetField = LinkSetModel::GetTargetField($oAttDef);

--- a/sources/Application/WebPage/AjaxPage.php
+++ b/sources/Application/WebPage/AjaxPage.php
@@ -92,7 +92,7 @@ class AjaxPage extends WebPage implements iTabbedPage
 	 * @inheritDoc
 	 * @throws \Exception
 	 */
-	public function AddTabContainer($sTabContainer, $sPrefix = '', iUIContentBlock $oParentBlock = null)
+	public function AddTabContainer($sTabContainer, $sPrefix = '', ?iUIContentBlock $oParentBlock = null)
 	{
 		if (is_null($oParentBlock)) {
 			$oParentBlock = PanelUIBlockFactory::MakeNeutral('');

--- a/sources/Application/WebPage/TabManager.php
+++ b/sources/Application/WebPage/TabManager.php
@@ -248,7 +248,7 @@ class TabManager
 	 * @param string $sTabCode
 	 * @param string|null $sTabContainer
 	 */
-	public function RemoveTab(string $sTabCode, string $sTabContainer = null)
+	public function RemoveTab(string $sTabCode, ?string $sTabContainer = null)
 	{
 		if ($sTabContainer == null) {
 			$sTabContainer = $this->m_sCurrentTabContainer;
@@ -272,7 +272,7 @@ class TabManager
 	 *
 	 * @return mixed The actual name of the tab (as a string) or false if not found
 	 */
-	public function FindTab(string $sPattern, string $sTabContainer = null)
+	public function FindTab(string $sPattern, ?string $sTabContainer = null)
 	{
 		$result = false;
 		if ($sTabContainer == null) {

--- a/sources/Application/WebPage/iTabbedPage.php
+++ b/sources/Application/WebPage/iTabbedPage.php
@@ -18,7 +18,7 @@ interface iTabbedPage
 	 *
 	 * @return mixed
 	 */
-	public function AddTabContainer($sTabContainer, $sPrefix = '', iUIContentBlock $oParentBlock = null);
+	public function AddTabContainer($sTabContainer, $sPrefix = '', ?iUIContentBlock $oParentBlock = null);
 
 	/**
 	 * @param string $sTabContainer

--- a/sources/Application/WebPage/iTopWebPage.php
+++ b/sources/Application/WebPage/iTopWebPage.php
@@ -1024,7 +1024,7 @@ HTML;
 	 * @inheritDoc
 	 * @throws \Exception
 	 */
-	public function AddTabContainer($sTabContainer, $sPrefix = '', iUIContentBlock $oParentBlock = null)
+	public function AddTabContainer($sTabContainer, $sPrefix = '', ?iUIContentBlock $oParentBlock = null)
 	{
 		if (is_null($oParentBlock)) {
 			$oParentBlock = PanelUIBlockFactory::MakeNeutral('');

--- a/sources/Form/Field/DateTimeField.php
+++ b/sources/Form/Field/DateTimeField.php
@@ -38,7 +38,7 @@ class DateTimeField extends StringField
 	/**
 	 * @inheritDoc
 	 */
-	public function __construct(string $sId, Closure $onFinalizeCallback = null)
+	public function __construct(string $sId, ?Closure $onFinalizeCallback = null)
 	{
 		parent::__construct($sId, $onFinalizeCallback);
 		$this->bDateOnly = false;

--- a/sources/Form/Field/Field.php
+++ b/sources/Form/Field/Field.php
@@ -89,7 +89,7 @@ abstract class Field
 	 * @param string        $sId
 	 * @param \Closure|null $onFinalizeCallback (Used in the $oForm->AddField($sId, ..., function() use ($oManager, $oForm, '...') { ... } ); )
 	 */
-	public function __construct(string $sId, Closure $onFinalizeCallback = null)
+	public function __construct(string $sId, ?Closure $onFinalizeCallback = null)
 	{
 		$this->sId = $sId;
 		// No space in such an id, that could be used as a DOM node id

--- a/sources/Form/Field/FileUploadField.php
+++ b/sources/Form/Field/FileUploadField.php
@@ -60,7 +60,7 @@ class FileUploadField extends AbstractSimpleField
 	/**
 	 * @inheritDoc
 	 */
-	public function __construct(string $sId, Closure $onFinalizeCallback = null)
+	public function __construct(string $sId, ?Closure $onFinalizeCallback = null)
 	{
 		$this->sTransactionId = null;
 		$this->oObject = null;

--- a/sources/Form/Field/LinkedSetField.php
+++ b/sources/Form/Field/LinkedSetField.php
@@ -64,7 +64,7 @@ class LinkedSetField extends AbstractSimpleField
 	/**
 	 * @inheritDoc
 	 */
-	public function __construct(string $sId, Closure $onFinalizeCallback = null)
+	public function __construct(string $sId, ?Closure $onFinalizeCallback = null)
 	{
 		$this->sTargetClass = null;
 		$this->sExtKeyToRemote = null;

--- a/sources/Form/Field/MultipleChoicesField.php
+++ b/sources/Form/Field/MultipleChoicesField.php
@@ -44,7 +44,7 @@ abstract class MultipleChoicesField extends AbstractSimpleField
 	/**
 	 * @inheritDoc
 	 */
-	public function __construct(string $sId, Closure $onFinalizeCallback = null)
+	public function __construct(string $sId, ?Closure $onFinalizeCallback = null)
 	{
 		parent::__construct($sId, $onFinalizeCallback);
 		$this->bMultipleValuesEnabled = static::DEFAULT_MULTIPLE_VALUES_ENABLED;

--- a/sources/Form/Field/SelectField.php
+++ b/sources/Form/Field/SelectField.php
@@ -45,7 +45,7 @@ class SelectField extends MultipleChoicesField
 	/**
 	 * @inheritDoc
 	 */
-	public function __construct(string $sId, Closure $onFinalizeCallback = null)
+	public function __construct(string $sId, ?Closure $onFinalizeCallback = null)
 	{
 		parent::__construct($sId, $onFinalizeCallback);
 		$this->bStartsWithNullChoice = static::DEFAULT_STARTS_WITH_NULL_CHOICE;

--- a/sources/Form/Field/SelectObjectField.php
+++ b/sources/Form/Field/SelectObjectField.php
@@ -70,7 +70,7 @@ class SelectObjectField extends AbstractSimpleField
 	/**
 	 * @inheritDoc
 	 */
-	public function __construct(string $sId, Closure $onFinalizeCallback = null)
+	public function __construct(string $sId, ?Closure $onFinalizeCallback = null)
 	{
 		parent::__construct($sId, $onFinalizeCallback);
 		$this->oSearch = null;

--- a/sources/Form/Field/SubFormField.php
+++ b/sources/Form/Field/SubFormField.php
@@ -34,7 +34,7 @@ class SubFormField extends Field
 	/**
 	 * @inheritDoc
 	 */
-	public function __construct(string $sId, Closure $onFinalizeCallback = null)
+	public function __construct(string $sId, ?Closure $onFinalizeCallback = null)
 	{
 		$this->oForm = new Form('subform_'.$sId);
 		parent::__construct($sId, $onFinalizeCallback);

--- a/sources/Form/Field/TextAreaField.php
+++ b/sources/Form/Field/TextAreaField.php
@@ -53,7 +53,7 @@ class TextAreaField extends TextField
 	 * @param \Closure|null  $onFinalizeCallback
 	 * @param \DBObject|null $oObject
 	 */
-	public function __construct(string $sId, Closure $onFinalizeCallback = null, DBObject $oObject = null)
+	public function __construct(string $sId, ?Closure $onFinalizeCallback = null, ?DBObject $oObject = null)
 	{
 		parent::__construct($sId, $onFinalizeCallback);
 		$this->sFormat = static::DEFAULT_FORMAT;

--- a/sources/Form/Field/UrlField.php
+++ b/sources/Form/Field/UrlField.php
@@ -39,7 +39,7 @@ class UrlField extends StringField
 	/**
 	 * @inheritDoc
 	 */
-	public function __construct(string $sId, Closure $onFinalizeCallback = null)
+	public function __construct(string $sId, ?Closure $onFinalizeCallback = null)
 	{
 		parent::__construct($sId, $onFinalizeCallback);
 

--- a/sources/Renderer/FormRenderer.php
+++ b/sources/Renderer/FormRenderer.php
@@ -48,7 +48,7 @@ abstract class FormRenderer
 	 *
 	 * @param \Combodo\iTop\Form\Form $oForm
 	 */
-	public function __construct(Form $oForm = null)
+	public function __construct(?Form $oForm = null)
 	{
 		if ($oForm !== null) {
 			$this->oForm = $oForm;

--- a/sources/Service/Base/ObjectRepository.php
+++ b/sources/Service/Base/ObjectRepository.php
@@ -84,7 +84,7 @@ class ObjectRepository
 	 * @return array|null
 	 * @since 3.2.0 Add $iLimit parameter
 	 */
-	public static function SearchFromOql(string $sObjectClass, array $aFieldsToLoad, string $sOql, string $sSearch, DBObject $oThisObject = null, int $iLimit = 0): ?array
+	public static function SearchFromOql(string $sObjectClass, array $aFieldsToLoad, string $sOql, string $sSearch, ?DBObject $oThisObject = null, int $iLimit = 0): ?array
 	{
 		try {
 
@@ -280,7 +280,7 @@ class ObjectRepository
 	 * @throws \CoreException
 	 * @throws \DictExceptionMissingString
 	 */
-	public static function ConvertObjectToArray(DBObject $oObject, string $sObjectClass, array $aFieldsToLoad = null, array $aComplementAttributeSpec = null, string $sObjectImageAttCode = null): array
+	public static function ConvertObjectToArray(DBObject $oObject, string $sObjectClass, ?array $aFieldsToLoad = null, ?array $aComplementAttributeSpec = null, ?string $sObjectImageAttCode = null): array
 	{
 		// Retrieve friendly name complementary specification
 		if ($aComplementAttributeSpec === null) {

--- a/sources/Service/Links/LinkSetDataTransformer.php
+++ b/sources/Service/Links/LinkSetDataTransformer.php
@@ -49,7 +49,7 @@ class LinkSetDataTransformer
 	 *
 	 * @return array
 	 */
-	public static function Decode(iDBObjectSetIterator $oDbObjectSet, string $sTargetClass, string $sTargetField = null): array
+	public static function Decode(iDBObjectSetIterator $oDbObjectSet, string $sTargetClass, ?string $sTargetField = null): array
 	{
 		try {
 			// Prepare result
@@ -96,7 +96,7 @@ class LinkSetDataTransformer
 	 *
 	 * @return array{to_be_created: array, to_be_deleted: array, to_be_added: array, to_be_removed: array}
 	 */
-	public static function Encode(array $aElements, string $sLinkClass, string $sExtKeyToRemote = null): array
+	public static function Encode(array $aElements, string $sLinkClass, ?string $sExtKeyToRemote = null): array
 	{
 		// Result arrays
 		$aToBeCreate = [];

--- a/sources/Service/Links/LinkSetRepository.php
+++ b/sources/Service/Links/LinkSetRepository.php
@@ -36,7 +36,7 @@ class LinkSetRepository
 	 *
 	 * @return array|null
 	 */
-	public static function LinksDbSetToTargetObjectArray(iDBObjectSetIterator $oDbObjectSet, bool $bForce, array &$aInitialOptions, string $sTargetClass, string $sTargetField = null): ?array
+	public static function LinksDbSetToTargetObjectArray(iDBObjectSetIterator $oDbObjectSet, bool $bForce, array &$aInitialOptions, string $sTargetClass, ?string $sTargetField = null): ?array
 	{
 		try {
 

--- a/sources/Service/Notification/NotificationsRepository.php
+++ b/sources/Service/Notification/NotificationsRepository.php
@@ -188,7 +188,7 @@ class NotificationsRepository
 	 *
 	 * @return DBObjectSet The set of subscriptions matching the given trigger, contact, and action.
 	 */
-	public function SearchUnsubscribedSubscriptionsByTriggerContactAndAction(int $iTriggerId, int $iActionId, int $iContactId = null): DBObjectSet
+	public function SearchUnsubscribedSubscriptionsByTriggerContactAndAction(int $iTriggerId, int $iActionId, ?int $iContactId = null): DBObjectSet
 	{
 		$oSearch = $this->PrepareSearchForSubscriptionsByTriggerContactAndAction($iTriggerId, $iActionId, $iContactId);
 		$oSearch->AddCondition("subscribed", "0");

--- a/tests/php-unit-tests/legacy-tests/testlist.inc.php
+++ b/tests/php-unit-tests/legacy-tests/testlist.inc.php
@@ -230,7 +230,7 @@ class TestMyBizModel extends TestBizModel
 
 	public function test_error()
 	{
-		trigger_error("Stop requested", E_USER_ERROR);
+		trigger_error("Stop requested", E_USER_WARNING);
 	}
 
 	public function test_changetracking()

--- a/tests/php-unit-tests/unitary-tests/application/query/QueryTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/query/QueryTest.php
@@ -73,7 +73,7 @@ class QueryTest extends ItopDataTestCase
 	 * @param string $sOql query oql phrase
 	 * @param string|null $sFields fields to export
 	 */
-	private function CreateQueryOQL(string $sName, string $sDescription, string $sOql, string $sFields = null): QueryOQL
+	private function CreateQueryOQL(string $sName, string $sDescription, string $sOql, ?string $sFields = null): QueryOQL
 	{
 		$oQuery = new QueryOQL();
 		$oQuery->Set('name', $sName);

--- a/tests/php-unit-tests/unitary-tests/core/BulkChangeTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/BulkChangeTest.php
@@ -80,7 +80,7 @@ class BulkChangeTest extends ItopDataTestCase
 	 * @param $aExtKeys
 	 * @param $aReconcilKeys
 	 */
-	public function testBulkChangeWithoutInitData($aCSVData, $aAttributes, $aExtKeys, $aReconcilKeys, $aResult, array $aResultHTML = null)
+	public function testBulkChangeWithoutInitData($aCSVData, $aAttributes, $aExtKeys, $aReconcilKeys, $aResult, ?array $aResultHTML = null)
 	{
 		$this->debug("aReconcilKeys:".$aReconcilKeys[0]);
 		$oBulk = new BulkChange(

--- a/tests/php-unit-tests/unitary-tests/core/DBObject/Utils/CRUDEventReceiver.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBObject/Utils/CRUDEventReceiver.php
@@ -77,7 +77,7 @@ class CRUDEventReceiver
 		}
 	}
 
-	public function RegisterCRUDEventListeners(string $sEvent = null, $mEventSource = null)
+	public function RegisterCRUDEventListeners(?string $sEvent = null, $mEventSource = null)
 	{
 		$this->Debug('Registering Test event listeners');
 		if (is_null($sEvent)) {

--- a/tests/php-unit-tests/unitary-tests/webservices/RestTest.php
+++ b/tests/php-unit-tests/unitary-tests/webservices/RestTest.php
@@ -268,7 +268,7 @@ JSON;
 	 *
 	 * @return bool|string
 	 */
-	private function CallRestApi_HTTP(string $sJsonDataContent = null, string $sCallbackName = null, bool $bJSONDataAsFile = false)
+	private function CallRestApi_HTTP(?string $sJsonDataContent = null, ?string $sCallbackName = null, bool $bJSONDataAsFile = false)
 	{
 		$ch = curl_init();
 		$aPostFields = [


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | [8851](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=8851) and [8854](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=8854)
| Type of change?                                               |  Enhancement


## Objective

To support migration to PHP8.4, we must address the new deprecation rules. 
After the initial analysis, the newly deprecated features affecting iTop are :
* [Implicitly nullable parameter](https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter)
* [Using trigger_error() with E_USER_ERROR](https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.underscore-class-name)


## Proposed solution

* For "Implicitly nullable parameter" : prefix the type name with a question mark, e.g. `?CMDBObject $oObject = null`
* For "trigger_error() with E_USER_ERROR": change to use `E_USER_WARNING`

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?