### PR TITLE
N°8673 - Avoid server overload when user access news page with a lot of unread news

### DIFF
--- a/css/backoffice/components/_panel.scss
+++ b/css/backoffice/components/_panel.scss
@@ -72,12 +72,12 @@ $ibo-panel--icon--spacing--as-medallion--is-sticking: $ibo-panel--icon--spacing-
 $ibo-panel--icon--bottom--as-medallion--is-sticking: -12px !default;
 $ibo-panel--icon--border--as-medallion--is-sticking: 1px $ibo-panel--base-border-style $ibo-panel--base-border-color !default;
 
-$ibo-panel--icon-img--size--must-contain: contain !default;
-$ibo-panel--icon-img--size--must-cover: cover !default;
-$ibo-panel--icon-img--size--must-zoomout: 66.67% !default;
-$ibo-panel--icon-background--size--must-contain: $ibo-panel--icon-img--size--must-contain; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-contain
-$ibo-panel--icon-background--size--must-cover: $ibo-panel--icon-img--size--must-cover; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-cover
-$ibo-panel--icon-background--size--must-zoomout: $ibo-panel--icon-img--size--must-zoomout; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-zoomout
+$ibo-panel--icon-background--size--must-contain: contain !default; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-contain
+$ibo-panel--icon-background--size--must-cover: cover !default; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-cover
+$ibo-panel--icon-background--size--must-zoomout: 66.67% !default; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-zoomout
+$ibo-panel--icon-img--size--must-contain: $ibo-panel--icon-background--size--must-contain !default; // TODO remove when dealing with N°9317
+$ibo-panel--icon-img--size--must-cover: $ibo-panel--icon-background--size--must-cover !default; // TODO remove when dealing with N°9317
+$ibo-panel--icon-img--size--must-zoomout: $ibo-panel--icon-background--size--must-zoomout !default; // TODO remove when dealing with N°9317
 
 $ibo-panel--title--font-size--is-sticking: $ibo-font-size-150 !default;
 $ibo-panel--title--color: $ibo-color-grey-900 !default;
@@ -182,7 +182,7 @@ $ibo-panel--is-selectable--body--after--font-size: $ibo-font-size-700 !default;
   min-height: $ibo-panel--icon--size;
 }
 
-.ibo-panel--icon-img, .ibo-panel--icon-background { // second class is deprecated
+.ibo-panel--icon-img, .ibo-panel--icon-background { // second class is deprecated, remove it when dealing with N°9317
   width: 100%;
   height: 100%;
   background-position: center;
@@ -190,15 +190,15 @@ $ibo-panel--is-selectable--body--after--font-size: $ibo-font-size-700 !default;
   background-size: $ibo-panel--icon-img--size--must-contain;
 }
 
-.ibo-panel--icon-img--must-contain, .ibo-panel--icon-background--must-contain { // second class is deprecated
+.ibo-panel--icon-img--must-contain, .ibo-panel--icon-background--must-contain { // second class is deprecated, remove it when dealing with N°9317
   background-size: $ibo-panel--icon-img--size--must-contain;
 }
 
-.ibo-panel--icon-img--must-cover, .ibo-panel--icon-background--must-cover { // second class is deprecated
+.ibo-panel--icon-img--must-cover, .ibo-panel--icon-background--must-cover { // second class is deprecated, remove it when dealing with N°9317
   background-size: $ibo-panel--icon-img--size--must-cover;
 }
 
-.ibo-panel--icon-img--must-zoomout, .ibo-panel--icon-background--must-zoomout { // second class is deprecated
+.ibo-panel--icon-img--must-zoomout, .ibo-panel--icon-background--must-zoomout { // second class is deprecated, remove it when dealing with N°9317
   width: $ibo-panel--icon-img--size--must-zoomout;
   height: $ibo-panel--icon-img--size--must-zoomout;
 }

--- a/css/backoffice/components/_panel.scss
+++ b/css/backoffice/components/_panel.scss
@@ -75,6 +75,9 @@ $ibo-panel--icon--border--as-medallion--is-sticking: 1px $ibo-panel--base-border
 $ibo-panel--icon-img--size--must-contain: contain !default;
 $ibo-panel--icon-img--size--must-cover: cover !default;
 $ibo-panel--icon-img--size--must-zoomout: 66.67% !default;
+$ibo-panel--icon-background--size--must-contain: $ibo-panel--icon-img--size--must-contain; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-contain
+$ibo-panel--icon-background--size--must-cover: $ibo-panel--icon-img--size--must-cover; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-cover
+$ibo-panel--icon-background--size--must-zoomout: $ibo-panel--icon-img--size--must-zoomout; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-zoomout
 
 $ibo-panel--title--font-size--is-sticking: $ibo-font-size-150 !default;
 $ibo-panel--title--color: $ibo-color-grey-900 !default;
@@ -179,7 +182,7 @@ $ibo-panel--is-selectable--body--after--font-size: $ibo-font-size-700 !default;
   min-height: $ibo-panel--icon--size;
 }
 
-.ibo-panel--icon-img {
+.ibo-panel--icon-img, .ibo-panel--icon-background { // second class is deprecated
   width: 100%;
   height: 100%;
   background-position: center;
@@ -187,15 +190,15 @@ $ibo-panel--is-selectable--body--after--font-size: $ibo-font-size-700 !default;
   background-size: $ibo-panel--icon-img--size--must-contain;
 }
 
-.ibo-panel--icon-img--must-contain {
+.ibo-panel--icon-img--must-contain, .ibo-panel--icon-background--must-contain { // second class is deprecated
   background-size: $ibo-panel--icon-img--size--must-contain;
 }
 
-.ibo-panel--icon-img--must-cover {
+.ibo-panel--icon-img--must-cover, .ibo-panel--icon-background--must-cover { // second class is deprecated
   background-size: $ibo-panel--icon-img--size--must-cover;
 }
 
-.ibo-panel--icon-img--must-zoomout {
+.ibo-panel--icon-img--must-zoomout, .ibo-panel--icon-background--must-zoomout { // second class is deprecated
   width: $ibo-panel--icon-img--size--must-zoomout;
   height: $ibo-panel--icon-img--size--must-zoomout;
 }

--- a/css/backoffice/components/_panel.scss
+++ b/css/backoffice/components/_panel.scss
@@ -72,9 +72,9 @@ $ibo-panel--icon--spacing--as-medallion--is-sticking: $ibo-panel--icon--spacing-
 $ibo-panel--icon--bottom--as-medallion--is-sticking: -12px !default;
 $ibo-panel--icon--border--as-medallion--is-sticking: 1px $ibo-panel--base-border-style $ibo-panel--base-border-color !default;
 
-$ibo-panel--icon-background--size--must-contain: contain !default;
-$ibo-panel--icon-background--size--must-cover: cover !default;
-$ibo-panel--icon-background--size--must-zoomout: 66.67% !default;
+$ibo-panel--icon-img--size--must-contain: contain !default;
+$ibo-panel--icon-img--size--must-cover: cover !default;
+$ibo-panel--icon-img--size--must-zoomout: 66.67% !default;
 
 $ibo-panel--title--font-size--is-sticking: $ibo-font-size-150 !default;
 $ibo-panel--title--color: $ibo-color-grey-900 !default;
@@ -179,24 +179,25 @@ $ibo-panel--is-selectable--body--after--font-size: $ibo-font-size-700 !default;
   min-height: $ibo-panel--icon--size;
 }
 
-.ibo-panel--icon-background {
+.ibo-panel--icon-img {
   width: 100%;
   height: 100%;
   background-position: center;
   background-repeat: no-repeat;
-  background-size: $ibo-panel--icon-background--size--must-contain;
+  background-size: $ibo-panel--icon-img--size--must-contain;
 }
 
-.ibo-panel--icon-background--must-contain {
-  background-size: $ibo-panel--icon-background--size--must-contain;
+.ibo-panel--icon-img--must-contain {
+  background-size: $ibo-panel--icon-img--size--must-contain;
 }
 
-.ibo-panel--icon-background--must-cover {
-  background-size: $ibo-panel--icon-background--size--must-cover;
+.ibo-panel--icon-img--must-cover {
+  background-size: $ibo-panel--icon-img--size--must-cover;
 }
 
-.ibo-panel--icon-background--must-zoomout {
-  background-size: $ibo-panel--icon-background--size--must-zoomout;
+.ibo-panel--icon-img--must-zoomout {
+  width: $ibo-panel--icon-img--size--must-zoomout;
+  height: $ibo-panel--icon-img--size--must-zoomout;
 }
 
 .ibo-panel--title {

--- a/css/backoffice/components/_title.scss
+++ b/css/backoffice/components/_title.scss
@@ -11,12 +11,12 @@ $ibo-title--icon--size: 90px !default;
 $ibo-title--icon--size-2: 80px !default;
 $ibo-title--icon--size-3: 70px !default;
 
-$ibo-title--icon-img--size--must-contain: contain !default;
-$ibo-title--icon-img--size--must-cover: cover !default;
-$ibo-title--icon-img--size--must-zoomout: 66.67% !default;
-$ibo-title--icon-background--size--must-contain: $ibo-title--icon-img--size--must-contain; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-contain
-$ibo-title--icon-background--size--must-cover: $ibo-title--icon-img--size--must-cover; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-cover
-$ibo-title--icon-background--size--must-zoomout: $ibo-title--icon-img--size--must-zoomout; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-zoomout
+$ibo-title--icon-background--size--must-contain: contain !default; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-contain
+$ibo-title--icon-background--size--must-cover: cover !default; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-cover
+$ibo-title--icon-background--size--must-zoomout: 66.67% !default; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-zoomout
+$ibo-title--icon-img--size--must-contain: $ibo-title--icon-background--size--must-contain !default; // TODO remove when dealing with N°9317
+$ibo-title--icon-img--size--must-cover: $ibo-title--icon-background--size--must-cover !default; // TODO remove when dealing with N°9317
+$ibo-title--icon-img--size--must-zoomout: $ibo-title--icon-background--size--must-zoomout !default; // TODO remove when dealing with N°9317
 
 
 .ibo-title {
@@ -47,22 +47,22 @@ $ibo-title--icon-background--size--must-zoomout: $ibo-title--icon-img--size--mus
   min-height: $ibo-title--icon--size-3;
 }
 
-.ibo-title--icon-img, .ibo-title--icon-background { // second class is deprecated
+.ibo-title--icon-img, .ibo-title--icon-background { // second class is deprecated, remove it when dealing with N°9317
   width: 100%;
   height: 100%;
   object-position: center;
   background-size: $ibo-title--icon-img--size--must-contain;
 }
 
-.ibo-title--icon-img--must-contain, .ibo-title--icon-background--must-contain { // second class is deprecated
+.ibo-title--icon-img--must-contain, .ibo-title--icon-background--must-contain { // second class is deprecated, remove it when dealing with N°9317
   background-size: $ibo-title--icon-img--size--must-contain;
 }
 
-.ibo-title--icon-img--must-cover, .ibo-title--icon-background--must-cover { // second class is deprecated
+.ibo-title--icon-img--must-cover, .ibo-title--icon-background--must-cover { // second class is deprecated, remove it when dealing with N°9317
   background-size: $ibo-title--icon-img--size--must-cover;
 }
 
-.ibo-title--icon-img--must-zoomout, .ibo-title--icon-background--must-zoomout { // second class is deprecated
+.ibo-title--icon-img--must-zoomout, .ibo-title--icon-background--must-zoomout { // second class is deprecated, remove it when dealing with N°9317
   background-size: $ibo-title--icon-img--size--must-zoomout;
 }
 

--- a/css/backoffice/components/_title.scss
+++ b/css/backoffice/components/_title.scss
@@ -14,9 +14,9 @@ $ibo-title--icon--size-3: 70px !default;
 $ibo-title--icon-img--size--must-contain: contain !default;
 $ibo-title--icon-img--size--must-cover: cover !default;
 $ibo-title--icon-img--size--must-zoomout: 66.67% !default;
-$ibo-title--icon-background--size--must-contain: $ibo-title--icon-img--size--must-contain; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-contain
-$ibo-title--icon-background--size--must-cover: $ibo-title--icon-img--size--must-cover; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-cover
-$ibo-title--icon-background--size--must-zoomout: $ibo-title--icon-img--size--must-zoomout; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-zoomout
+$ibo-title--icon-background--size--must-contain: $ibo-title--icon-img--size--must-contain; // deprecated, to be removed in favor of $ibo-title--icon-img--size--must-contain
+$ibo-title--icon-background--size--must-cover: $ibo-title--icon-img--size--must-cover; // deprecated, to be removed in favor of $ibo-title--icon-img--size--must-cover
+$ibo-title--icon-background--size--must-zoomout: $ibo-title--icon-img--size--must-zoomout; // deprecated, to be removed in favor of $ibo-title--icon-img--size--must-zoomout
 
 
 .ibo-title {

--- a/css/backoffice/components/_title.scss
+++ b/css/backoffice/components/_title.scss
@@ -11,9 +11,9 @@ $ibo-title--icon--size: 90px !default;
 $ibo-title--icon--size-2: 80px !default;
 $ibo-title--icon--size-3: 70px !default;
 
-$ibo-title--icon-background--size--must-contain: contain !default;
-$ibo-title--icon-background--size--must-cover: cover !default;
-$ibo-title--icon-background--size--must-zoomout: 66.67% !default;
+$ibo-title--icon-img--size--must-contain: contain !default;
+$ibo-title--icon-img--size--must-cover: cover !default;
+$ibo-title--icon-img--size--must-zoomout: 66.67% !default;
 
 
 .ibo-title {
@@ -44,24 +44,23 @@ $ibo-title--icon-background--size--must-zoomout: 66.67% !default;
   min-height: $ibo-title--icon--size-3;
 }
 
-.ibo-title--icon-background {
+.ibo-title--icon-img {
   width: 100%;
   height: 100%;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: $ibo-title--icon-background--size--must-contain;
+  object-position: center;
+  background-size: $ibo-title--icon-img--size--must-contain;
 }
 
-.ibo-title--icon-background--must-contain {
-  background-size: $ibo-title--icon-background--size--must-contain;
+.ibo-title--icon-img--must-contain {
+  background-size: $ibo-title--icon-img--size--must-contain;
 }
 
-.ibo-title--icon-background--must-cover {
-  background-size: $ibo-title--icon-background--size--must-cover;
+.ibo-title--icon-img--must-cover {
+  background-size: $ibo-title--icon-img--size--must-cover;
 }
 
-.ibo-title--icon-background--must-zoomout {
-  background-size: $ibo-title--icon-background--size--must-zoomout;
+.ibo-title--icon-img--must-zoomout {
+  background-size: $ibo-title--icon-img--size--must-zoomout;
 }
 
 .ibo-title--for-object-details {

--- a/css/backoffice/components/_title.scss
+++ b/css/backoffice/components/_title.scss
@@ -11,8 +11,8 @@ $ibo-title--icon--size: 90px !default;
 $ibo-title--icon--size-2: 80px !default;
 $ibo-title--icon--size-3: 70px !default;
 
-$ibo-title--icon-background--size--must-contain: contain !default; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-contain
-$ibo-title--icon-background--size--must-cover: cover !default; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-cover
+$ibo-title--icon-background--size--must-contain: contain !default; // deprecated, to be removed in favor of $ibo-title--icon-img--size--must-contain
+$ibo-title--icon-background--size--must-cover: cover !default; // deprecated, to be removed in favor of $ibo-title--icon-img--size--must-cover
 $ibo-title--icon-background--size--must-zoomout: 66.67% !default; // deprecated, to be removed in favor of $ibo-title--icon-img--size--must-zoomout
 $ibo-title--icon-img--size--must-contain: $ibo-title--icon-background--size--must-contain !default; // TODO remove when dealing with N°9317
 $ibo-title--icon-img--size--must-cover: $ibo-title--icon-background--size--must-cover !default; // TODO remove when dealing with N°9317

--- a/css/backoffice/components/_title.scss
+++ b/css/backoffice/components/_title.scss
@@ -14,6 +14,9 @@ $ibo-title--icon--size-3: 70px !default;
 $ibo-title--icon-img--size--must-contain: contain !default;
 $ibo-title--icon-img--size--must-cover: cover !default;
 $ibo-title--icon-img--size--must-zoomout: 66.67% !default;
+$ibo-title--icon-background--size--must-contain: $ibo-title--icon-img--size--must-contain; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-contain
+$ibo-title--icon-background--size--must-cover: $ibo-title--icon-img--size--must-cover; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-cover
+$ibo-title--icon-background--size--must-zoomout: $ibo-title--icon-img--size--must-zoomout; // deprecated, to be removed in favor of $ibo-panel--icon-img--size--must-zoomout
 
 
 .ibo-title {
@@ -44,22 +47,22 @@ $ibo-title--icon-img--size--must-zoomout: 66.67% !default;
   min-height: $ibo-title--icon--size-3;
 }
 
-.ibo-title--icon-img {
+.ibo-title--icon-img, .ibo-title--icon-background { // second class is deprecated
   width: 100%;
   height: 100%;
   object-position: center;
   background-size: $ibo-title--icon-img--size--must-contain;
 }
 
-.ibo-title--icon-img--must-contain {
+.ibo-title--icon-img--must-contain, .ibo-title--icon-background--must-contain { // second class is deprecated
   background-size: $ibo-title--icon-img--size--must-contain;
 }
 
-.ibo-title--icon-img--must-cover {
+.ibo-title--icon-img--must-cover, .ibo-title--icon-background--must-cover { // second class is deprecated
   background-size: $ibo-title--icon-img--size--must-cover;
 }
 
-.ibo-title--icon-img--must-zoomout {
+.ibo-title--icon-img--must-zoomout, .ibo-title--icon-background--must-zoomout { // second class is deprecated
   background-size: $ibo-title--icon-img--size--must-zoomout;
 }
 

--- a/sources/Application/UI/Base/Layout/UIContentBlock.php
+++ b/sources/Application/UI/Base/Layout/UIContentBlock.php
@@ -227,7 +227,7 @@ class UIContentBlock extends UIBlock implements iUIContentBlock
 	}
 
 	/**
-	 * @see static::bHasLazyLoadIcon
+	 * @see static::$bHasLazyLoadIcon
 	 * @return bool
 	 */
 	public function HasLazyLoadIcon(): bool
@@ -236,7 +236,7 @@ class UIContentBlock extends UIBlock implements iUIContentBlock
 	}
 
 	/**
-	 * @see static::$bLazyLoadIcon
+	 * @see static::$bHasLazyLoadIcon
 	 * @param bool $bLazyLoadIcon
 	 * @return $this
 	 */

--- a/sources/Application/UI/Base/Layout/UIContentBlock.php
+++ b/sources/Application/UI/Base/Layout/UIContentBlock.php
@@ -33,6 +33,10 @@ class UIContentBlock extends UIBlock implements iUIContentBlock
 	protected $aDeferredBlocks;
 	/** @var bool If set to true, the content block will have a surrounding <div> no matter its options / CSS classes / ... */
 	protected $bHasForcedDiv;
+	/** @var bool if set to true, the icon will be lazy loaded
+	 * @since 3.2.3
+	 */
+	protected bool $bHasLazyLoadIcon;
 
 	/**
 	 * UIContentBlock constructor.
@@ -48,6 +52,7 @@ class UIContentBlock extends UIBlock implements iUIContentBlock
 		$this->aSubBlocks = [];
 		$this->aDeferredBlocks = [];
 		$this->bHasForcedDiv = false;
+		$this->bHasLazyLoadIcon = false;
 		$this->SetCSSClasses($aContainerClasses);
 	}
 
@@ -218,6 +223,26 @@ class UIContentBlock extends UIBlock implements iUIContentBlock
 	public function SetHasForcedDiv(bool $bHasForcedDiv)
 	{
 		$this->bHasForcedDiv = $bHasForcedDiv;
+		return $this;
+	}
+
+	/**
+	 * @see static::bHasLazyLoadIcon
+	 * @return bool
+	 */
+	public function HasLazyLoadIcon(): bool
+	{
+		return $this->bHasLazyLoadIcon;
+	}
+
+	/**
+	 * @see static::$bLazyLoadIcon
+	 * @param bool $bLazyLoadIcon
+	 * @return $this
+	 */
+	public function SetHasLazyLoadIcon(bool $bLazyLoadIcon)
+	{
+		$this->bHasLazyLoadIcon = $bLazyLoadIcon;
 		return $this;
 	}
 }

--- a/sources/Controller/Newsroom/iTopNewsroomController.php
+++ b/sources/Controller/Newsroom/iTopNewsroomController.php
@@ -7,14 +7,11 @@ use Combodo\iTop\Application\Branding;
 use Combodo\iTop\Application\TwigBase\Controller\Controller;
 use Combodo\iTop\Application\UI\Base\Component\Button\Button;
 use Combodo\iTop\Application\UI\Base\Component\Button\ButtonUIBlockFactory;
-use Combodo\iTop\Application\UI\Base\Component\ButtonGroup\ButtonGroupUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Component\Html\Html;
 use Combodo\iTop\Application\UI\Base\Component\Input\InputUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Component\Input\Toggler;
 use Combodo\iTop\Application\UI\Base\Component\Panel\Panel;
 use Combodo\iTop\Application\UI\Base\Component\Panel\PanelUIBlockFactory;
-use Combodo\iTop\Application\UI\Base\Component\PopoverMenu\PopoverMenu;
-use Combodo\iTop\Application\UI\Base\Component\PopoverMenu\PopoverMenuItem\PopoverMenuItemFactory;
 use Combodo\iTop\Application\UI\Base\Component\Title\TitleUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Component\Toolbar\ToolbarUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Layout\Object\ObjectSummary;
@@ -29,13 +26,10 @@ use CoreException;
 use DBObjectSearch;
 use DBObjectSet;
 use Dict;
-use JSPopupMenuItem;
 use MetaModel;
 use SecurityException;
-use URLPopupMenuItem;
 use UserRights;
 use utils;
-use appUserPreferences;
 
 /**
  *  Class iTopNewsroomController
@@ -376,6 +370,7 @@ JS
 			$sReadColor = $oEvent->Get('read') === 'no' ? 'ibo-notifications--view-all--item--unread' : 'ibo-notifications--view-all--item--read';
 			$sReadLabel = $oEvent->Get('read') === 'no' ? Dict::S('UI:Newsroom:iTopNotification:ViewAllPage:Unread:Label') : Dict::S('UI:Newsroom:iTopNotification:ViewAllPage:Read:Label');
 			$oEventBlock = new ObjectSummary($oEvent);
+			$oEventBlock->SetHasLazyLoadIcon(true);
 			$oEventBlock->SetCSSColorClass($sReadColor);
 			$oEventBlock->SetSubTitle($sReadLabel);
 			$oEventBlock->SetClassLabel('');

--- a/templates/base/components/panel/layout.html.twig
+++ b/templates/base/components/panel/layout.html.twig
@@ -18,7 +18,9 @@
                         {% if oUIBlock.HasIcon() %}
                             <div class="ibo-panel--icon" data-role="ibo-panel--icon">
                                 {% block iboPanelIcon %}
-                                    <div class="ibo-panel--icon-background ibo-panel--icon-background--must-{{ oUIBlock.GetIconCoverMethod() }}" data-role="ibo-panel--icon-background" style="background-image: url('{{ oUIBlock.GetIconUrl()|raw }}');"></div>
+                                    <img class="ibo-panel--icon-background ibo-panel--icon-img--must-{{ oUIBlock.GetIconCoverMethod() }}"
+                                            {% if oUIBlock.HasLazyLoadIcon %} loading="lazy" {% endif %}
+                                         data-role="ibo-panel--icon-img" src="{{ oUIBlock.GetIconUrl()|raw }}">
                                 {% endblock %}
                             </div>
                         {% endif %}

--- a/templates/base/components/panel/layout.html.twig
+++ b/templates/base/components/panel/layout.html.twig
@@ -21,7 +21,7 @@
                                     <img class="ibo-panel--icon-background ibo-panel--icon-img--must-{{ oUIBlock.GetIconCoverMethod() }}
                                     ibo-panel--icon-background--must-{{ oUIBlock.GetIconCoverMethod() }}"
                                             {% if oUIBlock.HasLazyLoadIcon %} loading="lazy" {% endif %}
-                                         data-role="ibo-panel--icon-img" src="{{ oUIBlock.GetIconUrl()|raw }}">
+                                         data-role="ibo-panel--icon-img" src="{{ oUIBlock.GetIconUrl()|raw }}" alt="" aria-hidden="true">
                                 {% endblock %}
                             </div>
                         {% endif %}

--- a/templates/base/components/panel/layout.html.twig
+++ b/templates/base/components/panel/layout.html.twig
@@ -18,7 +18,8 @@
                         {% if oUIBlock.HasIcon() %}
                             <div class="ibo-panel--icon" data-role="ibo-panel--icon">
                                 {% block iboPanelIcon %}
-                                    <img class="ibo-panel--icon-background ibo-panel--icon-img--must-{{ oUIBlock.GetIconCoverMethod() }}"
+                                    <img class="ibo-panel--icon-background ibo-panel--icon-img--must-{{ oUIBlock.GetIconCoverMethod() }}
+                                    ibo-panel--icon-background--must-{{ oUIBlock.GetIconCoverMethod() }}"
                                             {% if oUIBlock.HasLazyLoadIcon %} loading="lazy" {% endif %}
                                          data-role="ibo-panel--icon-img" src="{{ oUIBlock.GetIconUrl()|raw }}">
                                 {% endblock %}


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N°8673
| Type of change?                                               | Bug fix


## Symptom (bug) / Objective (enhancement)
When a user has too much news, the "view all messages" will be slow and send many request to the server to load the news icon (1 by news), than can cause the server to slow down


## Reproduction procedure (bug)

1. On iTop 3.2.2 with 1K+ news
2. With PHP 8.1
2. Go to https://YOUR_ITOP_URL/pages/UI.php?route=itopnewsroom.view_all
2. Notice than 1K+ requests to load pictures are sent simultaneously to the server, making it slow down



## Cause (bug)
Request are sent simultaneously


## Proposed solution (bug and enhancement)
Make the icons load when they appear to the screen (on user scroll)

To do that, icons need to be ```<img>``` tags, not background of HTML elements.


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?