### PR TITLE
N°9248 - REST API - Updating a link creates an empty caselog on the linked object when there is no change

### DIFF
--- a/core/ormlinkset.class.inc.php
+++ b/core/ormlinkset.class.inc.php
@@ -179,7 +179,7 @@ class ormLinkSet implements iDBObjectSetIterator, Iterator, SeekableIterator
 		assert($oLink instanceof $this->sClass);
 
 		$iObjectId = $oLink->GetKey();
-		if (array_key_exists($iObjectId, $this->aPreserved)) {
+		if (array_key_exists($iObjectId, $this->aPreserved) && !$oLink->Equals(MetaModel::GetObject(get_class($oLink), $iObjectId, true))) {
 			unset($this->aPreserved[$iObjectId]);
 			$this->aModified[$iObjectId] = $oLink;
 			$this->bHasDelta = true;


### PR DESCRIPTION
internal
