### PR TITLE
 N°9230 - Sanitize dashboard_id parameter in "revert_dashboard" operation of AJAX render function

### DIFF
--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -998,7 +998,7 @@ JS
 				break;
 
 			case 'revert_dashboard':
-				$sDashboardId = utils::ReadParam('dashboard_id', '', false, 'raw_data');
+				$sDashboardId = utils::ReadParam('dashboard_id', '', false, utils::ENUM_SANITIZATION_FILTER_CONTEXT_PARAM);
 				$sReloadURL = utils::ReadParam('reload_url', '', false, utils::ENUM_SANITIZATION_FILTER_URL);
 				appUserPreferences::UnsetPref('display_original_dashboard_'.$sDashboardId);
 				$oDashboard = new RuntimeDashboard($sDashboardId);


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | [N°9230](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=9230)
| Type of change?                                               | Bug fix


## Symptom

The dashboard_id parameter in the revert_dashboard operation accepts unsanitized input, which is reflected in the JavaScript response without proper encoding


## Cause

The dashboard_id parameter is not sanitized in the revert_dashboard operation


## Proposed Solution

Sanitize the dashboard_id parameter


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?