### PR TITLE
N°9234 - Sanitize query expression parameter in suggested OQL on run query page

### DIFF
--- a/pages/run_query.php
+++ b/pages/run_query.php
@@ -306,7 +306,7 @@ JS
 					$sBefore = substr($sExpression, 0, $e->GetColumn());
 					$sAfter = substr($sExpression, $e->GetColumn() + strlen($sWrongWord));
 					$sFixedExpression = $sBefore.$sSuggestedWord.$sAfter;
-					$sFixedExpressionHtml = $sBefore.'<span class="ibo-run-query--highlight">'.$sSuggestedWord.'</span>'.$sAfter;
+					$sFixedExpressionHtml = $sBefore.'<span class="ibo-run-query--highlight">'.$sSuggestedWord.'</span>'.utils::EscapeHtml($sAfter);
 					$sSyntaxErrorText .= "<p>Suggesting: $sFixedExpressionHtml</p>";
 					$oSyntaxErrorPanel->AddSubBlock(new Html($sSyntaxErrorText));
 


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | [N°9234](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=9234)
| Type of change?                                               | Bug fix


## Symptom

The endpoint run_query.php by-design executes OQL queries, but when the query is invalid it reflects user input in response as an error that the query is invalid , the response is not sanitized


## Cause

The user input query is displayed in the suggested OQL without being sanitized


## Proposed solution

Escape HTML before displaying the user input query


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?