### PR TITLE
N°9238 - Sanitize data_source_id query parameter in synchro_import script

### DIFF
--- a/synchro/synchro_import.php
+++ b/synchro/synchro_import.php
@@ -301,7 +301,7 @@ try {
 	//
 	// Read parameters
 	//
-	$iDataSourceId = ReadMandatoryParam($oP, 'data_source_id', 'raw_data');
+	$iDataSourceId = ReadMandatoryParam($oP, 'data_source_id', utils::ENUM_SANITIZATION_FILTER_INTEGER);
 	$sSynchronize = ReadParam($oP, 'synchronize');
 	$sSep = ReadParam($oP, 'separator', 'raw_data');
 	$sQualifier = ReadParam($oP, 'qualifier', 'raw_data');


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | [N°9238](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=9238)
| Type of change?                                               | Bug fix


## Symptom

The data_source_id parameter in the synchro_import script accepts unsanitized input, which is reflected in the response without proper encoding


## Cause 

The _data_source_id_ parameter is not sanitized before printing the error value


## Proposed solution

Sanitize the _data_source_id_ parameter


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?