### PR TITLE
N°9235 - Sanitize oql_clause query parameter in universal search page

### DIFF
--- a/pages/UniversalSearch.php
+++ b/pages/UniversalSearch.php
@@ -109,7 +109,7 @@ if ($oFilter != null) {
 	$oP->SetBreadCrumbEntry($sPageId, $sLabel, '', '', 'fas fa-search', iTopWebPage::ENUM_BREADCRUMB_ENTRY_ICON_TYPE_CSS_CLASSES);
 
 	// Menu node
-	$sFilter = $oFilter->ToOQL();
+	$sFilter = utils::EscapeHtml($oFilter->ToOQL());
 	$oP->add("\n<!-- $sFilter -->\n");
 }
 $oP->add("</div>\n");

--- a/pages/UniversalSearch.php
+++ b/pages/UniversalSearch.php
@@ -107,10 +107,6 @@ if ($oFilter != null) {
 	$sPageId = "ui-search-".$oFilter->GetClass();
 	$sLabel = MetaModel::GetName($oFilter->GetClass());
 	$oP->SetBreadCrumbEntry($sPageId, $sLabel, '', '', 'fas fa-search', iTopWebPage::ENUM_BREADCRUMB_ENTRY_ICON_TYPE_CSS_CLASSES);
-
-	// Menu node
-	$sFilter = utils::EscapeHtml($oFilter->ToOQL());
-	$oP->add("\n<!-- $sFilter -->\n");
 }
 $oP->add("</div>\n");
 $oP->output();


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | [N°9235](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=9235)
| Type of change?                                               | Bug fix


## Symptom

The oql_clause parameter in the page Universal Search accepts unsanitized input, which is reflected in the response without proper encoding

## Cause

The oql_clause parameter is not sanitized before being rendered in HTML


## Proposed solution (bug and enhancement)

Remove the OQL from HTML comments because it is no longer useful today


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?
