### PR TITLE
N°8606 - Check user permissions in search operation of ajax.render.php

### DIFF
--- a/sources/Controller/AjaxRenderController.php
+++ b/sources/Controller/AjaxRenderController.php
@@ -42,6 +42,7 @@ use RunTimeEnvironment;
 use ScalarExpression;
 use SetupUtils;
 use UILinksWidget;
+use UserRights;
 use utils;
 use WizardHelper;
 
@@ -71,6 +72,12 @@ class AjaxRenderController
 			$bShowObsoleteData = utils::ShowObsoleteData();
 		}
 		$oSet->SetShowObsoleteData($bShowObsoleteData);
+
+		// N°8606 : Check user permissions on the main class
+		if (UserRights::IsActionAllowed($oSet->GetClass(), UR_ACTION_READ, $oSet) !== UR_ALLOWED_YES) {
+			throw new Exception(Dict::Format('UI:Error:ReadNotAllowedOn_Class', $oSet->GetClass()));
+		}
+
 		$aResult["draw"] = $iDrawNumber;
 		$aResult["recordsTotal"] = $oSet->Count();
 		$aResult["recordsFiltered"] = $aResult["recordsTotal"] ;
@@ -93,6 +100,11 @@ class AjaxRenderController
 							'aColumnsLoad' => $aColumnsLoad,
 						]);
 						continue;
+					}
+
+					// N°8606 : Check user permissions on the current class
+					if (UserRights::IsActionAllowed($sClass, UR_ACTION_READ, $oSet) !== UR_ALLOWED_YES) {
+						throw new Exception(Dict::Format('UI:Error:ReadNotAllowedOn_Class', $sClass));
 					}
 
 					foreach ($aColumnsLoad[$sAlias] as $sAttCode) {


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | [N°8606](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=8606)
| Type of change?                                               | Bug fix


## Symptom

Users can access unauthorized objects via the search operation in `ajax.render.php`


## Cause

User permissions are not checked before returning object


## Proposed solution 

Add a permission check before returning objects


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?