### PR TITLE
Feature/9138 display details cmdb

### DIFF
--- a/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
+++ b/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
@@ -2253,7 +2253,7 @@
                   </items>
                   <rank>10</rank>
                 </item>
-                <item id="fieldset:ConfigMgnt:moreinfo">
+                <item id="fieldset:Software:moreinfo">
                   <items>
                     <item id="system_id">
                       <rank>50</rank>
@@ -2275,16 +2275,21 @@
             </item>
             <item id="col:col2">
               <items>
-                <item id="fieldset:ConfigMgnt:otherinfo">
+                <item id="fieldset:Server:Date">
                   <items>
                     <item id="move2production">
-              <rank>90</rank>
+                      <rank>90</rank>
                     </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <items>
                     <item id="description">
                       <rank>100</rank>
                     </item>
                   </items>
-                  <rank>10</rank>
+                  <rank>20</rank>
                 </item>
               </items>
               <rank>20</rank>
@@ -2432,7 +2437,7 @@
                   </items>
                   <rank>10</rank>
                 </item>
-                <item id="fieldset:ConfigMgnt:moreinfo">
+                <item id="fieldset:Software:moreinfo">
                   <items>
                     <item id="system_id">
                       <rank>50</rank>
@@ -2454,16 +2459,21 @@
             </item>
             <item id="col:col2">
               <items>
-                <item id="fieldset:ConfigMgnt:otherinfo">
+                <item id="fieldset:Server:Date">
                   <items>
                     <item id="move2production">
-              <rank>90</rank>
+                      <rank>90</rank>
                     </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <items>
                     <item id="description">
                       <rank>100</rank>
                     </item>
                   </items>
-                  <rank>10</rank>
+                  <rank>20</rank>
                 </item>
               </items>
               <rank>20</rank>
@@ -2611,7 +2621,7 @@
                   </items>
                   <rank>10</rank>
                 </item>
-                <item id="fieldset:ConfigMgnt:moreinfo">
+                <item id="fieldset:Software:moreinfo">
                   <items>
                     <item id="system_id">
                       <rank>50</rank>
@@ -2633,16 +2643,21 @@
             </item>
             <item id="col:col2">
               <items>
-                <item id="fieldset:ConfigMgnt:otherinfo">
+                <item id="fieldset:Server:Date">
                   <items>
                     <item id="move2production">
-              <rank>90</rank>
+                      <rank>90</rank>
                     </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <items>
                     <item id="description">
                       <rank>100</rank>
                     </item>
                   </items>
-                  <rank>10</rank>
+                  <rank>20</rank>
                 </item>
               </items>
               <rank>20</rank>
@@ -2782,7 +2797,7 @@
                   </items>
                   <rank>10</rank>
                 </item>
-                <item id="fieldset:ConfigMgnt:moreinfo">
+                <item id="fieldset:Software:moreinfo">
                   <items>
                     <item id="system_id">
                       <rank>50</rank>
@@ -2804,16 +2819,21 @@
             </item>
             <item id="col:col2">
               <items>
-                <item id="fieldset:ConfigMgnt:otherinfo">
+                <item id="fieldset:Server:Date">
                   <items>
                     <item id="move2production">
-              <rank>90</rank>
+                      <rank>90</rank>
                     </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <items>
                     <item id="description">
                       <rank>100</rank>
                     </item>
                   </items>
-                  <rank>10</rank>
+                  <rank>20</rank>
                 </item>
               </items>
               <rank>20</rank>
@@ -2940,7 +2960,7 @@
                   </items>
                   <rank>10</rank>
                 </item>
-                <item id="fieldset:ConfigMgnt:moreinfo">
+                <item id="fieldset:Software:moreinfo">
                   <items>
                     <item id="system_id">
                       <rank>50</rank>
@@ -2962,16 +2982,21 @@
             </item>
             <item id="col:col2">
               <items>
-                <item id="fieldset:ConfigMgnt:otherinfo">
+                <item id="fieldset:Server:Date">
                   <items>
                     <item id="move2production">
-              <rank>90</rank>
+                      <rank>90</rank>
                     </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <items>
                     <item id="description">
                       <rank>100</rank>
                     </item>
                   </items>
-                  <rank>10</rank>
+                  <rank>20</rank>
                 </item>
               </items>
               <rank>20</rank>

--- a/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
+++ b/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
@@ -1129,7 +1129,7 @@
               </items>
             </item>
             <item id="col:col2">
-              <rank>90</rank>
+              <rank>20</rank>
               <items>
                 <item id="fieldset:Server:Date">
                   <rank>10</rank>
@@ -1182,7 +1182,7 @@
               <rank>100</rank>
             </item>
             <item id="connectablecis_list">
-              <rank>50</rank>
+              <rank>110</rank>
             </item>
           </items>
         </details>
@@ -4218,6 +4218,12 @@
             <item id="licence_key">
               <rank>30</rank>
             </item>
+            <item id="start_date">
+              <rank>40</rank>
+            </item>
+            <item id="end_date">
+              <rank>50</rank>
+            </item>
           </items>
         </default_search>
         <search>
@@ -4388,7 +4394,7 @@
             </item>
           </items>
         </details>
-        <default_search>
+        <search>
           <items>
             <item id="name">
               <rank>10</rank>
@@ -4406,26 +4412,7 @@
               <rank>40</rank>
             </item>
           </items>
-        </default_search>
-        <search>
-        <items>
-          <item id="name">
-            <rank>10</rank>
-          </item>
-          <item id="perpetual">
-            <rank>15</rank>
-          </item>
-          <item id="start_date">
-            <rank>20</rank>
-          </item>
-          <item id="end_date">
-            <rank>30</rank>
-          </item>
-          <item id="licence_key">
-            <rank>40</rank>
-          </item>
-        </items>
-      </search>
+        </search>
         <list>
           <items>
             <item id="osversion_id">

--- a/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
+++ b/datamodels/2.x/itop-config-mgmt/datamodel.itop-config-mgmt.xml
@@ -1065,23 +1065,8 @@
       <presentation>
         <details>
           <items>
-            <item id="contacts_list">
-              <rank>10</rank>
-            </item>
-            <item id="documents_list">
-              <rank>20</rank>
-            </item>
-            <item id="applicationsolution_list">
-              <rank>35</rank>
-            </item>
-            <item id="physicalinterface_list">
-              <rank>40</rank>
-            </item>
-            <item id="connectablecis_list">
-              <rank>50</rank>
-            </item>
             <item id="col:col1">
-              <rank>80</rank>
+              <rank>10</rank>
               <items>
                 <item id="fieldset:Server:baseinfo">
                   <rank>10</rank>
@@ -1183,6 +1168,21 @@
                   </items>
                 </item>
               </items>
+            </item>
+            <item id="contacts_list">
+              <rank>70</rank>
+            </item>
+            <item id="documents_list">
+              <rank>80</rank>
+            </item>
+            <item id="applicationsolution_list">
+              <rank>90</rank>
+            </item>
+            <item id="physicalinterface_list">
+              <rank>100</rank>
+            </item>
+            <item id="connectablecis_list">
+              <rank>50</rank>
             </item>
           </items>
         </details>
@@ -1717,23 +1717,43 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:ConfigMgnt:otherinfo">
+                  <items>
+                    <item id="move2production">
+                      <rank>50</rank>
+                    </item>
+                    <item id="description">
+                      <rank>60</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
               <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="move2production">
-              <rank>50</rank>
-            </item>
-            <item id="description">
-              <rank>60</rank>
             </item>
             <item id="contacts_list">
               <rank>70</rank>
@@ -1874,23 +1894,43 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:ConfigMgnt:otherinfo">
+                  <items>
+                    <item id="move2production">
+                      <rank>50</rank>
+                    </item>
+                    <item id="description">
+                      <rank>60</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
               <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="move2production">
-              <rank>50</rank>
-            </item>
-            <item id="description">
-              <rank>60</rank>
             </item>
             <item id="contacts_list">
               <rank>70</rank>
@@ -2194,35 +2234,60 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:ConfigMgnt:moreinfo">
+                  <items>
+                    <item id="system_id">
+                      <rank>50</rank>
+                    </item>
+                    <item id="software_id">
+                      <rank>60</rank>
+                    </item>
+                    <item id="softwarelicence_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="path">
+                      <rank>80</rank>
+                    </item>
+                  </items>
+                  <rank>20</rank>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="org_id">
-              <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="system_id">
-              <rank>50</rank>
-            </item>
-            <item id="software_id">
-              <rank>60</rank>
-            </item>
-            <item id="softwarelicence_id">
-              <rank>70</rank>
-            </item>
-            <item id="path">
-              <rank>80</rank>
-            </item>
-            <item id="move2production">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:ConfigMgnt:otherinfo">
+                  <items>
+                    <item id="move2production">
               <rank>90</rank>
-            </item>
-            <item id="description">
-              <rank>100</rank>
+                    </item>
+                    <item id="description">
+                      <rank>100</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
+              <rank>20</rank>
             </item>
             <item id="contacts_list">
               <rank>110</rank>
@@ -2348,35 +2413,60 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:ConfigMgnt:moreinfo">
+                  <items>
+                    <item id="system_id">
+                      <rank>50</rank>
+                    </item>
+                    <item id="software_id">
+                      <rank>60</rank>
+                    </item>
+                    <item id="softwarelicence_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="path">
+                      <rank>80</rank>
+                    </item>
+                  </items>
+                  <rank>20</rank>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="org_id">
-              <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="system_id">
-              <rank>50</rank>
-            </item>
-            <item id="software_id">
-              <rank>60</rank>
-            </item>
-            <item id="softwarelicence_id">
-              <rank>70</rank>
-            </item>
-            <item id="path">
-              <rank>80</rank>
-            </item>
-            <item id="move2production">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:ConfigMgnt:otherinfo">
+                  <items>
+                    <item id="move2production">
               <rank>90</rank>
-            </item>
-            <item id="description">
-              <rank>100</rank>
+                    </item>
+                    <item id="description">
+                      <rank>100</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
+              <rank>20</rank>
             </item>
             <item id="contacts_list">
               <rank>110</rank>
@@ -2502,35 +2592,60 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:ConfigMgnt:moreinfo">
+                  <items>
+                    <item id="system_id">
+                      <rank>50</rank>
+                    </item>
+                    <item id="software_id">
+                      <rank>60</rank>
+                    </item>
+                    <item id="softwarelicence_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="path">
+                      <rank>80</rank>
+                    </item>
+                  </items>
+                  <rank>20</rank>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="org_id">
-              <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="system_id">
-              <rank>50</rank>
-            </item>
-            <item id="software_id">
-              <rank>60</rank>
-            </item>
-            <item id="softwarelicence_id">
-              <rank>70</rank>
-            </item>
-            <item id="path">
-              <rank>80</rank>
-            </item>
-            <item id="move2production">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:ConfigMgnt:otherinfo">
+                  <items>
+                    <item id="move2production">
               <rank>90</rank>
-            </item>
-            <item id="description">
-              <rank>100</rank>
+                    </item>
+                    <item id="description">
+                      <rank>100</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
+              <rank>20</rank>
             </item>
             <item id="contacts_list">
               <rank>110</rank>
@@ -2648,35 +2763,60 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:ConfigMgnt:moreinfo">
+                  <items>
+                    <item id="system_id">
+                      <rank>50</rank>
+                    </item>
+                    <item id="software_id">
+                      <rank>60</rank>
+                    </item>
+                    <item id="softwarelicence_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="path">
+                      <rank>80</rank>
+                    </item>
+                  </items>
+                  <rank>20</rank>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="org_id">
-              <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="system_id">
-              <rank>50</rank>
-            </item>
-            <item id="software_id">
-              <rank>60</rank>
-            </item>
-            <item id="softwarelicence_id">
-              <rank>70</rank>
-            </item>
-            <item id="path">
-              <rank>80</rank>
-            </item>
-            <item id="move2production">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:ConfigMgnt:otherinfo">
+                  <items>
+                    <item id="move2production">
               <rank>90</rank>
-            </item>
-            <item id="description">
-              <rank>100</rank>
+                    </item>
+                    <item id="description">
+                      <rank>100</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
+              <rank>20</rank>
             </item>
             <item id="contacts_list">
               <rank>110</rank>
@@ -2781,35 +2921,60 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:ConfigMgnt:moreinfo">
+                  <items>
+                    <item id="system_id">
+                      <rank>50</rank>
+                    </item>
+                    <item id="software_id">
+                      <rank>60</rank>
+                    </item>
+                    <item id="softwarelicence_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="path">
+                      <rank>80</rank>
+                    </item>
+                  </items>
+                  <rank>20</rank>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="org_id">
-              <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="system_id">
-              <rank>50</rank>
-            </item>
-            <item id="software_id">
-              <rank>60</rank>
-            </item>
-            <item id="softwarelicence_id">
-              <rank>70</rank>
-            </item>
-            <item id="path">
-              <rank>80</rank>
-            </item>
-            <item id="move2production">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:ConfigMgnt:otherinfo">
+                  <items>
+                    <item id="move2production">
               <rank>90</rank>
-            </item>
-            <item id="description">
-              <rank>100</rank>
+                    </item>
+                    <item id="description">
+                      <rank>100</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
+              <rank>20</rank>
             </item>
             <item id="contacts_list">
               <rank>110</rank>
@@ -2927,23 +3092,48 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:ConfigMgnt:moreinfo">
+                  <items>
+                    <item id="middleware_id">
+                      <rank>30</rank>
+                    </item>
+                  </items>
+                  <rank>20</rank>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:ConfigMgnt:otherinfo">
+                  <items>
+                    <item id="move2production">
+                      <rank>50</rank>
+                    </item>
+                    <item id="description">
+                      <rank>60</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
               <rank>20</rank>
-            </item>
-            <item id="middleware_id">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="move2production">
-              <rank>50</rank>
-            </item>
-            <item id="description">
-              <rank>60</rank>
             </item>
             <item id="contacts_list">
               <rank>70</rank>
@@ -3064,23 +3254,48 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:ConfigMgnt:moreinfo">
+                  <items>
+                    <item id="dbserver_id">
+                      <rank>10</rank>
+                    </item>
+                  </items>
+                  <rank>20</rank>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:ConfigMgnt:otherinfo">
+                  <items>
+                    <item id="move2production">
+                      <rank>50</rank>
+                    </item>
+                    <item id="description">
+                      <rank>60</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
               <rank>20</rank>
-            </item>
-            <item id="dbserver_id">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="move2production">
-              <rank>50</rank>
-            </item>
-            <item id="description">
-              <rank>60</rank>
             </item>
             <item id="contacts_list">
               <rank>70</rank>
@@ -3207,26 +3422,51 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:ConfigMgnt:moreinfo">
+                  <items>
+                    <item id="webserver_id">
+                      <rank>30</rank>
+                    </item>
+                    <item id="url">
+                      <rank>40</rank>
+                    </item>
+                  </items>
+                  <rank>20</rank>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="org_id">
-              <rank>20</rank>
-            </item>
-            <item id="webserver_id">
-              <rank>30</rank>
-            </item>
-            <item id="url">
-              <rank>40</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>50</rank>
-            </item>
-            <item id="move2production">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:ConfigMgnt:otherinfo">
+                  <items>
+                    <item id="move2production">
               <rank>60</rank>
-            </item>
-            <item id="description">
-              <rank>70</rank>
+                    </item>
+                    <item id="description">
+                      <rank>70</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
+              <rank>20</rank>
             </item>
             <item id="contacts_list">
               <rank>80</rank>
@@ -3888,29 +4128,54 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:ConfigMgnt:moreinfo">
+                  <items>
+                    <item id="usage_limit">
+                      <rank>30</rank>
+                    </item>
+                    <item id="perpetual">
+                      <rank>50</rank>
+                    </item>
+                    <item id="licence_key">
+                      <rank>80</rank>
+                    </item>
+                  </items>
+                  <rank>20</rank>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:ConfigMgnt:otherinfo">
+                  <items>
+                    <item id="start_date">
+                      <rank>60</rank>
+                    </item>
+                    <item id="end_date">
+                      <rank>70</rank>
+                    </item>
+                    <item id="description">
+                      <rank>80</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
               <rank>20</rank>
-            </item>
-            <item id="usage_limit">
-              <rank>30</rank>
-            </item>
-            <item id="description">
-              <rank>40</rank>
-            </item>
-            <item id="perpetual">
-              <rank>50</rank>
-            </item>
-            <item id="start_date">
-              <rank>60</rank>
-            </item>
-            <item id="end_date">
-              <rank>70</rank>
-            </item>
-            <item id="licence_key">
-              <rank>80</rank>
             </item>
             <item id="documents_list">
               <rank>90</rank>
@@ -4035,35 +4300,60 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:ConfigMgnt:moreinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="osversion_id">
+                      <rank>30</rank>
+                    </item>
+                    <item id="usage_limit">
+                      <rank>50</rank>
+                    </item>
+                    <item id="perpetual">
+                      <rank>65</rank>
+                    </item>
+                    <item id="licence_key">
+                      <rank>90</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="documents_list">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:ConfigMgnt:otherinfo">
+                  <items>
+                    <item id="start_date">
+                      <rank>70</rank>
+                    </item>
+                    <item id="end_date">
+                      <rank>80</rank>
+                    </item>
+                    <item id="description">
+                      <rank>90</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
               <rank>20</rank>
             </item>
-            <item id="osversion_id">
-              <rank>30</rank>
-            </item>
-            <item id="org_id">
-              <rank>40</rank>
-            </item>
-            <item id="usage_limit">
-              <rank>50</rank>
-            </item>
-            <item id="description">
-              <rank>60</rank>
-            </item>
-            <item id="perpetual">
-              <rank>65</rank>
-            </item>
-            <item id="start_date">
-              <rank>70</rank>
-            </item>
-            <item id="end_date">
+            <item id="documents_list">
               <rank>80</rank>
-            </item>
-            <item id="licence_key">
-              <rank>90</rank>
             </item>
             <item id="servers_list">
               <rank>100</rank>
@@ -4073,7 +4363,7 @@
             </item>
           </items>
         </details>
-        <search>
+        <default_search>
           <items>
             <item id="name">
               <rank>10</rank>
@@ -4091,7 +4381,26 @@
               <rank>40</rank>
             </item>
           </items>
-        </search>
+        </default_search>
+        <search>
+        <items>
+          <item id="name">
+            <rank>10</rank>
+          </item>
+          <item id="perpetual">
+            <rank>15</rank>
+          </item>
+          <item id="start_date">
+            <rank>20</rank>
+          </item>
+          <item id="end_date">
+            <rank>30</rank>
+          </item>
+          <item id="licence_key">
+            <rank>40</rank>
+          </item>
+        </items>
+      </search>
         <list>
           <items>
             <item id="osversion_id">
@@ -4186,35 +4495,60 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:ConfigMgnt:moreinfo">
+                  <items>
+                    <item id="software_id">
+                      <rank>30</rank>
+                    </item>
+                    <item id="usage_limit">
+                      <rank>50</rank>
+                    </item>
+                    <item id="perpetual">
+                      <rank>65</rank>
+                    </item>
+                    <item id="licence_key">
+                      <rank>90</rank>
+                    </item>
+                  </items>
+                  <rank>20</rank>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="documents_list">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:ConfigMgnt:otherinfo">
+                  <items>
+                    <item id="start_date">
+                      <rank>70</rank>
+                    </item>
+                    <item id="end_date">
+                      <rank>80</rank>
+                    </item>
+                    <item id="description">
+                      <rank>90</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
               <rank>20</rank>
             </item>
-            <item id="software_id">
-              <rank>30</rank>
-            </item>
-            <item id="org_id">
-              <rank>40</rank>
-            </item>
-            <item id="usage_limit">
-              <rank>50</rank>
-            </item>
-            <item id="description">
-              <rank>60</rank>
-            </item>
-            <item id="perpetual">
-              <rank>65</rank>
-            </item>
-            <item id="start_date">
-              <rank>70</rank>
-            </item>
-            <item id="end_date">
+            <item id="documents_list">
               <rank>80</rank>
-            </item>
-            <item id="licence_key">
-              <rank>90</rank>
             </item>
             <item id="softwareinstance_list">
               <rank>100</rank>
@@ -6249,35 +6583,60 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:ConfigMgnt:moreinfo">
+                  <items>
+                    <item id="connectableci_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="location_id">
+                      <rank>30</rank>
+                    </item>
+                    <item id="ipaddress">
+                      <rank>50</rank>
+                    </item>
+                    <item id="macaddress">
+                      <rank>60</rank>
+                    </item>
+                    <item id="ipgateway">
+                      <rank>80</rank>
+                    </item>
+                    <item id="ipmask">
+                      <rank>90</rank>
+                    </item>
+                    <item id="speed">
+                      <rank>100</rank>
+                    </item>
+                  </items>
+                  <rank>20</rank>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="connectableci_id">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:Server:otherinfo">
+                  <items>
+                    <item id="comment">
+                      <rank>60</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
               <rank>20</rank>
-            </item>
-            <item id="location_id">
-              <rank>30</rank>
-            </item>
-            <item id="org_id">
-              <rank>40</rank>
-            </item>
-            <item id="ipaddress">
-              <rank>50</rank>
-            </item>
-            <item id="macaddress">
-              <rank>60</rank>
-            </item>
-            <item id="comment">
-              <rank>70</rank>
-            </item>
-            <item id="ipgateway">
-              <rank>80</rank>
-            </item>
-            <item id="ipmask">
-              <rank>90</rank>
-            </item>
-            <item id="speed">
-              <rank>100</rank>
             </item>
             <item id="vlans_list">
               <rank>110</rank>
@@ -7052,23 +7411,48 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+                <item id="fieldset:ConfigMgnt:moreinfo">
+                  <items>
+                    <item id="type">
+                      <rank>40</rank>
+                    </item>
+                    <item id="parent_id">
+                      <rank>60</rank>
+                    </item>
+                  </items>
+                  <rank>20</rank>
+                </item>
+              </items>
               <rank>10</rank>
             </item>
-            <item id="status">
-              <rank>20</rank>
-            </item>
-            <item id="org_id">
-              <rank>30</rank>
-            </item>
-            <item id="type">
-              <rank>40</rank>
-            </item>
-            <item id="description">
+            <item id="col:col2">
+              <items>
+                <item id="fieldset:Server:otherinfo">
+                  <items>
+                    <item id="description">
               <rank>50</rank>
-            </item>
-            <item id="parent_id">
-              <rank>60</rank>
+                    </item>
+                  </items>
+                  <rank>10</rank>
+                </item>
+              </items>
+              <rank>20</rank>
             </item>
             <item id="ci_list">
               <rank>70</rank>
@@ -7085,6 +7469,9 @@
             </item>
             <item id="org_id">
               <rank>30</rank>
+            </item>
+            <item id="status">
+              <rank>40</rank>
             </item>
           </items>
         </default_search>

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/cs.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/cs.dict.itop-config-mgmt.php
@@ -1532,6 +1532,8 @@ Dict::Add('CS CZ', 'Czech', 'Čeština', [
 	'ConfigMgnt:moreinfo' => 'CI specifics~~',
 	'Storage:moreinfo' => 'Storage specifics~~',
 	'ConfigMgnt:otherinfo' => 'Dates and description~~',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => 'Obecné informace',
 	'Server:Date' => 'Data',
 	'Server:moreinfo' => 'Více informací',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/cs.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/cs.dict.itop-config-mgmt.php
@@ -1528,6 +1528,10 @@ Dict::Add('CS CZ', 'Czech', 'Čeština', [
 // Add translation for Fieldsets
 
 Dict::Add('CS CZ', 'Czech', 'Čeština', [
+	'ConfigMgnt:baseinfo' => 'General~~',
+	'ConfigMgnt:moreinfo' => 'CI specifics~~',
+	'Storage:moreinfo' => 'Storage specifics~~',
+	'ConfigMgnt:otherinfo' => 'Dates and description~~',
 	'Server:baseinfo' => 'Obecné informace',
 	'Server:Date' => 'Data',
 	'Server:moreinfo' => 'Více informací',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/da.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/da.dict.itop-config-mgmt.php
@@ -1531,6 +1531,8 @@ Dict::Add('DA DA', 'Danish', 'Dansk', [
 	'ConfigMgnt:moreinfo' => 'CI specifics~~',
 	'Storage:moreinfo' => 'Storage specifics~~',
 	'ConfigMgnt:otherinfo' => 'Dates and description~~',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => 'Almindelig Informationen',
 	'Server:Date' => 'Dato',
 	'Server:moreinfo' => 'Yderligere Information',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/da.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/da.dict.itop-config-mgmt.php
@@ -1527,6 +1527,10 @@ Dict::Add('DA DA', 'Danish', 'Dansk', [
 // Add translation for Fieldsets
 
 Dict::Add('DA DA', 'Danish', 'Dansk', [
+	'ConfigMgnt:baseinfo' => 'General~~',
+	'ConfigMgnt:moreinfo' => 'CI specifics~~',
+	'Storage:moreinfo' => 'Storage specifics~~',
+	'ConfigMgnt:otherinfo' => 'Dates and description~~',
 	'Server:baseinfo' => 'Almindelig Informationen',
 	'Server:Date' => 'Dato',
 	'Server:moreinfo' => 'Yderligere Information',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/de.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/de.dict.itop-config-mgmt.php
@@ -1527,6 +1527,10 @@ Dict::Add('DE DE', 'German', 'Deutsch', [
 // Add translation for Fieldsets
 
 Dict::Add('DE DE', 'German', 'Deutsch', [
+	'ConfigMgnt:baseinfo' => 'General~~',
+	'ConfigMgnt:moreinfo' => 'CI specifics~~',
+	'Storage:moreinfo' => 'Storage specifics~~',
+	'ConfigMgnt:otherinfo' => 'Dates and description~~',
 	'Server:baseinfo' => 'Allgemeine Informationen',
 	'Server:Date' => 'Datum',
 	'Server:moreinfo' => 'Weitere Informationen',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/de.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/de.dict.itop-config-mgmt.php
@@ -1531,6 +1531,8 @@ Dict::Add('DE DE', 'German', 'Deutsch', [
 	'ConfigMgnt:moreinfo' => 'CI specifics~~',
 	'Storage:moreinfo' => 'Storage specifics~~',
 	'ConfigMgnt:otherinfo' => 'Dates and description~~',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => 'Allgemeine Informationen',
 	'Server:Date' => 'Datum',
 	'Server:moreinfo' => 'Weitere Informationen',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/en.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/en.dict.itop-config-mgmt.php
@@ -57,26 +57,7 @@ Dict::Add('EN US', 'English', 'English', [
 //////////////////////////////////////////////////////////////////////
 // Classes in 'bizmodel'
 //////////////////////////////////////////////////////////////////////
-//
 
-// Dictionnay conventions
-// Class:<class_name>
-// Class:<class_name>+
-// Class:<class_name>/Attribute:<attribute_code>
-// Class:<class_name>/Attribute:<attribute_code>+
-// Class:<class_name>/Attribute:<attribute_code>/Value:<value>
-// Class:<class_name>/Attribute:<attribute_code>/Value:<value>+
-// Class:<class_name>/Stimulus:<stimulus_code>
-// Class:<class_name>/Stimulus:<stimulus_code>+
-// Class:<class_name>/UniquenessRule:<rule_code>
-// Class:<class_name>/UniquenessRule:<rule_code>+
-
-//////////////////////////////////////////////////////////////////////
-// Note: The classes have been grouped by categories: bizmodel
-//////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////
-// Classes in 'bizmodel'
-//////////////////////////////////////////////////////////////////////
 //
 
 //
@@ -1536,6 +1517,17 @@ Dict::Add('EN US', 'English', 'English', [
 ]);
 
 //
+// Class: PhysicalInterface
+//
+
+Dict::Add('EN US', 'English', 'English', [
+	'Class:PhysicalInterface/Attribute:org_id' => 'Org id',
+	'Class:PhysicalInterface/Attribute:org_id+' => '',
+	'Class:PhysicalInterface/Attribute:location_id' => 'Location id',
+	'Class:PhysicalInterface/Attribute:location_id+' => '',
+]);
+
+//
 // Class: lnkGroupToCI
 //
 
@@ -1555,23 +1547,6 @@ Dict::Add('EN US', 'English', 'English', [
 	'Class:lnkGroupToCI/Attribute:reason+' => '',
 ]);
 
-// Add translation for Fieldsets
-
-Dict::Add('EN US', 'English', 'English', [
-	'Server:baseinfo' => 'General information',
-	'Server:Date' => 'Dates',
-	'Server:moreinfo' => 'More information',
-	'Server:otherinfo' => 'Other information',
-	'Server:power' => 'Power supply',
-	'Class:Subnet/Tab:IPUsage' => 'IP Usage',
-	'Class:Subnet/Tab:IPUsage+' => 'Which IP within this Subnet is used or not',
-	'Class:Subnet/Tab:IPUsage-explain' => 'Interfaces having an IP in the range: <em>%1$s</em> to <em>%2$s</em>',
-	'Class:Subnet/Tab:FreeIPs' => 'Free IPs',
-	'Class:Subnet/Tab:FreeIPs-count' => 'Free IPs: %1$s',
-	'Class:Subnet/Tab:FreeIPs-explain' => 'Here is an extract of 10 free IP addresses',
-	'Class:Document:PreviewTab' => 'Preview',
-]);
-
 //
 // Class: lnkDocumentToFunctionalCI
 //
@@ -1588,6 +1563,27 @@ Dict::Add('EN US', 'English', 'English', [
 	'Class:lnkDocumentToFunctionalCI/Attribute:document_id+' => '',
 	'Class:lnkDocumentToFunctionalCI/Attribute:document_name' => 'Document name',
 	'Class:lnkDocumentToFunctionalCI/Attribute:document_name+' => '',
+]);
+
+// Add translation for Fieldsets
+
+Dict::Add('EN US', 'English', 'English', [
+	'ConfigMgnt:baseinfo' => 'General',
+	'ConfigMgnt:moreinfo' => 'CI specifics',
+	'ConfigMgnt:otherinfo' => 'Dates and description',
+	'Storage:moreinfo' => 'Storage specifics',
+	'Server:baseinfo' => 'General',
+	'Server:moreinfo' => 'Device specifics',
+	'Server:Date' => 'Dates',
+	'Server:otherinfo' => 'Description',
+	'Server:power' => 'Power supply',
+	'Class:Subnet/Tab:IPUsage' => 'IP Usage',
+	'Class:Subnet/Tab:IPUsage+' => 'Which IP within this Subnet is used or not',
+	'Class:Subnet/Tab:IPUsage-explain' => 'Interfaces having an IP in the range: <em>%1$s</em> to <em>%2$s</em>',
+	'Class:Subnet/Tab:FreeIPs' => 'Free IPs',
+	'Class:Subnet/Tab:FreeIPs-count' => 'Free IPs: %1$s',
+	'Class:Subnet/Tab:FreeIPs-explain' => 'Here is an extract of 10 free IP addresses',
+	'Class:Document:PreviewTab' => 'Preview',
 ]);
 
 //
@@ -1639,15 +1635,4 @@ Dict::Add('EN US', 'English', 'English', [
 	'Menu:OSVersion+' => '',
 	'Menu:Software' => 'Software catalog',
 	'Menu:Software+' => 'Software catalog',
-]);
-
-//
-// Class: PhysicalInterface
-//
-
-Dict::Add('EN US', 'English', 'English', [
-	'Class:PhysicalInterface/Attribute:org_id' => 'Org id',
-	'Class:PhysicalInterface/Attribute:org_id+' => '',
-	'Class:PhysicalInterface/Attribute:location_id' => 'Location id',
-	'Class:PhysicalInterface/Attribute:location_id+' => '',
 ]);

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/en.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/en.dict.itop-config-mgmt.php
@@ -1572,6 +1572,8 @@ Dict::Add('EN US', 'English', 'English', [
 	'ConfigMgnt:moreinfo' => 'CI specifics',
 	'ConfigMgnt:otherinfo' => 'Dates and description',
 	'Storage:moreinfo' => 'Storage specifics',
+	'Software:moreinfo' => 'Software specifics',
+	'Phone:moreinfo' => 'Phone specifics',
 	'Server:baseinfo' => 'General',
 	'Server:moreinfo' => 'Device specifics',
 	'Server:Date' => 'Dates',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/en_gb.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/en_gb.dict.itop-config-mgmt.php
@@ -59,26 +59,6 @@ Dict::Add('EN GB', 'British English', 'British English', [
 //////////////////////////////////////////////////////////////////////
 //
 
-// Dictionnay conventions
-// Class:<class_name>
-// Class:<class_name>+
-// Class:<class_name>/Attribute:<attribute_code>
-// Class:<class_name>/Attribute:<attribute_code>+
-// Class:<class_name>/Attribute:<attribute_code>/Value:<value>
-// Class:<class_name>/Attribute:<attribute_code>/Value:<value>+
-// Class:<class_name>/Stimulus:<stimulus_code>
-// Class:<class_name>/Stimulus:<stimulus_code>+
-// Class:<class_name>/UniquenessRule:<rule_code>
-// Class:<class_name>/UniquenessRule:<rule_code>+
-
-//////////////////////////////////////////////////////////////////////
-// Note: The classes have been grouped by categories: bizmodel
-//////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////
-// Classes in 'bizmodel'
-//////////////////////////////////////////////////////////////////////
-//
-
 //
 // Class: lnkContactToFunctionalCI
 //
@@ -1548,10 +1528,14 @@ Dict::Add('EN GB', 'British English', 'British English', [
 // Add translation for Fieldsets
 
 Dict::Add('EN GB', 'British English', 'British English', [
-	'Server:baseinfo' => 'General information',
+	'ConfigMgnt:baseinfo' => 'General',
+	'ConfigMgnt:moreinfo' => 'CI specifics',
+	'ConfigMgnt:otherinfo' => 'Dates and description',
+	'Storage:moreinfo' => 'Storage specifics',
+	'Server:baseinfo' => 'General',
+	'Server:moreinfo' => 'Device specifics',
 	'Server:Date' => 'Dates',
-	'Server:moreinfo' => 'More information',
-	'Server:otherinfo' => 'Other information',
+	'Server:otherinfo' => 'Description',
 	'Server:power' => 'Power supply',
 	'Class:Subnet/Tab:IPUsage' => 'IP Usage',
 	'Class:Subnet/Tab:IPUsage+' => 'Which IP within this Subnet is used or not',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/en_gb.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/en_gb.dict.itop-config-mgmt.php
@@ -1532,6 +1532,8 @@ Dict::Add('EN GB', 'British English', 'British English', [
 	'ConfigMgnt:moreinfo' => 'CI specifics',
 	'ConfigMgnt:otherinfo' => 'Dates and description',
 	'Storage:moreinfo' => 'Storage specifics',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => 'General',
 	'Server:moreinfo' => 'Device specifics',
 	'Server:Date' => 'Dates',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/es_cr.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/es_cr.dict.itop-config-mgmt.php
@@ -1528,6 +1528,8 @@ Dict::Add('ES CR', 'Spanish', 'Español, Castellano', [
 	'ConfigMgnt:moreinfo' => 'CI specifics~~',
 	'Storage:moreinfo' => 'Storage specifics~~',
 	'ConfigMgnt:otherinfo' => 'Dates and description~~',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => 'Información General',
 	'Server:Date' => 'Fecha',
 	'Server:moreinfo' => 'Más Información',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/es_cr.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/es_cr.dict.itop-config-mgmt.php
@@ -1524,6 +1524,10 @@ Dict::Add('ES CR', 'Spanish', 'Español, Castellano', [
 // Add translation for Fieldsets
 
 Dict::Add('ES CR', 'Spanish', 'Español, Castellano', [
+	'ConfigMgnt:baseinfo' => 'General~~',
+	'ConfigMgnt:moreinfo' => 'CI specifics~~',
+	'Storage:moreinfo' => 'Storage specifics~~',
+	'ConfigMgnt:otherinfo' => 'Dates and description~~',
 	'Server:baseinfo' => 'Información General',
 	'Server:Date' => 'Fecha',
 	'Server:moreinfo' => 'Más Información',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/fr.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/fr.dict.itop-config-mgmt.php
@@ -37,23 +37,6 @@ Dict::Add('FR FR', 'French', 'Français', [
 // Class:<class_name>/UniquenessRule:<rule_code>+
 
 //////////////////////////////////////////////////////////////////////
-// Classes in 'bizmodel'
-//////////////////////////////////////////////////////////////////////
-//
-
-// Dictionnay conventions
-// Class:<class_name>
-// Class:<class_name>+
-// Class:<class_name>/Attribute:<attribute_code>
-// Class:<class_name>/Attribute:<attribute_code>+
-// Class:<class_name>/Attribute:<attribute_code>/Value:<value>
-// Class:<class_name>/Attribute:<attribute_code>/Value:<value>+
-// Class:<class_name>/Stimulus:<stimulus_code>
-// Class:<class_name>/Stimulus:<stimulus_code>+
-// Class:<class_name>/UniquenessRule:<rule_code>
-// Class:<class_name>/UniquenessRule:<rule_code>+
-
-//////////////////////////////////////////////////////////////////////
 // Note: The classes have been grouped by categories: bizmodel
 //////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
@@ -1686,6 +1669,17 @@ Dict::Add('FR FR', 'French', 'Français', [
 ]);
 
 //
+// Class: PhysicalInterface
+//
+
+Dict::Add('FR FR', 'French', 'Français', [
+	'Class:PhysicalInterface/Attribute:org_id' => 'Organisation',
+	'Class:PhysicalInterface/Attribute:org_id+' => '',
+	'Class:PhysicalInterface/Attribute:location_id' => 'Site',
+	'Class:PhysicalInterface/Attribute:location_id+' => '',
+]);
+
+//
 // Class: lnkGroupToCI
 //
 
@@ -1705,23 +1699,6 @@ Dict::Add('FR FR', 'French', 'Français', [
 	'Class:lnkGroupToCI/Attribute:reason+' => '',
 ]);
 
-// Add translation for Fieldsets
-
-Dict::Add('FR FR', 'French', 'Français', [
-	'Server:baseinfo' => 'Informations générales',
-	'Server:Date' => 'Dates',
-	'Server:moreinfo' => 'Informations complémentaires',
-	'Server:otherinfo' => 'Autres informations',
-	'Server:power' => 'Alimentation électrique',
-	'Class:Subnet/Tab:IPUsage' => 'IP utilisées',
-	'Class:Subnet/Tab:IPUsage+' => 'Utilisation des IPs de ce subnet',
-	'Class:Subnet/Tab:IPUsage-explain' => 'Interfaces ayant une IP dans la plage: <em>%1$s</em> à <em>%2$s</em>',
-	'Class:Subnet/Tab:FreeIPs' => 'IP disponibles',
-	'Class:Subnet/Tab:FreeIPs-count' => 'IP disponibles: %1$s',
-	'Class:Subnet/Tab:FreeIPs-explain' => 'Voici un échantillon de dix addresses IP disponibles',
-	'Class:Document:PreviewTab' => 'Aperçu',
-]);
-
 //
 // Class: lnkDocumentToFunctionalCI
 //
@@ -1738,6 +1715,27 @@ Dict::Add('FR FR', 'French', 'Français', [
 	'Class:lnkDocumentToFunctionalCI/Attribute:document_id+' => '',
 	'Class:lnkDocumentToFunctionalCI/Attribute:document_name' => 'Nom Document',
 	'Class:lnkDocumentToFunctionalCI/Attribute:document_name+' => '',
+]);
+
+// Add translation for Fieldsets
+
+Dict::Add('FR FR', 'French', 'Français', [
+	'ConfigMgnt:baseinfo' => 'Informations générales',
+	'Server:baseinfo' => 'Informations générales',
+	'ConfigMgnt:moreinfo' => 'Item spécifique',
+	'Server:moreinfo' => 'Matériel spécifique',
+	'Storage:moreinfo' => 'Stockage spécifique',
+	'ConfigMgnt:otherinfo' => 'Dates et description',
+	'Server:Date' => 'Dates',
+	'Server:otherinfo' => 'Description',
+	'Server:power' => 'Alimentation électrique',
+	'Class:Subnet/Tab:IPUsage' => 'IP utilisées',
+	'Class:Subnet/Tab:IPUsage+' => 'Utilisation des IPs de ce subnet',
+	'Class:Subnet/Tab:IPUsage-explain' => 'Interfaces ayant une IP dans la plage: <em>%1$s</em> à <em>%2$s</em>',
+	'Class:Subnet/Tab:FreeIPs' => 'IP disponibles',
+	'Class:Subnet/Tab:FreeIPs-count' => 'IP disponibles: %1$s',
+	'Class:Subnet/Tab:FreeIPs-explain' => 'Voici un échantillon de dix addresses IP disponibles',
+	'Class:Document:PreviewTab' => 'Aperçu',
 ]);
 
 //
@@ -1789,15 +1787,4 @@ Dict::Add('FR FR', 'French', 'Français', [
 	'Menu:OSVersion+' => '',
 	'Menu:Software' => 'Catalogue des logiciels de références',
 	'Menu:Software+' => 'Catalogue des logiciels de références',
-]);
-
-//
-// Class: PhysicalInterface
-//
-
-Dict::Add('FR FR', 'French', 'Français', [
-	'Class:PhysicalInterface/Attribute:org_id' => 'Organisation',
-	'Class:PhysicalInterface/Attribute:org_id+' => '',
-	'Class:PhysicalInterface/Attribute:location_id' => 'Site',
-	'Class:PhysicalInterface/Attribute:location_id+' => '',
 ]);

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/fr.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/fr.dict.itop-config-mgmt.php
@@ -1725,6 +1725,8 @@ Dict::Add('FR FR', 'French', 'Français', [
 	'ConfigMgnt:moreinfo' => 'Item spécifique',
 	'Server:moreinfo' => 'Matériel spécifique',
 	'Storage:moreinfo' => 'Stockage spécifique',
+	'Software:moreinfo' => 'Logiciel spécifique',
+	'Phone:moreinfo' => 'Téléphone spécifique',
 	'ConfigMgnt:otherinfo' => 'Dates et description',
 	'Server:Date' => 'Dates',
 	'Server:otherinfo' => 'Description',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/hu.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/hu.dict.itop-config-mgmt.php
@@ -1530,6 +1530,8 @@ Dict::Add('HU HU', 'Hungarian', 'Magyar', [
 	'ConfigMgnt:moreinfo' => 'CI specifics~~',
 	'Storage:moreinfo' => 'Storage specifics~~',
 	'ConfigMgnt:otherinfo' => 'Dates and description~~',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => 'Általános információ',
 	'Server:Date' => 'Dátumok',
 	'Server:moreinfo' => 'További információ',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/hu.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/hu.dict.itop-config-mgmt.php
@@ -1526,10 +1526,14 @@ Dict::Add('HU HU', 'Hungarian', 'Magyar', [
 // Add translation for Fieldsets
 
 Dict::Add('HU HU', 'Hungarian', 'Magyar', [
+	'ConfigMgnt:baseinfo' => 'General~~',
+	'ConfigMgnt:moreinfo' => 'CI specifics~~',
+	'Storage:moreinfo' => 'Storage specifics~~',
+	'ConfigMgnt:otherinfo' => 'Dates and description~~',
 	'Server:baseinfo' => 'Általános információ',
 	'Server:Date' => 'Dátumok',
 	'Server:moreinfo' => 'További információ',
-	'Server:otherinfo' => 'Other information~~',
+	'Server:otherinfo' => 'Description~~',
 	'Server:power' => 'Áramforrás',
 	'Class:Subnet/Tab:IPUsage' => 'IP felhasználás',
 	'Class:Subnet/Tab:IPUsage+' => 'Which IP within this Subnet is used or not~~',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/it.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/it.dict.itop-config-mgmt.php
@@ -1547,6 +1547,10 @@ Dict::Add('IT IT', 'Italian', 'Italiano', [
 // Add translation for Fieldsets
 
 Dict::Add('IT IT', 'Italian', 'Italiano', [
+	'ConfigMgnt:baseinfo' => 'General~~',
+	'ConfigMgnt:moreinfo' => 'CI specifics~~',
+	'Storage:moreinfo' => 'Storage specifics~~',
+	'ConfigMgnt:otherinfo' => 'Dates and description~~',
 	'Server:baseinfo' => 'Informazioni generali',
 	'Server:Date' => 'Date',
 	'Server:moreinfo' => 'Ulteriori informazioni',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/it.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/it.dict.itop-config-mgmt.php
@@ -1551,6 +1551,8 @@ Dict::Add('IT IT', 'Italian', 'Italiano', [
 	'ConfigMgnt:moreinfo' => 'CI specifics~~',
 	'Storage:moreinfo' => 'Storage specifics~~',
 	'ConfigMgnt:otherinfo' => 'Dates and description~~',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => 'Informazioni generali',
 	'Server:Date' => 'Date',
 	'Server:moreinfo' => 'Ulteriori informazioni',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/ja.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/ja.dict.itop-config-mgmt.php
@@ -1526,6 +1526,10 @@ Dict::Add('JA JP', 'Japanese', '日本語', [
 // Add translation for Fieldsets
 
 Dict::Add('JA JP', 'Japanese', '日本語', [
+	'ConfigMgnt:baseinfo' => 'General~~',
+	'ConfigMgnt:moreinfo' => 'CI specifics~~',
+	'Storage:moreinfo' => 'Storage specifics~~',
+	'ConfigMgnt:otherinfo' => 'Dates and description~~',
 	'Server:baseinfo' => '基本情報',
 	'Server:Date' => '日付',
 	'Server:moreinfo' => '追加情報',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/ja.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/ja.dict.itop-config-mgmt.php
@@ -1530,6 +1530,8 @@ Dict::Add('JA JP', 'Japanese', '日本語', [
 	'ConfigMgnt:moreinfo' => 'CI specifics~~',
 	'Storage:moreinfo' => 'Storage specifics~~',
 	'ConfigMgnt:otherinfo' => 'Dates and description~~',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => '基本情報',
 	'Server:Date' => '日付',
 	'Server:moreinfo' => '追加情報',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/nl.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/nl.dict.itop-config-mgmt.php
@@ -1528,6 +1528,10 @@ Dict::Add('NL NL', 'Dutch', 'Nederlands', [
 // Add translation for Fieldsets
 
 Dict::Add('NL NL', 'Dutch', 'Nederlands', [
+	'ConfigMgnt:baseinfo' => 'General~~',
+	'ConfigMgnt:moreinfo' => 'CI specifics~~',
+	'Storage:moreinfo' => 'Storage specifics~~',
+	'ConfigMgnt:otherinfo' => 'Dates and description~~',
 	'Server:baseinfo' => 'Globale informatie',
 	'Server:Date' => 'Datum',
 	'Server:moreinfo' => 'Meer informatie',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/nl.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/nl.dict.itop-config-mgmt.php
@@ -1532,6 +1532,8 @@ Dict::Add('NL NL', 'Dutch', 'Nederlands', [
 	'ConfigMgnt:moreinfo' => 'CI specifics~~',
 	'Storage:moreinfo' => 'Storage specifics~~',
 	'ConfigMgnt:otherinfo' => 'Dates and description~~',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => 'Globale informatie',
 	'Server:Date' => 'Datum',
 	'Server:moreinfo' => 'Meer informatie',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/pl.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/pl.dict.itop-config-mgmt.php
@@ -1526,6 +1526,10 @@ Dict::Add('PL PL', 'Polish', 'Polski', [
 // Add translation for Fieldsets
 
 Dict::Add('PL PL', 'Polish', 'Polski', [
+	'ConfigMgnt:baseinfo' => 'General~~',
+	'ConfigMgnt:moreinfo' => 'CI specifics~~',
+	'Storage:moreinfo' => 'Storage specifics~~',
+	'ConfigMgnt:otherinfo' => 'Dates and description~~',
 	'Server:baseinfo' => 'Informacje ogólne',
 	'Server:Date' => 'Daty',
 	'Server:moreinfo' => 'Więcej informacji',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/pl.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/pl.dict.itop-config-mgmt.php
@@ -1530,6 +1530,8 @@ Dict::Add('PL PL', 'Polish', 'Polski', [
 	'ConfigMgnt:moreinfo' => 'CI specifics~~',
 	'Storage:moreinfo' => 'Storage specifics~~',
 	'ConfigMgnt:otherinfo' => 'Dates and description~~',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => 'Informacje ogólne',
 	'Server:Date' => 'Daty',
 	'Server:moreinfo' => 'Więcej informacji',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/pt_br.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/pt_br.dict.itop-config-mgmt.php
@@ -1530,6 +1530,8 @@ Dict::Add('PT BR', 'Brazilian', 'Brazilian', [
 	'ConfigMgnt:moreinfo' => 'CI specifics~~',
 	'Storage:moreinfo' => 'Storage specifics~~',
 	'ConfigMgnt:otherinfo' => 'Dates and description~~',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => 'Informações gerais',
 	'Server:Date' => 'Data',
 	'Server:moreinfo' => 'Mais informações',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/pt_br.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/pt_br.dict.itop-config-mgmt.php
@@ -1526,6 +1526,10 @@ Dict::Add('PT BR', 'Brazilian', 'Brazilian', [
 // Add translation for Fieldsets
 
 Dict::Add('PT BR', 'Brazilian', 'Brazilian', [
+	'ConfigMgnt:baseinfo' => 'General~~',
+	'ConfigMgnt:moreinfo' => 'CI specifics~~',
+	'Storage:moreinfo' => 'Storage specifics~~',
+	'ConfigMgnt:otherinfo' => 'Dates and description~~',
 	'Server:baseinfo' => 'Informações gerais',
 	'Server:Date' => 'Data',
 	'Server:moreinfo' => 'Mais informações',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/ru.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/ru.dict.itop-config-mgmt.php
@@ -1531,6 +1531,8 @@ Dict::Add('RU RU', 'Russian', 'Русский', [
 	'ConfigMgnt:moreinfo' => 'CI specifics~~',
 	'Storage:moreinfo' => 'Storage specifics~~',
 	'ConfigMgnt:otherinfo' => 'Dates and description~~',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => 'Основное',
 	'Server:Date' => 'Даты',
 	'Server:moreinfo' => 'Спецификация',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/ru.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/ru.dict.itop-config-mgmt.php
@@ -1527,6 +1527,10 @@ Dict::Add('RU RU', 'Russian', 'Русский', [
 // Add translation for Fieldsets
 
 Dict::Add('RU RU', 'Russian', 'Русский', [
+	'ConfigMgnt:baseinfo' => 'General~~',
+	'ConfigMgnt:moreinfo' => 'CI specifics~~',
+	'Storage:moreinfo' => 'Storage specifics~~',
+	'ConfigMgnt:otherinfo' => 'Dates and description~~',
 	'Server:baseinfo' => 'Основное',
 	'Server:Date' => 'Даты',
 	'Server:moreinfo' => 'Спецификация',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/sk.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/sk.dict.itop-config-mgmt.php
@@ -1526,6 +1526,10 @@ Dict::Add('SK SK', 'Slovak', 'Slovenčina', [
 // Add translation for Fieldsets
 
 Dict::Add('SK SK', 'Slovak', 'Slovenčina', [
+	'ConfigMgnt:baseinfo' => 'General~~',
+	'ConfigMgnt:moreinfo' => 'CI specifics~~',
+	'Storage:moreinfo' => 'Storage specifics~~',
+	'ConfigMgnt:otherinfo' => 'Dates and description~~',
 	'Server:baseinfo' => 'Všeobecné informácie',
 	'Server:Date' => 'Dátum',
 	'Server:moreinfo' => 'Viac informácií',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/sk.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/sk.dict.itop-config-mgmt.php
@@ -1530,6 +1530,8 @@ Dict::Add('SK SK', 'Slovak', 'Slovenčina', [
 	'ConfigMgnt:moreinfo' => 'CI specifics~~',
 	'Storage:moreinfo' => 'Storage specifics~~',
 	'ConfigMgnt:otherinfo' => 'Dates and description~~',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => 'Všeobecné informácie',
 	'Server:Date' => 'Dátum',
 	'Server:moreinfo' => 'Viac informácií',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/tr.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/tr.dict.itop-config-mgmt.php
@@ -1527,6 +1527,10 @@ Dict::Add('TR TR', 'Turkish', 'Türkçe', [
 // Add translation for Fieldsets
 
 Dict::Add('TR TR', 'Turkish', 'Türkçe', [
+	'ConfigMgnt:baseinfo' => 'General~~',
+	'ConfigMgnt:moreinfo' => 'CI specifics~~',
+	'Storage:moreinfo' => 'Storage specifics~~',
+	'ConfigMgnt:otherinfo' => 'Dates and description~~',
 	'Server:baseinfo' => 'Genel Bilgi',
 	'Server:Date' => 'Tarihler',
 	'Server:moreinfo' => 'Daha fazla bilgi',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/tr.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/tr.dict.itop-config-mgmt.php
@@ -1531,6 +1531,8 @@ Dict::Add('TR TR', 'Turkish', 'Türkçe', [
 	'ConfigMgnt:moreinfo' => 'CI specifics~~',
 	'Storage:moreinfo' => 'Storage specifics~~',
 	'ConfigMgnt:otherinfo' => 'Dates and description~~',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => 'Genel Bilgi',
 	'Server:Date' => 'Tarihler',
 	'Server:moreinfo' => 'Daha fazla bilgi',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/zh_cn.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/zh_cn.dict.itop-config-mgmt.php
@@ -1543,6 +1543,10 @@ Dict::Add('ZH CN', 'Chinese', '简体中文', [
 // Add translation for Fieldsets
 
 Dict::Add('ZH CN', 'Chinese', '简体中文', [
+	'ConfigMgnt:baseinfo' => 'General~~',
+	'ConfigMgnt:moreinfo' => 'CI specifics~~',
+	'Storage:moreinfo' => 'Storage specifics~~',
+	'ConfigMgnt:otherinfo' => 'Dates and description~~',
 	'Server:baseinfo' => '基本信息',
 	'Server:Date' => '日期',
 	'Server:moreinfo' => '更多信息',

--- a/datamodels/2.x/itop-config-mgmt/dictionaries/zh_cn.dict.itop-config-mgmt.php
+++ b/datamodels/2.x/itop-config-mgmt/dictionaries/zh_cn.dict.itop-config-mgmt.php
@@ -1547,6 +1547,8 @@ Dict::Add('ZH CN', 'Chinese', '简体中文', [
 	'ConfigMgnt:moreinfo' => 'CI specifics~~',
 	'Storage:moreinfo' => 'Storage specifics~~',
 	'ConfigMgnt:otherinfo' => 'Dates and description~~',
+	'Software:moreinfo' => 'Software specifics~~',
+	'Phone:moreinfo' => 'Phone specifics~~',
 	'Server:baseinfo' => '基本信息',
 	'Server:Date' => '日期',
 	'Server:moreinfo' => '更多信息',

--- a/datamodels/2.x/itop-datacenter-mgmt/datamodel.itop-datacenter-mgmt.xml
+++ b/datamodels/2.x/itop-datacenter-mgmt/datamodel.itop-datacenter-mgmt.xml
@@ -57,47 +57,77 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
               <rank>10</rank>
+              <items>
+                <item id="fieldset:Server:baseinfo">
+                  <rank>10</rank>
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                    <item id="location_id">
+                      <rank>50</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:moreinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="brand_id">
+                      <rank>60</rank>
+                    </item>
+                    <item id="model_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="nb_u">
+                      <rank>80</rank>
+                    </item>
+                    <item id="serialnumber">
+                      <rank>90</rank>
+                    </item>
+                    <item id="asset_number">
+                      <rank>100</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
               <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="location_id">
-              <rank>50</rank>
-            </item>
-            <item id="brand_id">
-              <rank>60</rank>
-            </item>
-            <item id="model_id">
-              <rank>70</rank>
-            </item>
-            <item id="nb_u">
-              <rank>80</rank>
-            </item>
-            <item id="serialnumber">
-              <rank>90</rank>
-            </item>
-            <item id="asset_number">
-              <rank>100</rank>
-            </item>
-            <item id="move2production">
-              <rank>110</rank>
-            </item>
-            <item id="purchase_date">
-              <rank>120</rank>
-            </item>
-            <item id="end_of_warranty">
-              <rank>130</rank>
-            </item>
-            <item id="description">
-              <rank>140</rank>
+              <items>
+                <item id="fieldset:Server:Date">
+                  <rank>10</rank>
+                  <items>
+                    <item id="move2production">
+                      <rank>110</rank>
+                    </item>
+                    <item id="purchase_date">
+                      <rank>120</rank>
+                    </item>
+                    <item id="end_of_warranty">
+                      <rank>130</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="description">
+                      <rank>140</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
             <item id="contacts_list">
               <rank>150</rank>
@@ -257,50 +287,80 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
               <rank>10</rank>
+              <items>
+                <item id="fieldset:Server:baseinfo">
+                  <rank>10</rank>
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                    <item id="location_id">
+                      <rank>50</rank>
+                    </item>
+                    <item id="rack_id">
+                      <rank>60</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:moreinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="brand_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="model_id">
+                      <rank>80</rank>
+                    </item>
+                    <item id="nb_u">
+                      <rank>90</rank>
+                    </item>
+                    <item id="serialnumber">
+                      <rank>100</rank>
+                    </item>
+                    <item id="asset_number">
+                      <rank>110</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
               <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="location_id">
-              <rank>50</rank>
-            </item>
-            <item id="rack_id">
-              <rank>60</rank>
-            </item>
-            <item id="brand_id">
-              <rank>70</rank>
-            </item>
-            <item id="model_id">
-              <rank>80</rank>
-            </item>
-            <item id="nb_u">
-              <rank>90</rank>
-            </item>
-            <item id="serialnumber">
-              <rank>100</rank>
-            </item>
-            <item id="asset_number">
-              <rank>110</rank>
-            </item>
-            <item id="move2production">
-              <rank>120</rank>
-            </item>
-            <item id="purchase_date">
-              <rank>130</rank>
-            </item>
-            <item id="end_of_warranty">
-              <rank>140</rank>
-            </item>
-            <item id="description">
-              <rank>150</rank>
+              <items>
+                <item id="fieldset:Server:Date">
+                  <rank>10</rank>
+                  <items>
+                    <item id="move2production">
+                      <rank>120</rank>
+                    </item>
+                    <item id="purchase_date">
+                      <rank>130</rank>
+                    </item>
+                    <item id="end_of_warranty">
+                      <rank>140</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="description">
+                      <rank>150</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
             <item id="contacts_list">
               <rank>160</rank>
@@ -440,44 +500,74 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
               <rank>10</rank>
+              <items>
+                <item id="fieldset:Server:baseinfo">
+                  <rank>10</rank>
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                    <item id="location_id">
+                      <rank>50</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:moreinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="brand_id">
+                      <rank>60</rank>
+                    </item>
+                    <item id="model_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="serialnumber">
+                      <rank>80</rank>
+                    </item>
+                    <item id="asset_number">
+                      <rank>90</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
               <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="location_id">
-              <rank>50</rank>
-            </item>
-            <item id="brand_id">
-              <rank>60</rank>
-            </item>
-            <item id="model_id">
-              <rank>70</rank>
-            </item>
-            <item id="serialnumber">
-              <rank>80</rank>
-            </item>
-            <item id="asset_number">
-              <rank>90</rank>
-            </item>
-            <item id="move2production">
-              <rank>100</rank>
-            </item>
-            <item id="purchase_date">
-              <rank>110</rank>
-            </item>
-            <item id="end_of_warranty">
-              <rank>120</rank>
-            </item>
-            <item id="description">
-              <rank>130</rank>
+              <items>
+                <item id="fieldset:Server:Date">
+                  <rank>10</rank>
+                  <items>
+                    <item id="move2production">
+                      <rank>100</rank>
+                    </item>
+                    <item id="purchase_date">
+                      <rank>110</rank>
+                    </item>
+                    <item id="end_of_warranty">
+                      <rank>120</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="description">
+                      <rank>130</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
             <item id="contacts_list">
               <rank>140</rank>
@@ -613,44 +703,74 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
               <rank>10</rank>
+              <items>
+                <item id="fieldset:Server:baseinfo">
+                  <rank>10</rank>
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                    <item id="location_id">
+                      <rank>50</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:moreinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="brand_id">
+                      <rank>60</rank>
+                    </item>
+                    <item id="model_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="serialnumber">
+                      <rank>80</rank>
+                    </item>
+                    <item id="asset_number">
+                      <rank>90</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
               <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="location_id">
-              <rank>50</rank>
-            </item>
-            <item id="brand_id">
-              <rank>60</rank>
-            </item>
-            <item id="model_id">
-              <rank>70</rank>
-            </item>
-            <item id="serialnumber">
-              <rank>80</rank>
-            </item>
-            <item id="asset_number">
-              <rank>90</rank>
-            </item>
-            <item id="move2production">
-              <rank>100</rank>
-            </item>
-            <item id="purchase_date">
-              <rank>110</rank>
-            </item>
-            <item id="end_of_warranty">
-              <rank>120</rank>
-            </item>
-            <item id="description">
-              <rank>130</rank>
+              <items>
+                <item id="fieldset:Server:Date">
+                  <rank>10</rank>
+                  <items>
+                    <item id="move2production">
+                      <rank>100</rank>
+                    </item>
+                    <item id="purchase_date">
+                        <rank>110</rank>
+                    </item>
+                    <item id="end_of_warranty">
+                        <rank>120</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="description">
+                      <rank>130</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
             <item id="pdus_list">
               <rank>140</rank>
@@ -806,50 +926,80 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
               <rank>10</rank>
+              <items>
+                <item id="fieldset:Server:baseinfo">
+                  <rank>10</rank>
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                    <item id="location_id">
+                      <rank>50</rank>
+                    </item>
+                    <item id="rack_id">
+                      <rank>60</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:moreinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="powerstart_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="brand_id">
+                      <rank>80</rank>
+                    </item>
+                    <item id="model_id">
+                      <rank>90</rank>
+                    </item>
+                    <item id="serialnumber">
+                      <rank>100</rank>
+                    </item>
+                    <item id="asset_number">
+                      <rank>110</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
               <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="location_id">
-              <rank>50</rank>
-            </item>
-            <item id="rack_id">
-              <rank>60</rank>
-            </item>
-            <item id="powerstart_id">
-              <rank>70</rank>
-            </item>
-            <item id="brand_id">
-              <rank>80</rank>
-            </item>
-            <item id="model_id">
-              <rank>90</rank>
-            </item>
-            <item id="serialnumber">
-              <rank>100</rank>
-            </item>
-            <item id="asset_number">
-              <rank>110</rank>
-            </item>
-            <item id="move2production">
-              <rank>120</rank>
-            </item>
-            <item id="purchase_date">
-              <rank>130</rank>
-            </item>
-            <item id="end_of_warranty">
-              <rank>140</rank>
-            </item>
-            <item id="description">
-              <rank>150</rank>
+              <items>
+                <item id="fieldset:Server:Date">
+                  <rank>10</rank>
+                  <items>
+                    <item id="move2production">
+                        <rank>120</rank>
+                    </item>
+                    <item id="purchase_date">
+                      <rank>130</rank>
+                    </item>
+                    <item id="end_of_warranty">
+                        <rank>140</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="description">
+                      <rank>150</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
             <item id="contacts_list">
               <rank>160</rank>

--- a/datamodels/2.x/itop-endusers-devices/datamodel.itop-endusers-devices.xml
+++ b/datamodels/2.x/itop-endusers-devices/datamodel.itop-endusers-devices.xml
@@ -216,7 +216,7 @@
                     </item>
                   </items>
                 </item>
-                <item id="fieldset:Server:moreinfo">
+                <item id="fieldset:Phone:moreinfo">
                   <rank>20</rank>
                   <items>
                     <item id="brand_id">
@@ -427,7 +427,7 @@
                     </item>
                   </items>
                 </item>
-                <item id="fieldset:Server:moreinfo">
+                <item id="fieldset:Phone:moreinfo">
                   <rank>20</rank>
                   <items>
                     <item id="brand_id">
@@ -636,7 +636,7 @@
                     </item>
                   </items>
                 </item>
-                <item id="fieldset:Server:moreinfo">
+                <item id="fieldset:Phone:moreinfo">
                   <rank>20</rank>
                   <items>
                     <item id="brand_id">

--- a/datamodels/2.x/itop-endusers-devices/datamodel.itop-endusers-devices.xml
+++ b/datamodels/2.x/itop-endusers-devices/datamodel.itop-endusers-devices.xml
@@ -193,47 +193,77 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
               <rank>10</rank>
+              <items>
+                <item id="fieldset:Server:baseinfo">
+                  <rank>10</rank>
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                    <item id="location_id">
+                      <rank>50</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:moreinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="brand_id">
+                      <rank>60</rank>
+                    </item>
+                    <item id="model_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="phonenumber">
+                      <rank>80</rank>
+                    </item>
+                    <item id="serialnumber">
+                      <rank>90</rank>
+                    </item>
+                    <item id="asset_number">
+                      <rank>100</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
               <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="location_id">
-              <rank>50</rank>
-            </item>
-            <item id="brand_id">
-              <rank>60</rank>
-            </item>
-            <item id="model_id">
-              <rank>70</rank>
-            </item>
-            <item id="phonenumber">
-              <rank>80</rank>
-            </item>
-            <item id="serialnumber">
-              <rank>90</rank>
-            </item>
-            <item id="asset_number">
-              <rank>100</rank>
-            </item>
-            <item id="move2production">
-              <rank>110</rank>
-            </item>
-            <item id="purchase_date">
-              <rank>120</rank>
-            </item>
-            <item id="end_of_warranty">
-              <rank>130</rank>
-            </item>
-            <item id="description">
-              <rank>140</rank>
+              <items>
+                <item id="fieldset:Server:Date">
+                  <rank>10</rank>
+                  <items>
+                    <item id="move2production">
+                      <rank>110</rank>
+                    </item>
+                    <item id="purchase_date">
+                      <rank>120</rank>
+                    </item>
+                    <item id="end_of_warranty">
+                      <rank>130</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="description">
+                      <rank>140</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
             <item id="contacts_list">
               <rank>150</rank>
@@ -374,53 +404,83 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
               <rank>10</rank>
+              <items>
+                <item id="fieldset:Server:baseinfo">
+                  <rank>10</rank>
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                    <item id="location_id">
+                      <rank>50</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:moreinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="brand_id">
+                      <rank>60</rank>
+                    </item>
+                    <item id="model_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="phonenumber">
+                      <rank>80</rank>
+                    </item>
+                    <item id="imei">
+                      <rank>90</rank>
+                    </item>
+                    <item id="hw_pin">
+                      <rank>100</rank>
+                    </item>
+                    <item id="serialnumber">
+                      <rank>110</rank>
+                    </item>
+                    <item id="asset_number">
+                      <rank>120</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
               <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="location_id">
-              <rank>50</rank>
-            </item>
-            <item id="brand_id">
-              <rank>60</rank>
-            </item>
-            <item id="model_id">
-              <rank>70</rank>
-            </item>
-            <item id="phonenumber">
-              <rank>80</rank>
-            </item>
-            <item id="imei">
-              <rank>90</rank>
-            </item>
-            <item id="hw_pin">
-              <rank>100</rank>
-            </item>
-            <item id="serialnumber">
-              <rank>110</rank>
-            </item>
-            <item id="asset_number">
-              <rank>120</rank>
-            </item>
-            <item id="move2production">
+              <items>
+                <item id="fieldset:Server:Date">
+                  <rank>10</rank>
+                  <items>
+                    <item id="move2production">
               <rank>130</rank>
-            </item>
-            <item id="purchase_date">
+                    </item>
+                    <item id="purchase_date">
               <rank>140</rank>
-            </item>
-            <item id="end_of_warranty">
-              <rank>150</rank>
-            </item>
-            <item id="description">
-              <rank>160</rank>
+                    </item>
+                    <item id="end_of_warranty">
+                      <rank>150</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="description">
+                      <rank>160</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
             <item id="contacts_list">
               <rank>170</rank>
@@ -553,47 +613,77 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
               <rank>10</rank>
+              <items>
+                <item id="fieldset:Server:baseinfo">
+                  <rank>10</rank>
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                    <item id="location_id">
+                      <rank>50</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:moreinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="brand_id">
+                      <rank>60</rank>
+                    </item>
+                    <item id="model_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="phonenumber">
+                      <rank>80</rank>
+                    </item>
+                    <item id="serialnumber">
+                      <rank>90</rank>
+                    </item>
+                    <item id="asset_number">
+                      <rank>100</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
               <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="location_id">
-              <rank>50</rank>
-            </item>
-            <item id="brand_id">
-              <rank>60</rank>
-            </item>
-            <item id="model_id">
-              <rank>70</rank>
-            </item>
-            <item id="phonenumber">
-              <rank>80</rank>
-            </item>
-            <item id="serialnumber">
-              <rank>90</rank>
-            </item>
-            <item id="asset_number">
-              <rank>100</rank>
-            </item>
-            <item id="move2production">
+              <items>
+                <item id="fieldset:Server:Date">
+                  <rank>10</rank>
+                  <items>
+                    <item id="move2production">
               <rank>110</rank>
-            </item>
-            <item id="purchase_date">
+                    </item>
+                    <item id="purchase_date">
               <rank>120</rank>
-            </item>
-            <item id="end_of_warranty">
-              <rank>130</rank>
-            </item>
-            <item id="description">
-              <rank>140</rank>
+                    </item>
+                    <item id="end_of_warranty">
+                      <rank>130</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="description">
+                      <rank>140</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
             <item id="contacts_list">
               <rank>150</rank>
@@ -722,44 +812,74 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
               <rank>10</rank>
+              <items>
+                <item id="fieldset:Server:baseinfo">
+                  <rank>10</rank>
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                    <item id="location_id">
+                      <rank>50</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:moreinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="brand_id">
+                      <rank>60</rank>
+                    </item>
+                    <item id="model_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="serialnumber">
+                      <rank>80</rank>
+                    </item>
+                    <item id="asset_number">
+                      <rank>90</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
               <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="location_id">
-              <rank>50</rank>
-            </item>
-            <item id="brand_id">
-              <rank>60</rank>
-            </item>
-            <item id="model_id">
-              <rank>70</rank>
-            </item>
-            <item id="serialnumber">
-              <rank>80</rank>
-            </item>
-            <item id="asset_number">
-              <rank>90</rank>
-            </item>
-            <item id="move2production">
+              <items>
+                <item id="fieldset:Server:Date">
+                  <rank>10</rank>
+                  <items>
+                    <item id="move2production">
               <rank>100</rank>
-            </item>
-            <item id="purchase_date">
+                    </item>
+                    <item id="purchase_date">
               <rank>110</rank>
-            </item>
-            <item id="end_of_warranty">
-              <rank>120</rank>
-            </item>
-            <item id="description">
-              <rank>130</rank>
+                    </item>
+                    <item id="end_of_warranty">
+                      <rank>120</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="description">
+                      <rank>130</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
             <item id="contacts_list">
               <rank>140</rank>
@@ -938,23 +1058,8 @@
       <presentation>
         <details>
           <items>
-            <item id="softwares_list">
-              <rank>5</rank>
-            </item>
-            <item id="contacts_list">
-              <rank>10</rank>
-            </item>
-            <item id="documents_list">
-              <rank>20</rank>
-            </item>
-            <item id="physicalinterface_list">
-              <rank>40</rank>
-            </item>
-            <item id="networkdevice_list">
-              <rank>50</rank>
-            </item>
             <item id="col:col1">
-              <rank>80</rank>
+              <rank>10</rank>
               <items>
                 <item id="fieldset:Server:baseinfo">
                   <rank>10</rank>
@@ -1011,7 +1116,7 @@
               </items>
             </item>
             <item id="col:col2">
-              <rank>90</rank>
+              <rank>20</rank>
               <items>
                 <item id="fieldset:Server:Date">
                   <rank>10</rank>
@@ -1036,6 +1141,21 @@
                   </items>
                 </item>
               </items>
+            </item>
+            <item id="softwares_list">
+              <rank>50</rank>
+            </item>
+            <item id="contacts_list">
+              <rank>80</rank>
+            </item>
+            <item id="documents_list">
+              <rank>90</rank>
+            </item>
+            <item id="physicalinterface_list">
+              <rank>100</rank>
+            </item>
+            <item id="networkdevice_list">
+              <rank>110</rank>
             </item>
           </items>
         </details>
@@ -1159,18 +1279,6 @@
       <presentation>
         <details>
           <items>
-            <item id="contacts_list">
-              <rank>10</rank>
-            </item>
-            <item id="documents_list">
-              <rank>20</rank>
-            </item>
-            <item id="physicalinterface_list">
-              <rank>40</rank>
-            </item>
-            <item id="networkdevice_list">
-              <rank>50</rank>
-            </item>
             <item id="col:col1">
               <rank>80</rank>
               <items>
@@ -1239,6 +1347,18 @@
                   </items>
                 </item>
               </items>
+            </item>
+            <item id="contacts_list">
+              <rank>80</rank>
+            </item>
+            <item id="documents_list">
+              <rank>90</rank>
+            </item>
+            <item id="physicalinterface_list">
+              <rank>100</rank>
+            </item>
+            <item id="networkdevice_list">
+              <rank>110</rank>
             </item>
           </items>
         </details>
@@ -1359,44 +1479,74 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
               <rank>10</rank>
+              <items>
+                <item id="fieldset:Server:baseinfo">
+                  <rank>10</rank>
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="status">
+                      <rank>30</rank>
+                    </item>
+                    <item id="business_criticity">
+                      <rank>40</rank>
+                    </item>
+                    <item id="location_id">
+                      <rank>50</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:moreinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="brand_id">
+                      <rank>60</rank>
+                    </item>
+                    <item id="model_id">
+                      <rank>70</rank>
+                    </item>
+                    <item id="serialnumber">
+                      <rank>80</rank>
+                    </item>
+                    <item id="asset_number">
+                      <rank>90</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
-            <item id="org_id">
+            <item id="col:col2">
               <rank>20</rank>
-            </item>
-            <item id="status">
-              <rank>30</rank>
-            </item>
-            <item id="business_criticity">
-              <rank>40</rank>
-            </item>
-            <item id="location_id">
-              <rank>50</rank>
-            </item>
-            <item id="brand_id">
-              <rank>60</rank>
-            </item>
-            <item id="model_id">
-              <rank>70</rank>
-            </item>
-            <item id="serialnumber">
-              <rank>80</rank>
-            </item>
-            <item id="asset_number">
-              <rank>90</rank>
-            </item>
-            <item id="move2production">
+              <items>
+                <item id="fieldset:Server:Date">
+                  <rank>10</rank>
+                  <items>
+                    <item id="move2production">
               <rank>100</rank>
-            </item>
-            <item id="purchase_date">
+                    </item>
+                    <item id="purchase_date">
               <rank>110</rank>
-            </item>
-            <item id="end_of_warranty">
-              <rank>120</rank>
-            </item>
-            <item id="description">
-              <rank>130</rank>
+                    </item>
+                    <item id="end_of_warranty">
+                      <rank>120</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Server:otherinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="description">
+                      <rank>130</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
             <item id="contacts_list">
               <rank>140</rank>

--- a/datamodels/2.x/itop-endusers-devices/datamodel.itop-endusers-devices.xml
+++ b/datamodels/2.x/itop-endusers-devices/datamodel.itop-endusers-devices.xml
@@ -1280,7 +1280,7 @@
         <details>
           <items>
             <item id="col:col1">
-              <rank>80</rank>
+              <rank>10</rank>
               <items>
                 <item id="fieldset:Server:baseinfo">
                   <rank>10</rank>
@@ -1322,7 +1322,7 @@
               </items>
             </item>
             <item id="col:col2">
-              <rank>90</rank>
+              <rank>20</rank>
               <items>
                 <item id="fieldset:Server:Date">
                   <rank>10</rank>

--- a/datamodels/2.x/itop-storage-mgmt/datamodel.itop-storage-mgmt.xml
+++ b/datamodels/2.x/itop-storage-mgmt/datamodel.itop-storage-mgmt.xml
@@ -873,7 +873,7 @@
                     </item>
                   </items>
                 </item>
-                <item id="fieldset:Server:moreinfo">
+                <item id="fieldset:Storage:moreinfo">
                   <rank>20</rank>
                   <items>
                     <item id="brand_id">
@@ -1212,26 +1212,51 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
               <rank>10</rank>
+              <items>
+                <item id="fieldset:Server:baseinfo">
+                  <rank>10</rank>
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="location_id">
+                      <rank>50</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Storage:moreinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="nas_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="raid_level">
+                      <rank>60</rank>
+                    </item>
+                    <item id="size">
+                      <rank>70</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
-            <item id="nas_id">
+            <item id="col:col2">
               <rank>20</rank>
-            </item>
-            <item id="location_id">
-              <rank>30</rank>
-            </item>
-            <item id="org_id">
-              <rank>40</rank>
-            </item>
-            <item id="description">
-              <rank>50</rank>
-            </item>
-            <item id="raid_level">
-              <rank>60</rank>
-            </item>
-            <item id="size">
-              <rank>70</rank>
+              <items>
+                <item id="fieldset:Server:otherinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="description">
+                      <rank>10</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
           </items>
         </details>
@@ -1350,26 +1375,41 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
               <rank>10</rank>
-            </item>
-            <item id="datacenterdevice_id">
-              <rank>20</rank>
-            </item>
-            <item id="location_id">
-              <rank>30</rank>
-            </item>
-            <item id="org_id">
-              <rank>40</rank>
-            </item>
-            <item id="speed">
-              <rank>50</rank>
-            </item>
-            <item id="topology">
-              <rank>60</rank>
-            </item>
-            <item id="wwn">
-              <rank>70</rank>
+              <items>
+                <item id="fieldset:Server:baseinfo">
+                  <rank>10</rank>
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="location_id">
+                      <rank>50</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Storage:moreinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="datacenterdevice_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="speed">
+                      <rank>50</rank>
+                    </item>
+                    <item id="topology">
+                      <rank>60</rank>
+                    </item>
+                    <item id="wwn">
+                      <rank>70</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
           </items>
         </details>
@@ -1521,29 +1561,54 @@
       <presentation>
         <details>
           <items>
-            <item id="name">
+            <item id="col:col1">
               <rank>10</rank>
+              <items>
+                <item id="fieldset:ConfigMgnt:baseinfo">
+                  <rank>10</rank>
+                  <items>
+                    <item id="name">
+                      <rank>10</rank>
+                    </item>
+                    <item id="org_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="location_id">
+                      <rank>50</rank>
+                    </item>
+                  </items>
+                </item>
+                <item id="fieldset:Storage:moreinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="lun_id">
+                      <rank>20</rank>
+                    </item>
+                    <item id="storagesystem_id">
+                      <rank>30</rank>
+                    </item>
+                    <item id="raid_level">
+                      <rank>70</rank>
+                    </item>
+                    <item id="size">
+                      <rank>80</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
-            <item id="lun_id">
+            <item id="col:col2">
               <rank>20</rank>
-            </item>
-            <item id="storagesystem_id">
-              <rank>30</rank>
-            </item>
-            <item id="location_id">
-              <rank>40</rank>
-            </item>
-            <item id="org_id">
-              <rank>50</rank>
-            </item>
-            <item id="description">
-              <rank>60</rank>
-            </item>
-            <item id="raid_level">
-              <rank>70</rank>
-            </item>
-            <item id="size">
-              <rank>80</rank>
+              <items>
+                <item id="fieldset:Server:otherinfo">
+                  <rank>20</rank>
+                  <items>
+                    <item id="description">
+                      <rank>10</rank>
+                    </item>
+                  </items>
+                </item>
+              </items>
             </item>
             <item id="servers_list">
               <rank>90</rank>


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | ([N°9138](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=9138))
| Type of change?                                               |  Enhancement 


## Symptom (bug) / Objective (enhancement)
Finding a particular field in some CMDB classes details is a bit difficult

## Proposed solution (bug and enhancement)
Organize most CMDB class display, using the same set of fielsets from the existing Server class display
When a field exists in multiple classes then you will always find it in the same fieldset and in the same position compare to other fields present in that fieldset
 - General Information
   - name
   - organization
   - status
   - business criticality
   - location
   - rack
   - enclosure
 - CI specifics
   - _non common fields_ 
 - Dates
   - _any dates_
 - Power Supply
 - Description
   - logo
   - description
   - comment 


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [ ] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge
<!--
Things that needs to be done in the PR before it can be considered as ready to be merged

Examples:
- Changes requested in the review
- Unit test to add
- Dictionary entries to translate
- ...
-->

- [ ] ...
- [ ] ...
- [ ] ...
