### PR TITLE
N°9233 - Check user access before acquiring lock on object

### DIFF
--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -2054,6 +2054,9 @@ EOF
 				if (false === $oSet->CountExceeds(0)) {
 					throw new SecurityException(Dict::S('UI:ObjectDoesNotExist'));
 				}
+				if (UserRights::IsActionAllowed($sObjClass, UR_ACTION_MODIFY, $oSet) != UR_ALLOWED_YES) {
+					throw new SecurityException(Dict::S('UI:ActionNotAllowed'));
+				}
 
 				$aResult = iTopOwnershipLock::AcquireLock($sObjClass, $iObjKey);
 				if (false === $aResult['success']) {

--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -2051,11 +2051,11 @@ EOF
 				$oSearch = new DBObjectSearch($sObjClass);
 				$oSearch->AddCondition(MetaModel::DBGetKey($sObjClass), $iObjKey, '=');
 				$oSet = new CMDBObjectSet($oSearch);
-				if (false === $oSet->CountExceeds(0)) {
+				if (
+					false === $oSet->CountExceeds(0) ||
+					UserRights::IsActionAllowed($sObjClass, UR_ACTION_MODIFY, $oSet) !== UR_ALLOWED_YES
+				) {
 					throw new SecurityException(Dict::S('UI:ObjectDoesNotExist'));
-				}
-				if (UserRights::IsActionAllowed($sObjClass, UR_ACTION_MODIFY, $oSet) != UR_ALLOWED_YES) {
-					throw new SecurityException(Dict::S('UI:ActionNotAllowed'));
 				}
 
 				$aResult = iTopOwnershipLock::AcquireLock($sObjClass, $iObjKey);

--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -2047,6 +2047,14 @@ EOF
 				$sObjClass = utils::ReadParam('obj_class', '', false, 'class');
 				$iObjKey = (int)utils::ReadParam('obj_key', 0, false, 'integer');
 
+				// Check user has access to the object before trying to acquire the lock
+				$oSearch = new DBObjectSearch($sObjClass);
+				$oSearch->AddCondition(MetaModel::DBGetKey($sObjClass), $iObjKey, '=');
+				$oSet = new CMDBObjectSet($oSearch);
+				if (false === $oSet->CountExceeds(0)) {
+					throw new SecurityException(Dict::S('UI:ObjectDoesNotExist'));
+				}
+
 				$aResult = iTopOwnershipLock::AcquireLock($sObjClass, $iObjKey);
 				if (false === $aResult['success']) {
 					$aLockData = iTopOwnershipLock::IsLocked($sObjClass, $iObjKey);


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | [N°9233](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=9233)
| Type of change?                                               | Bug fix


## Symptom

A user without write permissions for an object is still able to lock it


## Cause

User permissions are not verified during the locking operation


## Proposed solution

Verify that the user has write permissions before allowing the locking operation