### PR TITLE
N°8532 - Apply filters on all DBSearch classes

### DIFF
--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1730,6 +1730,14 @@ class Config
 			'source_of_value' => '',
 			'show_in_conf_sample' => false,
 		],
+		'security.disable_joined_classes_filter' => [
+			'type'                => 'bool',
+			'description'         => 'If true, scope filters aren\'t applied to joined classes or union classes not directly listed in the SELECT clause.',
+			'default'             => true,
+			'value'               => true,
+			'source_of_value'     => '',
+			'show_in_conf_sample' => false,
+		],
 		'security.hide_administrators' => [
 			'type'                => 'bool',
 			'description'         => 'If true, non-administrator users will not be able to see the administrator accounts, the Administrator profile and the links between the administrator accounts and their profiles.',

--- a/core/dbobjectsearch.class.php
+++ b/core/dbobjectsearch.class.php
@@ -1928,8 +1928,9 @@ class DBObjectSearch extends DBSearch
 
 	/**
 	 * @inheritDoc
+	 * @return DBObjectSearch
 	 */
-	protected function ApplyDataFilters()
+	protected function ApplyDataFilters(): DBObjectSearch
 	{
 		if ($this->IsAllDataAllowed() || $this->IsDataFiltered()) {
 			return $this;

--- a/core/dbobjectsearch.class.php
+++ b/core/dbobjectsearch.class.php
@@ -1925,4 +1925,36 @@ class DBObjectSearch extends DBSearch
 	{
 		return $this->GetCriteria()->ListParameters();
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function ApplyDataFilters()
+	{
+		if ($this->IsAllDataAllowed() || $this->IsDataFiltered()) {
+			return $this;
+		}
+
+		$oSearch = $this;
+		$aClassesToFilter = $this->GetSelectedClasses();
+
+		// Opt-in for joined classes filtering, otherwise only filter the selected class(es)
+		if (MetaModel::GetConfig()->Get('security.disable_joined_classes_filter') === false) {
+			$aClassesToFilter = $this->GetJoinedClasses();
+		}
+
+		// Apply filter (this is similar to the one in DBSearch but the factorization could make it less readable)
+		foreach ($aClassesToFilter as $sClassAlias => $sClass) {
+			$oVisibleObjects = UserRights::GetSelectFilter($sClass, $this->GetModifierProperties('UserRightsGetSelectFilter'));
+			if ($oVisibleObjects === false) {
+				$oVisibleObjects = DBObjectSearch::FromEmptySet($sClass);
+			}
+			if (is_object($oVisibleObjects)) {
+				$oVisibleObjects->AllowAllData();
+				$oSearch = $oSearch->Filter($sClassAlias, $oVisibleObjects);
+				$oSearch->SetDataFiltered();
+			}
+		}
+		return $oSearch;
+	}
 }

--- a/core/dbsearch.class.php
+++ b/core/dbsearch.class.php
@@ -1598,7 +1598,7 @@ abstract class DBSearch
 	/**
 	 * Apply data filters to the search, if needed
 	 *
-	 * @return $this|DBSearch
+	 * @return DBSearch
 	 * @throws CoreException
 	 */
 	protected function ApplyDataFilters(): DBSearch

--- a/core/dbsearch.class.php
+++ b/core/dbsearch.class.php
@@ -1601,7 +1601,7 @@ abstract class DBSearch
 	 * @return $this|DBSearch
 	 * @throws CoreException
 	 */
-	protected function ApplyDataFilters()
+	protected function ApplyDataFilters(): DBSearch
 	{
 		if ($this->IsAllDataAllowed() || $this->IsDataFiltered()) {
 			return $this;

--- a/core/dbsearch.class.php
+++ b/core/dbsearch.class.php
@@ -1122,21 +1122,7 @@ abstract class DBSearch
 	 */
 	protected function GetSQLQuery($aOrderBy, $aArgs, $aAttToLoad, $aExtendedDataSpec, $iLimitCount, $iLimitStart, $bGetCount, $aGroupByExpr = null, $aSelectExpr = null)
 	{
-		$oSearch = $this;
-		if (!$this->IsAllDataAllowed() && !$this->IsDataFiltered()) {
-			foreach ($this->GetSelectedClasses() as $sClassAlias => $sClass) {
-				$oVisibleObjects = UserRights::GetSelectFilter($sClass, $this->GetModifierProperties('UserRightsGetSelectFilter'));
-				if ($oVisibleObjects === false) {
-					// Make sure this is a valid search object, saying NO for all
-					$oVisibleObjects = DBObjectSearch::FromEmptySet($sClass);
-				}
-				if (is_object($oVisibleObjects)) {
-					$oVisibleObjects->AllowAllData();
-					$oSearch = $oSearch->Filter($sClassAlias, $oVisibleObjects);
-					$oSearch->SetDataFiltered();
-				}
-			}
-		}
+		$oSearch = $this->ApplyDataFilters();
 
 		if (is_array($aGroupByExpr)) {
 			foreach ($aGroupByExpr as $sAlias => $oGroupByExp) {
@@ -1608,4 +1594,33 @@ abstract class DBSearch
 	 * @return array{\VariableExpression}
 	 */
 	abstract public function GetExpectedArguments(): array;
+
+	/**
+	 * Apply data filters to the search, if needed
+	 *
+	 * @return $this|DBSearch
+	 * @throws CoreException
+	 */
+	protected function ApplyDataFilters()
+	{
+		if ($this->IsAllDataAllowed() || $this->IsDataFiltered()) {
+			return $this;
+		}
+
+		$oSearch = $this;
+		$aClassesToFilter = $this->GetSelectedClasses();
+
+		foreach ($aClassesToFilter as $sClassAlias => $sClass) {
+			$oVisibleObjects = UserRights::GetSelectFilter($sClass, $this->GetModifierProperties('UserRightsGetSelectFilter'));
+			if ($oVisibleObjects === false) {
+				$oVisibleObjects = DBObjectSearch::FromEmptySet($sClass);
+			}
+			if (is_object($oVisibleObjects)) {
+				$oVisibleObjects->AllowAllData();
+				$oSearch = $oSearch->Filter($sClassAlias, $oVisibleObjects);
+				$oSearch->SetDataFiltered();
+			}
+		}
+		return $oSearch;
+	}
 }

--- a/core/dbunionsearch.class.php
+++ b/core/dbunionsearch.class.php
@@ -676,8 +676,9 @@ class DBUnionSearch extends DBSearch
 
 	/**
 	 * @inheritDoc
+	 * @return DBUnionSearch
 	 */
-	protected function ApplyDataFilters()
+	protected function ApplyDataFilters(): DBUnionSearch
 	{
 		if ($this->IsAllDataAllowed() || $this->IsDataFiltered()) {
 			return $this;

--- a/core/dbunionsearch.class.php
+++ b/core/dbunionsearch.class.php
@@ -673,4 +673,29 @@ class DBUnionSearch extends DBSearch
 
 		return $aVariableCriteria;
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function ApplyDataFilters()
+	{
+		if ($this->IsAllDataAllowed() || $this->IsDataFiltered()) {
+			return $this;
+		}
+
+		// Opt-in for joined classes filtering, otherwise fallback on DBSearch filtering
+		if (MetaModel::GetConfig()->Get('security.disable_joined_classes_filter') === true) {
+			return parent::ApplyDataFilters();
+		}
+
+		// Apply filters per sub-search
+		$aFilteredSearches = [];
+		foreach ($this->GetSearches() as $oSubSearch) {
+			// Recursively call ApplyDataFilters on sub-searches
+			$aFilteredSearches[] = $oSubSearch->ApplyDataFilters();
+		}
+
+		$oSearch = new DBUnionSearch($aFilteredSearches);
+		return $oSearch;
+	}
 }

--- a/tests/php-unit-tests/unitary-tests/core/DBSearchFilterJoinTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBSearchFilterJoinTest.php
@@ -154,11 +154,16 @@ class DBSearchFilterJoinTest extends ItopDataTestCase
 			'virtualhost_id' => 1,
 		]);
 
+		$iVirtualHostId = $this->GivenObjectInDB('Hypervisor', [
+			'name'   => 'DBSearchFilterVHost-'.$sSuffix,
+			'org_id' => $iAllowedOrgId,
+		]);
+
 		$this->GivenObjectInDB('VirtualMachine', [
 			'name' => 'DBSearchFilterVmAllowed-'.$sSuffix,
 			'org_id' => $iAllowedOrgId,
 			'osfamily_id' => $iAllowedOsFamilyId,
-			'virtualhost_id' => 1,
+			'virtualhost_id' => $iVirtualHostId,
 		]);
 
 		$oDeniedPerson = $this->CreatePerson('Denied-'.$sSuffix, $iDeniedOrgId);

--- a/tests/php-unit-tests/unitary-tests/core/DBSearchFilterJoinTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBSearchFilterJoinTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Combodo\iTop\Test\UnitTest\Core;
+
+use CMDBSource;
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use DBObjectSearch;
+use DBObjectSet;
+use DBSearch;
+use lnkFunctionalCIToTicket;
+use MetaModel;
+use ormLinkSet;
+use UserRequest;
+use UserRights;
+
+class DBSearchFilterJoinTest extends ItopDataTestCase
+{
+	private const RESTRICTED_PROFILE = 'Configuration Manager';
+	private $aData = [];
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->RequireOnceItopFile('application/startup.inc.php');
+		$this->BackupConfiguration();
+		$this->aData = $this->CreateDBSearchFilterTestData();
+		DBSearch::EnableQueryCache(false, false);
+		$this->LoginRestrictedUser($this->aData['allowed_org_id'], self::RESTRICTED_PROFILE);
+
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider JoinedAndNestedOqlProvider
+	 */
+	public function testDBSearchFilterAppliedToJoinsWhenEnabled(string $sOqlTemplate, int $iExpectedCount): void
+	{
+		$this->EnableJoinFilterConfig(true);
+
+		$sOql = sprintf($sOqlTemplate, $this->aData['denied_org_name'], $this->aData['allowed_org_name']);
+		$oSearch = DBObjectSearch::FromOQL($sOql);
+		$oSet = new \DBObjectSet($oSearch);
+		CMDBSource::TestQuery($oSearch->MakeSelectQuery());
+		$this->assertEquals($iExpectedCount, $oSet->Count());
+	}
+
+	/**
+	 * @dataProvider JoinedAndNestedOqlProvider
+	 */
+	public function testDBSearchFilterAppliedToJoinsWhenDisabled(string $sOqlTemplate, int $iExpectedCount, int $iExpectedDisabledCount): void
+	{
+		$this->EnableJoinFilterConfig(false);
+
+		$sOql = sprintf($sOqlTemplate, $this->aData['denied_org_name'], $this->aData['allowed_org_name']);
+		$oSearch = DBObjectSearch::FromOQL($sOql);
+		$oSet = new \DBObjectSet($oSearch);
+		CMDBSource::TestQuery($oSearch->MakeSelectQuery());
+		$this->assertEquals($iExpectedDisabledCount, $oSet->Count());
+	}
+
+	/**
+	 * @dataProvider JoinedAndNestedOqlProvider
+	 */
+	public function testAllowAllDataBypassesDBSearchFilterWhenEnabled(string $sOqlTemplate, int $iExpectedCount, int $iExpectedDisabledCount): void
+	{
+		$this->EnableJoinFilterConfig(true);
+
+		$sOql = sprintf($sOqlTemplate, $this->aData['denied_org_name'], $this->aData['allowed_org_name']);
+		$oSearch = DBObjectSearch::FromOQL($sOql);
+		$oSearch->AllowAllData();
+		$oSet = new \DBObjectSet($oSearch);
+		CMDBSource::TestQuery($oSearch->MakeSelectQuery());
+		$this->assertEquals($iExpectedDisabledCount, $oSet->Count());
+	}
+
+	/**
+	 * @dataProvider JoinedAndNestedOqlProvider
+	 */
+	public function testAllowAllDataBypassesDBSearchFilterWhenDisabled(string $sOqlTemplate, int $iExpectedCount, int $iExpectedDisabledCount): void
+	{
+		$this->EnableJoinFilterConfig(false);
+
+		$sOql = sprintf($sOqlTemplate, $this->aData['denied_org_name'], $this->aData['allowed_org_name']);
+		$oSearch = DBObjectSearch::FromOQL($sOql);
+		$oSearch->AllowAllData();
+		$oSet = new \DBObjectSet($oSearch);
+		CMDBSource::TestQuery($oSearch->MakeSelectQuery());
+		$this->assertEquals($iExpectedDisabledCount, $oSet->Count());
+	}
+
+	public function JoinedAndNestedOqlProvider(): array
+	{
+		return [
+			'join-filter-on-org' => [
+				"SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = '%s'",
+				0,
+				1,
+			],
+			'nested-in-select' => [
+				"SELECT OSF FROM OSFamily AS OSF WHERE OSF.id IN (SELECT OSF1 FROM OSFamily AS OSF1 JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF1.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = '%s')",
+				0,
+				1,
+			],
+			'userrequest-join-person-org' => [
+				"SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN lnkFunctionalCIToTicket AS L ON L.functionalci_id = VM.id JOIN UserRequest AS UR ON L.ticket_id = UR.id  JOIN Person AS P ON UR.caller_id = P.id JOIN Organization AS O ON P.org_id = O.id WHERE O.name = '%s'",
+				0,
+				1,
+			],
+			'union-join-filter-on-org' => [
+				"SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = '%s' UNION SELECT OSF2 FROM OSFamily AS OSF2 JOIN VirtualMachine AS VM2 ON VM2.osfamily_id = OSF2.id JOIN Organization AS O2 ON VM2.org_id = O2.id WHERE O2.name = '%s'",
+				1,
+				2,
+			],
+		];
+	}
+
+	private function EnableJoinFilterConfig(bool $bEnabled): void
+	{
+		$oConfig = MetaModel::GetConfig();
+		$oConfig->Set('security.disable_joined_classes_filter', !$bEnabled);
+	}
+
+	private function CreateDBSearchFilterTestData(): array
+	{
+		$sSuffix = 'DBSearchFilterJoinTest';
+
+		$sAllowedOrgName = 'DBSearchFilterAllowedOrg-'.$sSuffix;
+		$iAllowedOrgId = $this->GivenObjectInDB('Organization', [
+			'name' => $sAllowedOrgName,
+		]);
+
+		$this->debug("Org allowed id: $iAllowedOrgId");
+		$sDeniedOrgName = 'DBSearchFilterDeniedOrg-'.$sSuffix;
+		$iDeniedOrgId = $this->GivenObjectInDB('Organization', [
+			'name' => $sDeniedOrgName,
+		]);
+		$this->debug("Org denied id: $iDeniedOrgId");
+
+		$iDeniedOsFamilyId = $this->GivenObjectInDB('OSFamily', [
+			'name' => 'DBSearchFilterOsFamilyDenied-'.$sSuffix,
+		]);
+
+		$iAllowedOsFamilyId = $this->GivenObjectInDB('OSFamily', [
+			'name' => 'DBSearchFilterOsFamilyAllowed-'.$sSuffix,
+		]);
+
+		$iDeniedVMId = $this->GivenObjectInDB('VirtualMachine', [
+			'name' => 'DBSearchFilterVmDenied-'.$sSuffix,
+			'org_id' => $iDeniedOrgId,
+			'osfamily_id' => $iDeniedOsFamilyId,
+			'virtualhost_id' => 1,
+		]);
+
+		$this->GivenObjectInDB('VirtualMachine', [
+			'name' => 'DBSearchFilterVmAllowed-'.$sSuffix,
+			'org_id' => $iAllowedOrgId,
+			'osfamily_id' => $iAllowedOsFamilyId,
+			'virtualhost_id' => 1,
+		]);
+
+		$oDeniedPerson = $this->CreatePerson('Denied-'.$sSuffix, $iDeniedOrgId);
+
+		$oUserRequest = $this->CreateUserRequest('Denied'.$sSuffix, [
+			'caller_id' => $oDeniedPerson->GetKey(),
+			'org_id' => $iDeniedOrgId,
+		]);
+
+		// Add Virtual Machine to UserRequest lnk
+		$oLinkSet = new ormLinkSet(UserRequest::class, 'functionalcis_list', DBObjectSet::FromScratch(lnkFunctionalCIToTicket::class));
+
+		$oLink = MetaModel::NewObject(lnkFunctionalCIToTicket::class, ['functionalci_id' => $iDeniedVMId]);
+		$oLinkSet->AddItem($oLink);
+
+		$oUserRequest->Set('functionalcis_list', $oLinkSet);
+		$oUserRequest->DBUpdate();
+
+		return [
+			'allowed_org_id' => $iAllowedOrgId,
+			'allowed_org_name' => $sAllowedOrgName,
+			'denied_org_name' => $sDeniedOrgName,
+		];
+	}
+
+	private function LoginRestrictedUser(int $iAllowedOrgId, string $sProfileName): void
+	{
+		$sLogin = $this->GivenUserRestrictedToAnOrganizationInDB($iAllowedOrgId, self::$aURP_Profiles[$sProfileName]);
+		UserRights::Login($sLogin);
+	}
+}

--- a/tests/php-unit-tests/unitary-tests/core/DBSearchFilterJoinTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBSearchFilterJoinTest.php
@@ -35,12 +35,11 @@ class DBSearchFilterJoinTest extends ItopDataTestCase
 	/**
 	 * @dataProvider JoinedAndNestedOqlProvider
 	 */
-	public function testDBSearchFilterAppliedToJoinsWhenEnabled(string $sOqlTemplate, int $iExpectedCount): void
+	public function testDBSearchFilterAppliedToJoinsWhenEnabled(string $sOql, int $iExpectedCount): void
 	{
 		$this->EnableJoinFilterConfig(true);
 
-		$sOql = sprintf($sOqlTemplate, $this->aData['denied_org_name'], $this->aData['allowed_org_name']);
-		$oSearch = DBObjectSearch::FromOQL($sOql);
+		$oSearch = DBObjectSearch::FromOQL($sOql, ['denied_org' => $this->aData['denied_org_name'], 'allowed_org' => $this->aData['allowed_org_name']]);
 		$oSet = new \DBObjectSet($oSearch);
 		CMDBSource::TestQuery($oSearch->MakeSelectQuery());
 		$this->assertEquals($iExpectedCount, $oSet->Count());
@@ -49,12 +48,11 @@ class DBSearchFilterJoinTest extends ItopDataTestCase
 	/**
 	 * @dataProvider JoinedAndNestedOqlProvider
 	 */
-	public function testDBSearchFilterAppliedToJoinsWhenDisabled(string $sOqlTemplate, int $iExpectedCount, int $iExpectedDisabledCount): void
+	public function testDBSearchFilterAppliedToJoinsWhenDisabled(string $sOql, int $iExpectedCount, int $iExpectedDisabledCount): void
 	{
 		$this->EnableJoinFilterConfig(false);
 
-		$sOql = sprintf($sOqlTemplate, $this->aData['denied_org_name'], $this->aData['allowed_org_name']);
-		$oSearch = DBObjectSearch::FromOQL($sOql);
+		$oSearch = DBObjectSearch::FromOQL($sOql, ['denied_org' => $this->aData['denied_org_name'], 'allowed_org' => $this->aData['allowed_org_name']]);
 		$oSet = new \DBObjectSet($oSearch);
 		CMDBSource::TestQuery($oSearch->MakeSelectQuery());
 		$this->assertEquals($iExpectedDisabledCount, $oSet->Count());
@@ -63,12 +61,11 @@ class DBSearchFilterJoinTest extends ItopDataTestCase
 	/**
 	 * @dataProvider JoinedAndNestedOqlProvider
 	 */
-	public function testAllowAllDataBypassesDBSearchFilterWhenEnabled(string $sOqlTemplate, int $iExpectedCount, int $iExpectedDisabledCount): void
+	public function testAllowAllDataBypassesDBSearchFilterWhenEnabled(string $sOql, int $iExpectedCount, int $iExpectedDisabledCount): void
 	{
 		$this->EnableJoinFilterConfig(true);
 
-		$sOql = sprintf($sOqlTemplate, $this->aData['denied_org_name'], $this->aData['allowed_org_name']);
-		$oSearch = DBObjectSearch::FromOQL($sOql);
+		$oSearch = DBObjectSearch::FromOQL($sOql, ['denied_org' => $this->aData['denied_org_name'], 'allowed_org' => $this->aData['allowed_org_name']]);
 		$oSearch->AllowAllData();
 		$oSet = new \DBObjectSet($oSearch);
 		CMDBSource::TestQuery($oSearch->MakeSelectQuery());
@@ -78,12 +75,11 @@ class DBSearchFilterJoinTest extends ItopDataTestCase
 	/**
 	 * @dataProvider JoinedAndNestedOqlProvider
 	 */
-	public function testAllowAllDataBypassesDBSearchFilterWhenDisabled(string $sOqlTemplate, int $iExpectedCount, int $iExpectedDisabledCount): void
+	public function testAllowAllDataBypassesDBSearchFilterWhenDisabled(string $sOql, int $iExpectedCount, int $iExpectedDisabledCount): void
 	{
 		$this->EnableJoinFilterConfig(false);
 
-		$sOql = sprintf($sOqlTemplate, $this->aData['denied_org_name'], $this->aData['allowed_org_name']);
-		$oSearch = DBObjectSearch::FromOQL($sOql);
+		$oSearch = DBObjectSearch::FromOQL($sOql, ['denied_org' => $this->aData['denied_org_name'], 'allowed_org' => $this->aData['allowed_org_name']]);
 		$oSearch->AllowAllData();
 		$oSet = new \DBObjectSet($oSearch);
 		CMDBSource::TestQuery($oSearch->MakeSelectQuery());
@@ -94,23 +90,23 @@ class DBSearchFilterJoinTest extends ItopDataTestCase
 	{
 		return [
 			'join-filter-on-org' => [
-				'oql' => "SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = '%s'",
+				'oql' => "SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = :denied_org",
 				'expected_filtered_count' => 0,
 				'expected_unfiltered_count' => 1,
 			],
 			'nested-in-select' => [
-				'oql' => "SELECT OSF FROM OSFamily AS OSF WHERE OSF.id IN (SELECT OSF1 FROM OSFamily AS OSF1 JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF1.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = '%s')",
+				'oql' => "SELECT OSF FROM OSFamily AS OSF WHERE OSF.id IN (SELECT OSF1 FROM OSFamily AS OSF1 JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF1.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = :denied_org)",
 				'expected_filtered_count' => 0,
 				'expected_unfiltered_count' => 1,
 
 			],
 			'userrequest-join-person-org' => [
-				'oql' => "SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN lnkFunctionalCIToTicket AS L ON L.functionalci_id = VM.id JOIN UserRequest AS UR ON L.ticket_id = UR.id  JOIN Person AS P ON UR.caller_id = P.id JOIN Organization AS O ON P.org_id = O.id WHERE O.name = '%s'",
+				'oql' => "SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN lnkFunctionalCIToTicket AS L ON L.functionalci_id = VM.id JOIN UserRequest AS UR ON L.ticket_id = UR.id  JOIN Person AS P ON UR.caller_id = P.id JOIN Organization AS O ON P.org_id = O.id WHERE O.name = :denied_org",
 				'expected_filtered_count' => 0,
 				'expected_unfiltered_count' => 1,
 			],
 			'union-join-filter-on-org' => [
-				'oql' => "SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = '%s' UNION SELECT OSF2 FROM OSFamily AS OSF2 JOIN VirtualMachine AS VM2 ON VM2.osfamily_id = OSF2.id JOIN Organization AS O2 ON VM2.org_id = O2.id WHERE O2.name = '%s'",
+				'oql' => "SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = :denied_org UNION SELECT OSF2 FROM OSFamily AS OSF2 JOIN VirtualMachine AS VM2 ON VM2.osfamily_id = OSF2.id JOIN Organization AS O2 ON VM2.org_id = O2.id WHERE O2.name = :allowed_org",
 				'expected_filtered_count' => 1,
 				'expected_unfiltered_count' => 2,
 			],

--- a/tests/php-unit-tests/unitary-tests/core/DBSearchFilterJoinTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBSearchFilterJoinTest.php
@@ -94,24 +94,25 @@ class DBSearchFilterJoinTest extends ItopDataTestCase
 	{
 		return [
 			'join-filter-on-org' => [
-				"SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = '%s'",
-				0,
-				1,
+				'oql' => "SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = '%s'",
+				'expected_filtered_count' => 0,
+				'expected_unfiltered_count' => 1,
 			],
 			'nested-in-select' => [
-				"SELECT OSF FROM OSFamily AS OSF WHERE OSF.id IN (SELECT OSF1 FROM OSFamily AS OSF1 JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF1.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = '%s')",
-				0,
-				1,
+				'oql' => "SELECT OSF FROM OSFamily AS OSF WHERE OSF.id IN (SELECT OSF1 FROM OSFamily AS OSF1 JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF1.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = '%s')",
+				'expected_filtered_count' => 0,
+				'expected_unfiltered_count' => 1,
+
 			],
 			'userrequest-join-person-org' => [
-				"SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN lnkFunctionalCIToTicket AS L ON L.functionalci_id = VM.id JOIN UserRequest AS UR ON L.ticket_id = UR.id  JOIN Person AS P ON UR.caller_id = P.id JOIN Organization AS O ON P.org_id = O.id WHERE O.name = '%s'",
-				0,
-				1,
+				'oql' => "SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN lnkFunctionalCIToTicket AS L ON L.functionalci_id = VM.id JOIN UserRequest AS UR ON L.ticket_id = UR.id  JOIN Person AS P ON UR.caller_id = P.id JOIN Organization AS O ON P.org_id = O.id WHERE O.name = '%s'",
+				'expected_filtered_count' => 0,
+				'expected_unfiltered_count' => 1,
 			],
 			'union-join-filter-on-org' => [
-				"SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = '%s' UNION SELECT OSF2 FROM OSFamily AS OSF2 JOIN VirtualMachine AS VM2 ON VM2.osfamily_id = OSF2.id JOIN Organization AS O2 ON VM2.org_id = O2.id WHERE O2.name = '%s'",
-				1,
-				2,
+				'oql' => "SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN Organization AS O ON VM.org_id = O.id WHERE O.name = '%s' UNION SELECT OSF2 FROM OSFamily AS OSF2 JOIN VirtualMachine AS VM2 ON VM2.osfamily_id = OSF2.id JOIN Organization AS O2 ON VM2.org_id = O2.id WHERE O2.name = '%s'",
+				'expected_filtered_count' => 1,
+				'expected_unfiltered_count' => 2,
 			],
 		];
 	}

--- a/tests/php-unit-tests/unitary-tests/core/DBSearchFilterJoinTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBSearchFilterJoinTest.php
@@ -21,7 +21,6 @@ class DBSearchFilterJoinTest extends ItopDataTestCase
 	{
 		parent::setUp();
 		$this->RequireOnceItopFile('application/startup.inc.php');
-		$this->BackupConfiguration();
 		$this->aData = $this->CreateDBSearchFilterTestData();
 		DBSearch::EnableQueryCache(false, false);
 		$this->LoginRestrictedUser($this->aData['allowed_org_id'], self::RESTRICTED_PROFILE);


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N°8532
| Type of change?                                               | Bug fix


## Symptom 
When multiple classes are present in a OQL through JOIN statements, it's expected to apply the scope filters to all classes present in the query.

## Reproduction procedure

Run this query with a user that does not have access to certain `VirtualMachine` because of their organization

```SQL
SELECT OSF FROM OSFamily AS OSF JOIN VirtualMachine AS VM ON VM.osfamily_id = OSF.id JOIN Organization AS O ON VM.org_id = O.id
```

See that the `OSFamily` for these are listed


## Cause
The `DBSearch` method of filtering only applies to the selected class. So it does not happen for the joined classes nor for the unioned classes.


## Proposed solution
Make this filter apply to every class in the query.
This also allows to make it work recursively for `UNION` searches.
It's triggered with an opt-in `security.disable_joined_classes_filter` parameter as some iTop functionalities may relay on this behavior.

## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?
