### PR TITLE
N°9328 - Add scssphp compatibility with PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "pear/archive_tar": "~1.4.14",
     "pelago/emogrifier": "^7.2.0",
     "psr/log": "^3.0.0",
-    "scssphp/scssphp": "^1.12.1",
+    "scssphp/scssphp": "dev-combodo/1.x",
     "symfony/console": "~6.4.0",
     "symfony/dotenv": "~6.4.0",
     "symfony/framework-bundle": "~6.4.0",
@@ -43,6 +43,10 @@
     {
       "type": "vcs",
       "url": "https://github.com/EsupPortail/phpCAS"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/combodo-itop-libs/scssphp"
     }
   ],
   "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ceac38f6033afe07b7ab977fa39fe348",
+    "content-hash": "eebbdc6c10a479b0e62fc18d88496f5c",
     "packages": [
         {
             "name": "apereo/phpcas",
@@ -1588,16 +1588,16 @@
         },
         {
             "name": "scssphp/scssphp",
-            "version": "v1.13.0",
+            "version": "dev-combodo/1.x",
             "source": {
                 "type": "git",
-                "url": "https://github.com/scssphp/scssphp.git",
-                "reference": "63d1157457e5554edf00b0c1fabab4c1511d2520"
+                "url": "https://github.com/combodo-itop-libs/scssphp.git",
+                "reference": "dde81c0a39d02e8e6fc81b70269747734e16d526"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/63d1157457e5554edf00b0c1fabab4c1511d2520",
-                "reference": "63d1157457e5554edf00b0c1fabab4c1511d2520",
+                "url": "https://api.github.com/repos/combodo-itop-libs/scssphp/zipball/dde81c0a39d02e8e6fc81b70269747734e16d526",
+                "reference": "dde81c0a39d02e8e6fc81b70269747734e16d526",
                 "shasum": ""
             },
             "require": {
@@ -1626,8 +1626,8 @@
             "type": "library",
             "extra": {
                 "bamarni-bin": {
-                    "bin-links": false,
-                    "forward-command": false
+                    "forward-command": false,
+                    "bin-links": false
                 }
             },
             "autoload": {
@@ -1635,7 +1635,11 @@
                     "ScssPhp\\ScssPhp\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ScssPhp\\ScssPhp\\Tests\\": "tests/"
+                }
+            },
             "license": [
                 "MIT"
             ],
@@ -1661,10 +1665,9 @@
                 "stylesheet"
             ],
             "support": {
-                "issues": "https://github.com/scssphp/scssphp/issues",
-                "source": "https://github.com/scssphp/scssphp/tree/v1.13.0"
+                "source": "https://github.com/combodo-itop-libs/scssphp/tree/combodo/1.x"
             },
-            "time": "2024-08-17T21:02:11+00:00"
+            "time": "2026-03-23T15:26:59+00:00"
         },
         {
             "name": "soundasleep/html2text",
@@ -5097,7 +5100,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "apereo/phpcas": 20
+        "apereo/phpcas": 20,
+        "scssphp/scssphp": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/lib/composer/installed.json
+++ b/lib/composer/installed.json
@@ -1654,17 +1654,17 @@
         },
         {
             "name": "scssphp/scssphp",
-            "version": "v1.13.0",
-            "version_normalized": "1.13.0.0",
+            "version": "dev-combodo/1.x",
+            "version_normalized": "dev-combodo/1.x",
             "source": {
                 "type": "git",
-                "url": "https://github.com/scssphp/scssphp.git",
-                "reference": "63d1157457e5554edf00b0c1fabab4c1511d2520"
+                "url": "https://github.com/combodo-itop-libs/scssphp.git",
+                "reference": "dde81c0a39d02e8e6fc81b70269747734e16d526"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/63d1157457e5554edf00b0c1fabab4c1511d2520",
-                "reference": "63d1157457e5554edf00b0c1fabab4c1511d2520",
+                "url": "https://api.github.com/repos/combodo-itop-libs/scssphp/zipball/dde81c0a39d02e8e6fc81b70269747734e16d526",
+                "reference": "dde81c0a39d02e8e6fc81b70269747734e16d526",
                 "shasum": ""
             },
             "require": {
@@ -1687,15 +1687,15 @@
                 "ext-iconv": "Can be used as fallback when ext-mbstring is not available",
                 "ext-mbstring": "For best performance, mbstring should be installed as it is faster than ext-iconv"
             },
-            "time": "2024-08-17T21:02:11+00:00",
+            "time": "2026-03-23T15:26:59+00:00",
             "bin": [
                 "bin/pscss"
             ],
             "type": "library",
             "extra": {
                 "bamarni-bin": {
-                    "bin-links": false,
-                    "forward-command": false
+                    "forward-command": false,
+                    "bin-links": false
                 }
             },
             "installation-source": "dist",
@@ -1704,7 +1704,11 @@
                     "ScssPhp\\ScssPhp\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ScssPhp\\ScssPhp\\Tests\\": "tests/"
+                }
+            },
             "license": [
                 "MIT"
             ],
@@ -1730,8 +1734,7 @@
                 "stylesheet"
             ],
             "support": {
-                "issues": "https://github.com/scssphp/scssphp/issues",
-                "source": "https://github.com/scssphp/scssphp/tree/v1.13.0"
+                "source": "https://github.com/combodo-itop-libs/scssphp/tree/combodo/1.x"
             },
             "install-path": "../scssphp/scssphp"
         },

--- a/lib/composer/installed.php
+++ b/lib/composer/installed.php
@@ -292,9 +292,9 @@
             'dev_requirement' => false,
         ),
         'scssphp/scssphp' => array(
-            'pretty_version' => 'v1.13.0',
-            'version' => '1.13.0.0',
-            'reference' => '63d1157457e5554edf00b0c1fabab4c1511d2520',
+            'pretty_version' => 'dev-combodo/1.x',
+            'version' => 'dev-combodo/1.x',
+            'reference' => 'dde81c0a39d02e8e6fc81b70269747734e16d526',
             'type' => 'library',
             'install_path' => __DIR__ . '/../scssphp/scssphp',
             'aliases' => array(),

--- a/lib/scssphp/scssphp/src/Compiler.php
+++ b/lib/scssphp/scssphp/src/Compiler.php
@@ -5052,7 +5052,7 @@ EOL;
      *
      * @return array
      */
-    protected function multiplyMedia(Environment $env = null, $childQueries = null)
+    protected function multiplyMedia(?Environment $env = null, $childQueries = null)
     {
         if (
             ! isset($env) ||
@@ -5144,7 +5144,7 @@ EOL;
      *
      * @return \ScssPhp\ScssPhp\Compiler\Environment
      */
-    protected function pushEnv(Block $block = null)
+    protected function pushEnv(?Block $block = null)
     {
         $env = new Environment();
         $env->parent = $this->env;
@@ -5208,7 +5208,7 @@ EOL;
      *
      * @return void
      */
-    protected function set($name, $value, $shadow = false, Environment $env = null, $valueUnreduced = null)
+    protected function set($name, $value, $shadow = false, ?Environment $env = null, $valueUnreduced = null)
     {
         $name = $this->normalizeName($name);
 
@@ -5314,7 +5314,7 @@ EOL;
      *
      * @return mixed|null
      */
-    public function get($name, $shouldThrow = true, Environment $env = null, $unreduced = false)
+    public function get($name, $shouldThrow = true, ?Environment $env = null, $unreduced = false)
     {
         $normalizedName = $this->normalizeName($name);
         $specialContentKey = static::$namespaces['special'] . 'content';
@@ -5379,7 +5379,7 @@ EOL;
      *
      * @return bool
      */
-    protected function has($name, Environment $env = null)
+    protected function has($name, ?Environment $env = null)
     {
         return ! \is_null($this->get($name, false, $env));
     }

--- a/lib/scssphp/scssphp/src/Formatter.php
+++ b/lib/scssphp/scssphp/src/Formatter.php
@@ -272,7 +272,7 @@ abstract class Formatter
      *
      * @return string
      */
-    public function format(OutputBlock $block, SourceMapGenerator $sourceMapGenerator = null)
+    public function format(OutputBlock $block, ?SourceMapGenerator $sourceMapGenerator = null)
     {
         $this->sourceMapGenerator = null;
 

--- a/lib/scssphp/scssphp/src/Node/Number.php
+++ b/lib/scssphp/scssphp/src/Node/Number.php
@@ -578,7 +578,7 @@ class Number extends Node implements \ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function output(Compiler $compiler = null)
+    public function output(?Compiler $compiler = null)
     {
         $dimension = round($this->dimension, self::PRECISION);
 

--- a/lib/scssphp/scssphp/src/Parser.php
+++ b/lib/scssphp/scssphp/src/Parser.php
@@ -140,7 +140,7 @@ class Parser
      * @param bool                 $cssOnly
      * @param LoggerInterface|null $logger
      */
-    public function __construct($sourceName, $sourceIndex = 0, $encoding = 'utf-8', Cache $cache = null, $cssOnly = false, LoggerInterface $logger = null)
+    public function __construct($sourceName, $sourceIndex = 0, $encoding = 'utf-8', ?Cache $cache = null, $cssOnly = false, ?LoggerInterface $logger = null)
     {
         $this->sourceName       = $sourceName ?: '(stdin)';
         $this->sourceIndex      = $sourceIndex;

--- a/lib/scssphp/scssphp/src/Warn.php
+++ b/lib/scssphp/scssphp/src/Warn.php
@@ -59,7 +59,7 @@ final class Warn
      *
      * @internal
      */
-    public static function setCallback(callable $callback = null)
+    public static function setCallback(?callable $callback = null)
     {
         $previousCallback = self::$callback;
         self::$callback = $callback;


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N°9328
| Type of change?                                               | Enhancement

## Objective (enhancement)
scssphp 1.x is not compatible with PHP 8.4

## Proposed solution enhancement
Fork the library, apply fixes for PHP 8.4 and temporarily change the source of scssphp to our fork (until we figure out how to use the 2.x version)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?
