### PR TITLE
fix(ModuleInstallerAPI): Rename class in DB recursively

### DIFF
--- a/setup/moduleinstaller.class.inc.php
+++ b/setup/moduleinstaller.class.inc.php
@@ -77,7 +77,7 @@ abstract class ModuleInstallerAPI
 	/**
 	 * Helper to complete the renaming of a class
 	 * The renaming is made in the datamodel definition, but the name has to be changed in the DB as well
-	 * Must be called after DB update, i.e within an implementation of AfterDatabaseCreation()
+	 * Must be called before DB update, i.e within an implementation of BeforeDatabaseCreation()
 	 *
 	 * @param string $sFrom Original name (already INVALID in the current datamodel)
 	 * @param string $sTo New name (valid in the current datamodel)
@@ -85,8 +85,14 @@ abstract class ModuleInstallerAPI
 	 */
 	public static function RenameClassInDB($sFrom, $sTo)
 	{
+		if (!MetaModel::DBExists(false)) {
+			// Install from scratch, no migration
+			return;
+		}
+
 		try {
 			if (!MetaModel::IsStandaloneClass($sTo)) {
+				$iAffectedRows = 0;
 				foreach (MetaModel::EnumParentClasses($sTo) as $sParentClass) {
 					$sTableName = MetaModel::DBGetTable($sParentClass);
 					$sFinalClassCol = MetaModel::DBGetClassField($sParentClass);
@@ -100,6 +106,7 @@ abstract class ModuleInstallerAPI
 			// Also rename the class reference on the following classes
 			$aAdditionalClassReferences = [
 				['class' => CMDBChangeOp::class, 'attcode' => 'objclass'],
+				['class' => SynchroDataSource::class, 'attcode' => 'scope_class'],
 				['class' => SynchroReplica::class, 'attcode' => 'dest_class'],
 				['class' => TriggerOnObject::class, 'attcode' => 'target_class'],
 				['class' => EventOnObject::class, 'attcode' => 'obj_class'],

--- a/setup/moduleinstaller.class.inc.php
+++ b/setup/moduleinstaller.class.inc.php
@@ -96,6 +96,24 @@ abstract class ModuleInstallerAPI
 				}
 				SetupLog::Info("Renaming class in DB - final class from '$sFrom' to '$sTo': $iAffectedRows rows affected");
 			}
+
+			// Also rename the class reference on the following classes
+			$aAdditionalClassReferences = [
+				['class' => CMDBChangeOp::class, 'attcode' => 'objclass'],
+				['class' => SynchroReplica::class, 'attcode' => 'dest_class'],
+				['class' => TriggerOnObject::class, 'attcode' => 'target_class'],
+				['class' => EventOnObject::class, 'attcode' => 'obj_class'],
+			];
+			foreach ($aAdditionalClassReferences as ['class' => $sClass, 'attcode' => $sAttCode]) {
+				if (MetaModel::IsValidAttCode($sClass, $sAttCode)) {
+					$sTableName = MetaModel::DBGetTable($sClass, $sAttCode);
+					$sClassCol = MetaModel::GetAttributeDef($sClass, $sAttCode)->Get("sql");
+					$sRepair = "UPDATE `$sTableName` SET `$sClassCol` = '$sTo' WHERE `$sClassCol` = BINARY '$sFrom'";
+					CMDBSource::Query($sRepair);
+					$iAffectedRows = CMDBSource::AffectedRows();
+					SetupLog::Info("Renaming class in DB - $sClass::$sAttCode - from '$sFrom' to '$sTo': $iAffectedRows rows affected");
+				}
+			}
 		} catch (Exception $e) {
 			SetupLog::Warning("Failed to rename class in DB - final class from '$sFrom' to '$sTo'. Reason: ".$e->getMessage());
 		}

--- a/setup/moduleinstaller.class.inc.php
+++ b/setup/moduleinstaller.class.inc.php
@@ -87,12 +87,14 @@ abstract class ModuleInstallerAPI
 	{
 		try {
 			if (!MetaModel::IsStandaloneClass($sTo)) {
-				$sRootClass = MetaModel::GetRootClass($sTo);
-				$sTableName = MetaModel::DBGetTable($sRootClass);
-				$sFinalClassCol = MetaModel::DBGetClassField($sRootClass);
-				$sRepair = "UPDATE `$sTableName` SET `$sFinalClassCol` = '$sTo' WHERE `$sFinalClassCol` = BINARY '$sFrom'";
-				CMDBSource::Query($sRepair);
-				$iAffectedRows = CMDBSource::AffectedRows();
+				$sClass = $sTo;
+				foreach (MetaModel::EnumParentClasses($Class) as $sParentClass) {
+					$sTableName = MetaModel::DBGetTable($sParentClass);
+					$sFinalClassCol = MetaModel::DBGetClassField($sParentClass);
+					$sRepair = "UPDATE `$sTableName` SET `$sFinalClassCol` = '$sTo' WHERE `$sFinalClassCol` = BINARY '$sFrom'";
+					CMDBSource::Query($sRepair);
+					$iAffectedRows += CMDBSource::AffectedRows();
+				}
 				SetupLog::Info("Renaming class in DB - final class from '$sFrom' to '$sTo': $iAffectedRows rows affected");
 			}
 		} catch (Exception $e) {

--- a/setup/moduleinstaller.class.inc.php
+++ b/setup/moduleinstaller.class.inc.php
@@ -87,8 +87,7 @@ abstract class ModuleInstallerAPI
 	{
 		try {
 			if (!MetaModel::IsStandaloneClass($sTo)) {
-				$sClass = $sTo;
-				foreach (MetaModel::EnumParentClasses($Class) as $sParentClass) {
+				foreach (MetaModel::EnumParentClasses($sTo) as $sParentClass) {
 					$sTableName = MetaModel::DBGetTable($sParentClass);
 					$sFinalClassCol = MetaModel::DBGetClassField($sParentClass);
 					$sRepair = "UPDATE `$sTableName` SET `$sFinalClassCol` = '$sTo' WHERE `$sFinalClassCol` = BINARY '$sFrom'";


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Bug fix

## Symptom

Using `ModuleInstallerAPI::RenameClassInDB` to rename classes does not work for classes having intermediate classes.

Renaming `Child` works:

* `Parent`
  * `Child`

Renaming `Child` does not work:

* `Parent`
  * `Intermediate`
    * `Child`

## Reproduction procedure

1. Have an old datamodel where DB server objects are still called `DBserver`.
2. `ModuleInstallerAPI::RenameClassInDB('DBserver', 'DBServer');` as done in `itop-config-mgmt`.
3. Run query `SELECT SoftwareInstance`

Observe the DB server objects not being listed (but they are counted in total objects).

## Cause

The mentioned helper method only updates the finalclass field for the root class.

## Proposed solution

Update the finalclass field for all parent classes recursively.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?
