### PR TITLE
fix(DBOjbect): Display attribute value in uniqueness rule message

### DIFF
--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -2183,7 +2183,7 @@ abstract class DBObject implements iDisplay
 						$aPlaceholdersData[] = MetaModel::GetObject($oAttDef->GetTargetClass(), $this->Get($sAttCode))->Get('friendlyname');
 					} else {
 						$aPlaceholdersData[] = $oAttDef->GetLabel();
-						$aPlaceholdersData[] = $oAttDef->GetLabel($this->Get($sAttCode));
+						$aPlaceholdersData[] = $oAttDef->GetValueLabel($this->Get($sAttCode));
 					}
 				}
 			}


### PR DESCRIPTION
## Base information

| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Bug fix

## Symptom

The generic uniqueness rule message for `no_duplicate` displays the field label twice:

> Location: Test location is already linked to Role: Role, duplicates are not allowed on this relation.

## Reproduction procedure

1. Add a new `uniqueness_rules/rule` with id `no_duplicate` in the class datamodel.
2. Try to create a duplicate who would match the rule.
3. Observe the error message as shown above.

## Cause

The `DBObject::GetUniquenessRuleGenericMessage` method wrongly calls `AttributeDefinition::GetLabel` with the attribute value as parameter.

## Proposed solution

Call `AttributeDefinition::GetValueLabel` instead.

I could not add a test for this case in `UniquenessMessageTest`, since (I think) there are no uniqueness rules without a custom message and without externalkey attributes in the standard datamodel.

Resulting message would be:

> Location: Test location is already linked to Role: Testrole, duplicates are not allowed on this relation.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?