### PR TITLE
N°9101 - Improve HTML markup for end-to-end tests automation

### DIFF
--- a/setup/setuppage.class.inc.php
+++ b/setup/setuppage.class.inc.php
@@ -36,6 +36,8 @@ class SetupPage extends NiceWebPage
 {
 	public const DEFAULT_PAGE_TEMPLATE_REL_PATH = 'pages/backoffice/setuppage/layout';
 
+	protected const BODY_DATA_GUI_TYPE = 'setup';
+
 	public function __construct($sTitle)
 	{
 		parent::__construct($sTitle);

--- a/sources/Application/WebPage/AjaxPage.php
+++ b/sources/Application/WebPage/AjaxPage.php
@@ -233,6 +233,7 @@ class AjaxPage extends WebPage implements iTabbedPage
 			'aJsInlineLive'       => $this->a_scripts,
 			'aJsInlineOnDomReady' => $this->GetReadyScripts(),
 			'aJsInlineOnInit'     => $this->a_init_scripts,
+			'sBodyDataGuiType'    => static::BODY_DATA_GUI_TYPE,
 			'bEscapeContent'      => ($this->sContentType == 'text/html') && ($this->sContentDisposition == 'inline'),
 			// TODO 3.0.0: TEMP, used while developping, remove it.
 			'sSanitizedContent'   => utils::FilterXSS($this->s_content),

--- a/sources/Application/WebPage/UnauthenticatedWebPage.php
+++ b/sources/Application/WebPage/UnauthenticatedWebPage.php
@@ -172,6 +172,7 @@ class UnauthenticatedWebPage extends NiceWebPage
 			'aJsInlineLive'       => $this->a_scripts,
 			'aJsInlineOnDomReady' => $this->GetReadyScripts(),
 			'aJsInlineOnInit'     => $this->a_init_scripts,
+			'sBodyDataGuiType'    => static::BODY_DATA_GUI_TYPE,
 
 			// TODO 3.0.0: TEMP, used while developing, remove it.
 			'sCapturedOutput'     => utils::FilterXSS($s_captured_output),

--- a/sources/Application/WebPage/WebPage.php
+++ b/sources/Application/WebPage/WebPage.php
@@ -152,6 +152,8 @@ class WebPage implements Page
 	 */
 	public const DEFAULT_PAGE_TEMPLATE_REL_PATH = 'pages/backoffice/webpage/layout';
 
+	protected const BODY_DATA_GUI_TYPE = 'backoffice';
+
 	protected $s_title;
 	protected $s_content;
 	protected $s_deferred_content;
@@ -1702,6 +1704,7 @@ JS;
 			'aJsInlineLive'       => $this->a_scripts,
 			'aJsInlineOnDomReady' => $this->GetReadyScripts(),
 			'aJsInlineOnInit'     => $this->a_init_scripts,
+			'sBodyDataGuiType'    => static::BODY_DATA_GUI_TYPE,
 
 			// TODO 3.0.0: TEMP, used while developing, remove it.
 			'sCapturedOutput'     => utils::FilterXSS($s_captured_output),

--- a/sources/Application/WebPage/iTopWebPage.php
+++ b/sources/Application/WebPage/iTopWebPage.php
@@ -1003,6 +1003,7 @@ HTML;
 				'aJsInlineOnInit' => $this->a_init_scripts,
 				'aJsInlineOnDomReady' => $this->GetReadyScripts(),
 				'aJsInlineLive' => $this->a_scripts,
+				'sBodyDataGuiType' => static::BODY_DATA_GUI_TYPE,
 				// TODO 3.0.0: TEMP, used while developping, remove it.
 				'sSanitizedContent' => utils::FilterXSS($this->s_content),
 				'sDeferredContent' => utils::FilterXSS($this->s_deferred_content),

--- a/templates/pages/backoffice/webpage/layout.html.twig
+++ b/templates/pages/backoffice/webpage/layout.html.twig
@@ -49,7 +49,7 @@
         {% endfor %}
     {% endblock %}
 </head>
-<body data-gui-type="backoffice">
+<body data-gui-type="{{ aPage.sBodyDataGuiType|default('backoffice') }}">
 {% if aPage.isPrintable %}<div class="printable-content" style="width: 27.7cm;">{% endif %}
     {% block iboPageBodyHtml %}
         <div id="ibo-page-container">


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | [N°9101](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=9101)
| Type of change?                                               | Enhancement


## Objective

Be able to identify the type of "setup" GUI in setup pages using the "data-gui-type" attribute.
This will make it possible to distinguish setup pages from console pages in end-to-end tests

## Proposed solution

Add a "sBodyDataGuiType" parameter, which is passed to the TWIG template on the various pages, with a default value of "backoffice" and "setup" on the setup pages

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?