### PR TITLE
N°8234 - Fix permission checks to conditionally allow display of unauthorized objects

### DIFF
--- a/sources/Controller/AjaxRenderController.php
+++ b/sources/Controller/AjaxRenderController.php
@@ -74,7 +74,10 @@ class AjaxRenderController
 		$oSet->SetShowObsoleteData($bShowObsoleteData);
 
 		// N°8606 : Check user permissions on the main class
-		if (UserRights::IsActionAllowed($oSet->GetClass(), UR_ACTION_READ, $oSet) !== UR_ALLOWED_YES) {
+		if (
+			UserRights::IsActionAllowed($oSet->GetClass(), UR_ACTION_READ, $oSet) !== UR_ALLOWED_YES
+			&& ($aExtraParams['display_unauthorized_objects'] ?? false) === false
+		) {
 			throw new Exception(Dict::Format('UI:Error:ReadNotAllowedOn_Class', $oSet->GetClass()));
 		}
 
@@ -103,7 +106,10 @@ class AjaxRenderController
 					}
 
 					// N°8606 : Check user permissions on the current class
-					if (UserRights::IsActionAllowed($sClass, UR_ACTION_READ, $oSet) !== UR_ALLOWED_YES) {
+					if (
+						UserRights::IsActionAllowed($sClass, UR_ACTION_READ, $oSet) !== UR_ALLOWED_YES
+						&& ($aExtraParams['display_unauthorized_objects'] ?? false) === false
+					) {
 						throw new Exception(Dict::Format('UI:Error:ReadNotAllowedOn_Class', $sClass));
 					}
 


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | [N°8234](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=8234)
| Type of change?                                               | Bug fix

## Symptom

Following [PR 853](https://github.com/Combodo/iTop/pull/853), notifications for an object are no longer displayed if the user does not have read permissions on the EventNotification{YXZ} class. We would like to display them without being able to access the notification details


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?