### PR TITLE
N°8737 - Fix search criteria dropdown vertical overflow

### DIFF
--- a/css/backoffice/components/_search-form.scss
+++ b/css/backoffice/components/_search-form.scss
@@ -21,6 +21,8 @@ $ibo-search-form-panel--more-criteria--color: $ibo-color-blue-grey-800 !default;
 $ibo-search-form-panel--more-criteria--background-color: $ibo-color-white-100 !default;
 $ibo-search-form-panel--more-criteria--icon--color: $ibo-color-primary-600 !default;
 $ibo-search-form-panel--more-criteria--border-color: $ibo-search-form-panel--criteria--border-color !default;
+// calc is redundant but avoid SCSS min() from being used instead of CSS min()
+$ibo-search-form-panel--criteria--max-height: calc(min(#{$ibo-size-750}, 50vh)) !default;
 
 $ibo-search-form-panel--items--hover--color: $ibo-color-grey-200 !default;
 
@@ -278,9 +280,10 @@ $ibo-search-results-area--datatable-scrollhead--border--is-sticking: $ibo-search
 				}
 
 				.sfc_form_group {
-          display: block;
-          margin-top: -1px;
-          z-index: -1;
+                  display: flex;
+                  flex-direction: column;
+                  margin-top: -1px;
+                  z-index: -1;
         }
 			}
 
@@ -346,11 +349,14 @@ $ibo-search-results-area--datatable-scrollhead--border--is-sticking: $ibo-search
         display: none;
         max-width: 450px;
         width: max-content;
-        max-height: 520px;
+        max-height: $ibo-search-form-panel--criteria--max-height;
         overflow-x: auto;
         overflow-y: hidden;
 
 				.sfc_fg_operators {
+                    display: flex;
+                    flex-direction: column;
+                    overflow: auto;
 					font-size: 12px;
 
 					.sfc_fg_operator {
@@ -387,6 +393,9 @@ $ibo-search-results-area--datatable-scrollhead--border--is-sticking: $ibo-search
 						}
 
 						.sfc_opc_multichoices {
+                            display: flex;
+                            flex-direction: column;
+                            height: 100%;
 							label > input {
 								vertical-align: text-top;
 								margin-left: $ibo-spacing-0;
@@ -398,7 +407,6 @@ $ibo-search-results-area--datatable-scrollhead--border--is-sticking: $ibo-search
 							}
 
 							.sfc_opc_mc_items_wrapper {
-								max-height: 415px; /* Must be less than .sfc_form_group:max-height - .sfc_opc_mc_toggler:height - .sfc_opc_mc_filter:height */
 								overflow-y: auto;
 								margin: $ibo-spacing-0 -8px; /* Compensate .sfc_opc_multichoices side padding so the hover style can take the full with */
 
@@ -560,8 +568,14 @@ $ibo-search-results-area--datatable-scrollhead--border--is-sticking: $ibo-search
 			&.search_form_criteria_enum {
 				.sfc_form_group {
 					.sfc_fg_operator_in {
+                        display: flex;
+                        flex-direction: column;
+                        height: 100%;
+                        min-height: 0;
 						> label {
-							display: inline-block;
+							display: flex;
+                            height: 100%;
+                            min-height: 0;
 							width: 100%;
 							line-height: initial;
 							white-space: nowrap;

--- a/css/backoffice/components/_search-form.scss
+++ b/css/backoffice/components/_search-form.scss
@@ -357,6 +357,7 @@ $ibo-search-results-area--datatable-scrollhead--border--is-sticking: $ibo-search
                     display: flex;
                     flex-direction: column;
                     overflow: auto;
+                    min-height: 0;
 					font-size: 12px;
 
 					.sfc_fg_operator {


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N°8737
| Type of change?                                               | Bug fix


## Symptom (bug)
On smaller screens, the criteria dropdown could overflow out of the viewport


## Reproduction procedure (bug)

1. On a iTop 3.2.2
2. With an admin user account
3. Open the console, go to "Search User Requests"
4. Open the "Requester" filter criteria
5. Ensure there are more than 20 values; if not, add more data or change `max_combo_length` parameter
6. Change the browser window size or screen resolution to 720p maximum height
7. Observe that the criterion values ​​extend beyond the screen

## Cause (bug)
The max-height for criteria is hardcoded to 520px


## Proposed solution (bug and enhancement)
Replace the hardcoded value with a min between 512px and 50vh to keep the height consistent
Move most of the criterion display to flex display to ensure overflow and good placement of top filter or bottom buttons


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?
