### PR TITLE
:white_check_mark: Fix PHPUnit cURL calls to iTop within Combodo's Docker dev. env. with PHP version autodetection

### DIFF
--- a/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
+++ b/tests/php-unit-tests/src/BaseTestCase/ItopTestCase.php
@@ -708,6 +708,16 @@ abstract class ItopTestCase extends KernelTestCase
 	{
 		$sUrl = \MetaModel::GetConfig()->Get('app_root_url')."/$sUri";
 
+		// Add PHP version in header to be able to handle Docker dev environments with automatic PHP version detection (instead of hardcoding the PHP version in the app_root_url)
+		$sPhpVersion = PHP_VERSION;
+		$aPhpVersionParts = explode('.', $sPhpVersion);
+		$sPhpVersionHeaderValue = ($aPhpVersionParts[0] ?? '0').($aPhpVersionParts[1] ?? '0');
+		$aCurlOptions = $aCurlOptions ?? [];
+		$aCurlOptions[CURLOPT_HTTPHEADER] = array_merge(
+			$aCurlOptions[CURLOPT_HTTPHEADER] ?? [],
+			['X-PHP-Version: '.$sPhpVersionHeaderValue]
+		);
+
 		return $this->CallUrl($sUrl, $aPostFields, $aCurlOptions, $bXDebugEnabled);
 	}
 }


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N.A.
| Type of change?                                               | Bug fix


## Symptom (bug) / Objective (enhancement)
PHPUnit tests failing when run in [Combodo's Docker dev/test environments](https://github.com/Combodo/docker-environment) when PHP version is autodetected, cURL calls from PHPUnit to iTop can fail because the target PHP version is not provided.

Symptom can vary depending on the unit test, for example with `\Combodo\iTop\Test\UnitTest\Webservices\RestTest::testPostJSONDataAsCurlFile()` you have the following error:
```
Trying to access array offset on value of type null
 /var/www/html/itop/dev-support-3.2/tests/php-unit-tests/unitary-tests/webservices/RestTest.php:102
```

The objective is to pass the running PHP version so the endpoint can be resolved correctly; without having to manually set the corresponding port in the `app_root_url`.


## Reproduction procedure (bug)
1. On iTop `suport/3.2` branch
2. With Combodo's Docker environment
3. With `app_root_url` set to `https` with PHP version autodection
4. Run unit test `\Combodo\iTop\Test\UnitTest\Webservices\RestTest::testPostJSONDataAsCurlFile()`
2. See that you ahve the following error


## Cause (bug)
When using PHP version autodetection in the `app_root_url`, the PHP version to use ust be passed through an HTTP header, which is done through a browser extension when using the browser, but isn't present for programatical calls.

* PHP version autodetection URL examples:
  * `https://localhost/itop`
  * `http://localhost:88/itop`
* PHP version passed with the URL examples:
  * `http://localhost:83/itop` for PHP 8.3
  * `http://localhost:84/itop` for PHP 8.4
  * ...

## Proposed solution (bug and enhancement)
Add an `X-PHP-Version` header in `\Combodo\iTop\Test\UnitTest\ItopTestCase::CallItopUri()`, derived from `PHP_VERSION` \(major+minor, e.g. 8.3.x →83\), and pass it through to `\Combodo\iTop\Test\UnitTest\ItopTestCase::CallUrl`. This enables automatic PHP version detection in Docker dev/test environments.


## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand digging in the code?
