### PR TITLE
N°9448 - Fix external auth variable value

### DIFF
--- a/application/loginexternal.class.inc.php
+++ b/application/loginexternal.class.inc.php
@@ -75,13 +75,10 @@ class LoginExternal extends AbstractLoginFSMExtension
 	}
 
 	/**
-	 * @return bool
+	 * @return bool|mixed
 	 */
 	private function GetAuthUser()
 	{
-		$sExtAuthVar = MetaModel::GetConfig()->GetExternalAuthenticationVariable(); // In which variable is the info passed ?
-		eval('$sAuthUser = isset('.$sExtAuthVar.') ? '.$sExtAuthVar.' : false;'); // Retrieve the value
-		/** @var string $sAuthUser */
-		return $sAuthUser; // Retrieve the value
+		return MetaModel::GetConfig()->GetExternalAuthenticationVariable();
 	}
 }

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -873,8 +873,8 @@ class Config
 		'ext_auth_variable' => [
 			'type' => 'string',
 			'description' => 'External authentication expression (allowed: $_SERVER[\'key\'], $_COOKIE[\'key\'], $_REQUEST[\'key\'], getallheaders()[\'Header-Name\'])',
-			'default' => '',
-			'value' => '',
+			'default' => '$_SERVER[\'REMOTE_USER\']',
+			'value' => '$_SERVER[\'REMOTE_USER\']',
 			'source_of_value' => '',
 			'show_in_conf_sample' => false,
 		],

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -1976,11 +1976,6 @@ class Config
 	protected $m_sAllowedLoginTypes;
 
 	/**
-	 * @var string Name of the PHP variable in which external authentication information is passed by the web server
-	 */
-	protected $m_sExtAuthVariable;
-
-	/**
 	 * @var string Encryption key used for all attributes of type "encrypted string". Can be set to a random value
 	 *             unless you want to import a database from another iTop instance, in which case you must use
 	 *             the same encryption key in order to properly decode the encrypted fields
@@ -2052,7 +2047,6 @@ class Config
 		$this->m_bSecureConnectionRequired = DEFAULT_SECURE_CONNECTION_REQUIRED;
 		$this->m_sDefaultLanguage = 'EN US';
 		$this->m_sAllowedLoginTypes = DEFAULT_ALLOWED_LOGIN_TYPES;
-		$this->m_sExtAuthVariable = DEFAULT_EXT_AUTH_VARIABLE;
 		$this->m_aCharsets = [];
 		$this->m_bQueryCacheEnabled = DEFAULT_QUERY_CACHE_ENABLED;
 		$this->m_iPasswordHashAlgo = DEFAULT_HASH_ALGO;
@@ -2206,7 +2200,6 @@ class Config
 
 		$this->m_sDefaultLanguage = isset($MySettings['default_language']) ? trim($MySettings['default_language']) : 'EN US';
 		$this->m_sAllowedLoginTypes = isset($MySettings['allowed_login_types']) ? trim($MySettings['allowed_login_types']) : DEFAULT_ALLOWED_LOGIN_TYPES;
-		$this->m_sExtAuthVariable = isset($MySettings['ext_auth_variable']) ? trim($MySettings['ext_auth_variable']) : DEFAULT_EXT_AUTH_VARIABLE;
 		$this->m_sEncryptionKey = isset($MySettings['encryption_key']) ? trim($MySettings['encryption_key']) : $this->m_sEncryptionKey;
 		$this->m_sEncryptionLibrary = isset($MySettings['encryption_library']) ? trim($MySettings['encryption_library']) : $this->m_sEncryptionLibrary;
 		$this->m_aCharsets = isset($MySettings['csv_import_charsets']) ? $MySettings['csv_import_charsets'] : [];
@@ -2521,7 +2514,7 @@ class Config
 
 	public function SetExternalAuthenticationVariable($sExtAuthVariable)
 	{
-		$this->m_sExtAuthVariable = $sExtAuthVariable;
+		$this->Set('ext_auth_variable', $sExtAuthVariable);
 	}
 
 	public function SetEncryptionKey($sKey)
@@ -2576,7 +2569,6 @@ class Config
 		$aSettings['secure_connection_required'] = $this->m_bSecureConnectionRequired;
 		$aSettings['default_language'] = $this->m_sDefaultLanguage;
 		$aSettings['allowed_login_types'] = $this->m_sAllowedLoginTypes;
-		$aSettings['ext_auth_variable'] = $this->m_sExtAuthVariable;
 		$aSettings['encryption_key'] = $this->m_sEncryptionKey;
 		$aSettings['encryption_library'] = $this->m_sEncryptionLibrary;
 		$aSettings['csv_import_charsets'] = $this->m_aCharsets;
@@ -2681,7 +2673,6 @@ class Config
 			$aOtherValues = [
 				'default_language' => $this->m_sDefaultLanguage,
 				'allowed_login_types' => $this->m_sAllowedLoginTypes,
-				'ext_auth_variable' => $this->m_sExtAuthVariable,
 				'encryption_key' => $this->m_sEncryptionKey,
 				'encryption_library' => $this->m_sEncryptionLibrary,
 				'csv_import_charsets' => $this->m_aCharsets,

--- a/core/config.class.inc.php
+++ b/core/config.class.inc.php
@@ -75,6 +75,7 @@ define('DEFAULT_EXT_AUTH_VARIABLE', '$_SERVER[\'REMOTE_USER\']');
 define('DEFAULT_ENCRYPTION_KEY', '@iT0pEncr1pti0n!'); // We'll use a random generated key later (if possible)
 define('DEFAULT_ENCRYPTION_LIB', 'Mcrypt'); // We'll define the best encryption available later
 define('DEFAULT_HASH_ALGO', PASSWORD_DEFAULT);
+
 /**
  * Config
  * configuration data (this class cannot not be localized, because it is responsible for loading the dictionaries)
@@ -866,6 +867,14 @@ class Config
 			// examples... not used (nor 'description')
 			'default' => false,
 			'value' => false,
+			'source_of_value' => '',
+			'show_in_conf_sample' => false,
+		],
+		'ext_auth_variable' => [
+			'type' => 'string',
+			'description' => 'External authentication expression (allowed: $_SERVER[\'key\'], $_COOKIE[\'key\'], $_REQUEST[\'key\'], getallheaders()[\'Header-Name\'])',
+			'default' => '',
+			'value' => '',
 			'source_of_value' => '',
 			'show_in_conf_sample' => false,
 		],
@@ -2350,9 +2359,73 @@ class Config
 		return explode('|', $this->m_sAllowedLoginTypes);
 	}
 
+	/**
+	 * @return bool|mixed
+	 * @since 3.2.3 return the parsed value instead of an unsecured variable name
+	 */
 	public function GetExternalAuthenticationVariable()
 	{
-		return $this->m_sExtAuthVariable;
+		$sExpression = $this->Get('ext_auth_variable');
+		$aParsed = $this->ParseExternalAuthVariableExpression($sExpression);
+		if ($aParsed === null) {
+			return false;
+		}
+
+		$sKey = $aParsed['key'];
+		switch ($aParsed['type']) {
+			case 'server':
+				return $_SERVER[$sKey] ?? false;
+			case 'cookie':
+				return $_COOKIE[$sKey] ?? false;
+			case 'request':
+				return $_REQUEST[$sKey] ?? false;
+			case 'header':
+				if (!function_exists('getallheaders')) {
+					return false;
+				}
+				$aHeaders = getallheaders();
+				if (!is_array($aHeaders)) {
+					return false;
+				}
+				return $aHeaders[$sKey] ?? false;
+		}
+		return false;
+	}
+
+	/**
+	 * @param $sExpression
+	 * @return array|null
+	 */
+	private function ParseExternalAuthVariableExpression($sExpression)
+	{
+		// If it's a configuration parameter it's probably already trimmed, but just in case
+		$sExpression = trim((string) $sExpression);
+		if ($sExpression === '') {
+			return null;
+		}
+
+		// Match $_SERVER/$_COOKIE/$_REQUEST['key'] with optional whitespace and single/double quotes.
+		if (preg_match('/^\$_(SERVER|COOKIE|REQUEST)\s*\[\s*(["\'])\s*([^"\']+)\2\s*\]\s*$/', $sExpression, $aMatches) === 1) {
+			$sContext = strtoupper($aMatches[1]);
+			$sKey = $aMatches[3];
+			return [
+				'type' => strtolower($sContext),
+				'key' => $sKey,
+				'normalized' => '$_'.$sContext.'[\''.$sKey.'\']',
+			];
+		}
+
+		// Match getallheaders()['Header-Name'] in a case-insensitive way.
+		if (preg_match('/^getallheaders\(\)\s*\[\s*(["\'])\s*([^"\']+)\1\s*\]\s*$/i', $sExpression, $aMatches) === 1) {
+			$sKey = $aMatches[2];
+			return [
+				'type' => 'header',
+				'key' => $sKey,
+				'normalized' => 'getallheaders()[\''.$sKey.'\']',
+			];
+		}
+
+		return null;
 	}
 
 	public function GetCSVImportCharsets()

--- a/tests/php-unit-tests/unitary-tests/application/LoginExternalTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/LoginExternalTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Copyright (C) 2010-2024 Combodo SAS
+ *
+ * This file is part of iTop.
+ *
+ * iTop is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * iTop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with iTop. If not, see <http://www.gnu.org/licenses/>
+ */
+
+namespace Combodo\iTop\Test\UnitTest\Application;
+
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use utils;
+
+class LoginExternalTest extends ItopDataTestCase
+{
+	private $oConfig;
+	private $sOriginalExtAuthVariable;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		require_once APPROOT.'application/loginexternal.class.inc.php';
+		$this->oConfig = utils::GetConfig();
+		$this->sOriginalExtAuthVariable = $this->oConfig->Get('ext_auth_variable');
+	}
+
+	protected function tearDown(): void
+	{
+		$this->oConfig->Set('ext_auth_variable', $this->sOriginalExtAuthVariable, 'unit_test');
+		parent::tearDown();
+	}
+
+	private function CallGetAuthUser()
+	{
+		$oLoginExternal = new \LoginExternal();
+		$oMethod = new \ReflectionMethod(\LoginExternal::class, 'GetAuthUser');
+		$oMethod->setAccessible(true);
+		return $oMethod->invoke($oLoginExternal);
+	}
+
+	public function testGetAuthUserFromServerVariable()
+	{
+		$_SERVER['REMOTE_USER'] = 'alice';
+		$this->oConfig->Set('ext_auth_variable', '$_SERVER[\'REMOTE_USER\']', 'unit_test');
+
+		$this->assertSame('alice', $this->CallGetAuthUser());
+	}
+
+	public function testGetAuthUserFromCookie()
+	{
+		$_COOKIE['auth_user'] = 'bob';
+		$this->oConfig->Set('ext_auth_variable', '$_COOKIE[\'auth_user\']', 'unit_test');
+
+		$this->assertSame('bob', $this->CallGetAuthUser());
+	}
+
+	public function testGetAuthUserFromRequest()
+	{
+		$_REQUEST['auth_user'] = 'carol';
+		$this->oConfig->Set('ext_auth_variable', '$_REQUEST[\'auth_user\']', 'unit_test');
+
+		$this->assertSame('carol', $this->CallGetAuthUser());
+	}
+
+	public function testInvalidExpressionReturnsFalse()
+	{
+		$this->oConfig->Set('ext_auth_variable', '$_SERVER[\'HTTP_X_CMD\']) ? print(\'x\') : false; //', 'unit_test');
+
+		$this->assertFalse($this->CallGetAuthUser());
+	}
+
+	public function testGetAuthUserFromHeaderWithoutAllowlist()
+	{
+		if (!function_exists('getallheaders')) {
+			$this->markTestSkipped('getallheaders() not available');
+		}
+		$_SERVER['HTTP_X_REMOTE_USER'] = 'CN=header-test';
+		$this->oConfig->Set('ext_auth_variable', 'getallheaders()[\'X-Remote-User\']', 'unit_test');
+
+		$this->assertSame('CN=header-test', $this->CallGetAuthUser());
+	}
+}

--- a/tests/php-unit-tests/unitary-tests/application/LoginExternalTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/LoginExternalTest.php
@@ -39,7 +39,7 @@ class LoginExternalTest extends ItopDataTestCase
 
 	protected function tearDown(): void
 	{
-		$this->oConfig->Set('ext_auth_variable', $this->sOriginalExtAuthVariable, 'unit_test');
+		$this->oConfig->SetExternalAuthenticationVariable($this->sOriginalExtAuthVariable);
 		parent::tearDown();
 	}
 
@@ -54,7 +54,7 @@ class LoginExternalTest extends ItopDataTestCase
 	public function testGetAuthUserFromServerVariable()
 	{
 		$_SERVER['REMOTE_USER'] = 'alice';
-		$this->oConfig->Set('ext_auth_variable', '$_SERVER[\'REMOTE_USER\']', 'unit_test');
+		$this->oConfig->SetExternalAuthenticationVariable('$_SERVER[\'REMOTE_USER\']');
 
 		$this->assertSame('alice', $this->CallGetAuthUser());
 	}
@@ -62,7 +62,7 @@ class LoginExternalTest extends ItopDataTestCase
 	public function testGetAuthUserFromCookie()
 	{
 		$_COOKIE['auth_user'] = 'bob';
-		$this->oConfig->Set('ext_auth_variable', '$_COOKIE[\'auth_user\']', 'unit_test');
+		$this->oConfig->SetExternalAuthenticationVariable('$_COOKIE[\'auth_user\']');
 
 		$this->assertSame('bob', $this->CallGetAuthUser());
 	}
@@ -70,14 +70,14 @@ class LoginExternalTest extends ItopDataTestCase
 	public function testGetAuthUserFromRequest()
 	{
 		$_REQUEST['auth_user'] = 'carol';
-		$this->oConfig->Set('ext_auth_variable', '$_REQUEST[\'auth_user\']', 'unit_test');
+		$this->oConfig->SetExternalAuthenticationVariable('$_REQUEST[\'auth_user\']');
 
 		$this->assertSame('carol', $this->CallGetAuthUser());
 	}
 
 	public function testInvalidExpressionReturnsFalse()
 	{
-		$this->oConfig->Set('ext_auth_variable', '$_SERVER[\'HTTP_X_CMD\']) ? print(\'x\') : false; //', 'unit_test');
+		$this->oConfig->SetExternalAuthenticationVariable('$_SERVER[\'HTTP_X_CMD\']) ? print(\'x\') : false; //');
 
 		$this->assertFalse($this->CallGetAuthUser());
 	}
@@ -88,7 +88,7 @@ class LoginExternalTest extends ItopDataTestCase
 			$this->markTestSkipped('getallheaders() not available');
 		}
 		$_SERVER['HTTP_X_REMOTE_USER'] = 'CN=header-test';
-		$this->oConfig->Set('ext_auth_variable', 'getallheaders()[\'X-Remote-User\']', 'unit_test');
+		$this->oConfig->SetExternalAuthenticationVariable('getallheaders()[\'X-Remote-User\']');
 
 		$this->assertSame('CN=header-test', $this->CallGetAuthUser());
 	}


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N°9448
| Type of change?                                               | Bug fix 

## Symptom (bug) / Objective (enhancement)
`ext_auth_variable` wasn't sanitized and allowed more values than anticipated

## Proposed solution (bug and enhancement)
Parse the value and interpret it later rather than evaluating the string value


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?

