### PR TITLE
N°8576 - [RequestTemplate] Slowness during the selection of drop-down list field

### DIFF
--- a/js/field_set.js
+++ b/js/field_set.js
@@ -192,8 +192,9 @@ $(function()
 			for (let i in oData.updated_fields)
 			{
 				const oUpdatedField = oData.updated_fields[i];
+				const oUpdatedField = oData.updated_fields[i];
 				const oPreviousField = this.options.fields_list[oUpdatedField.id];
-				if (!oPreviousField || oPreviousField !== oUpdatedField) {
+				if (!oPreviousField || JSON.stringify(oPreviousField) !== JSON.stringify(oUpdatedField)) {
 					this.options.fields_list[oUpdatedField.id] = oUpdatedField;
 					this._prepareField(oUpdatedField.id);
 				}

--- a/js/field_set.js
+++ b/js/field_set.js
@@ -192,7 +192,6 @@ $(function()
 			for (let i in oData.updated_fields)
 			{
 				const oUpdatedField = oData.updated_fields[i];
-				const oUpdatedField = oData.updated_fields[i];
 				const oPreviousField = this.options.fields_list[oUpdatedField.id];
 				if (!oPreviousField || JSON.stringify(oPreviousField) !== JSON.stringify(oUpdatedField)) {
 					this.options.fields_list[oUpdatedField.id] = oUpdatedField;

--- a/js/field_set.js
+++ b/js/field_set.js
@@ -189,11 +189,14 @@ $(function()
 			this.buildData.script_code = '';
 			this.buildData.style_code = '';
 
-			for (var i in oData.updated_fields)
+			for (let i in oData.updated_fields)
 			{
-				var oUpdatedField = oData.updated_fields[i];
-				this.options.fields_list[oUpdatedField.id] = oUpdatedField;
-				this._prepareField(oUpdatedField.id);
+				const oUpdatedField = oData.updated_fields[i];
+				const oPreviousField = this.options.fields_list[oUpdatedField.id];
+				if (!oPreviousField || oPreviousField !== oUpdatedField) {
+					this.options.fields_list[oUpdatedField.id] = oUpdatedField;
+					this._prepareField(oUpdatedField.id);
+				}
 			}
 
 			// Adding code to the dom


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=8576
| Type of change?                                               | Bug fix

## Symptom (bug) / Objective (enhancement)
When selecting a value in a drop-down that affect many fields (in templates) it takes up to 5-10 seconds to update the interface, if many fields are updated.

## Reproduction procedure (bug)
1. On iTop3.2.1
2. With PHP 8.33.
3. Create a user request (defined in a template) with a drop-down list field
4. Select a value from the drop-down list (that may have impact on many other fields)
5. Observe the slowness in the UI

## Cause (bug)
The slowness is caused by the system updating all fields, even if their data has not changed. This results in unnecessary DOM manipulations.

## Proposed solution (bug and enhancement)
Only update fields that are new or have been modified.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?