### PR TITLE
N°9043 - Fix automatic search on direct linkset block

### DIFF
--- a/application/ui.linksdirectwidget.class.inc.php
+++ b/application/ui.linksdirectwidget.class.inc.php
@@ -228,7 +228,7 @@ JS
 			<<<HTML
 <form id="ObjectsAddForm_{$this->sInputid}">
     <div id="SearchResultsToAdd_{$this->sInputid}">
-        <div style="background: #fff; border:0; text-align:center; vertical-align:middle;"><p>{$sEmptyList}</p></div>
+        <div style="border:0; text-align:center; vertical-align:middle;"><p>{$sEmptyList}</p></div>
     </div>
     <input type="hidden" id="count_{$this->sInputid}" value="0"/>
 </form>

--- a/application/ui.searchformforeignkeys.class.inc.php
+++ b/application/ui.searchformforeignkeys.class.inc.php
@@ -68,7 +68,7 @@ class UISearchFormForeignKeys
 			<<<HTML
 <form id="ObjectsAddForm_{$this->m_iInputId}">
     <div id="SearchResultsToAdd_{$this->m_iInputId}" style="vertical-align:top;height:100%;overflow:auto;padding:0;border:0;">
-        <div style="background: #fff; border:0; text-align:center; vertical-align:middle;"><p>{$sEmptyList}</p></div>
+        <div style="border:0; text-align:center; vertical-align:middle;"><p>{$sEmptyList}</p></div>
     </div>
     <input type="hidden" id="count_{$this->m_iInputId}" value="0"/>
 </form>

--- a/templates/application/links/direct/block-direct-linkset-edit-table/layout.js.twig
+++ b/templates/application/links/direct/block-direct-linkset-edit-table/layout.js.twig
@@ -7,6 +7,6 @@ oWidget{{ oUIBlock.oUILinksDirectWidget.GetInputId() }} = $('#{{ oUIBlock.oUILin
     input_name: '{{ oUIBlock.sInputName }}',
     submit_to: '{{ oUIBlock.sSubmitUrl }}',
     oWizardHelper: {{ oUIBlock.sWizHelper }},
-    do_search: '{{ oUIBlock.sJSDoSearch }}'
+    do_search: {{ oUIBlock.sJSDoSearch }}
 });
 {% endapply %}


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | [N°9043](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=9043) && [N°9483](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=9483)
| Type of change?                                               | Bug fix


## Symptom

The `search_manual_submit` and `high_cardinality_classes` settings are not taken into account when selecting objects.
If `search_manual_submit` is set to `true` in the general configuration, or if the class being searched for is in the `high_cardinality_classes` array, then the search must not start automatically

## Reproduction procedure

1. On an iTop Community 3.2.2-1 with PHP 8.3
2. Set the "search_manual_submit" parameter to true in the general configuration
3. Go to an user request page
4. Switch to edit mode
5. Child Requests > Add
6. Note that the search is still launched automatically


## Cause

The JS parameter `do_search`, which indicates whether or not a search should be initiated, is not treated as a boolean as expected, but as a string; therefore, the condition `if (me.options.do_search)` in the script always returns true

## Proposed solution

Remove the quotation marks around the initialisation of the `do_search` parameter so as not to change its type to a string


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?