### PR TITLE
 N°9468 - Fix double scroll down bars in input set

### DIFF
--- a/css/backoffice/components/input/_input-select.scss
+++ b/css/backoffice/components/input/_input-select.scss
@@ -201,8 +201,9 @@ $ibo-input-select--autocomplete-item-image--border: 1px solid $ibo-color-grey-60
 }
 
 // N°7982 Default selectize stylesheet override
+// N°9468 Dropdown content needs to be a few pixel shorter than the dropdown itself to avoid double scrollbar
 .selectize-dropdown-content{
-  max-height: $ibo-input-select-selectize--dropdown--max-height;
+  max-height: calc(#{$ibo-input-select-selectize--dropdown--max-height} - 4px);
 }
 
 .selectize-dropdown.ui-menu .ui-state-active {

--- a/js/extkeywidget.js
+++ b/js/extkeywidget.js
@@ -171,7 +171,7 @@ function ExtKeyWidget(id, sTargetClass, sFilter, sTitle, bSelectMode, oWizHelper
 			// To avoid dropdown to be cut by the container's overflow hidden rule
 			dropdownParent: 'body',
 			onDropdownOpen: function (oDropdownElem) {
-				me.UpdateDropdownPosition(this.$control, oDropdownElem);
+				me.UpdateDropdownPosition(this.$control, oDropdownElem, this.$dropdown_content);
 			},
 		});
 		let $selectize = $select[0].selectize; // This stores the selectize object to a variable (with name 'selectize')
@@ -320,7 +320,7 @@ function ExtKeyWidget(id, sTargetClass, sFilter, sTitle, bSelectMode, oWizHelper
 	 * @param {object} oDropdownElem jQuery object representing the results dropdown
 	 * @return {void}
 	 */
-	this.UpdateDropdownPosition = function (oControlElem, oDropdownElem) {
+	this.UpdateDropdownPosition = function (oControlElem, oDropdownElem, oDropdownContentElem) {
 		// First fix width to ensure it's not too long
 		const fControlWidth = oControlElem.outerWidth();
 		oDropdownElem.css('width', fControlWidth);
@@ -340,6 +340,11 @@ function ExtKeyWidget(id, sTargetClass, sFilter, sTitle, bSelectMode, oWizHelper
 			// Set dropdown max-height to 1/3 of the screen, this way we are sure the dropdown will fit in either the top / bottom half of the screen
 			oDropdownElem.css('max-height', '30vh');
 			fDropdownHeight = oDropdownElem.outerHeight();
+
+            // N°9468 Dropdown content needs to be a few pixel shorter than the dropdown itself to avoid double scrollbar
+            if(oDropdownContentElem) {
+                oDropdownContentElem.css('max-height', 'calc(30vh - 4px)');
+            }
 
 			// Position dropdown above input if not enough space on the bottom part of the screen
 			if ((fDropdownTopY / fWindowHeight) > 0.6) {

--- a/js/extkeywidget.js
+++ b/js/extkeywidget.js
@@ -120,6 +120,7 @@ function ExtKeyWidget(id, sTargetClass, sFilter, sTitle, bSelectMode, oWizHelper
 	this.sFormAttCode = sFormAttCode;
 
 	var me = this;
+    const iDropdownContentHeightDifference = 4;
 
 	this.Init = function () {
 		// make sure that the form is clean
@@ -353,13 +354,13 @@ function ExtKeyWidget(id, sTargetClass, sFilter, sTitle, bSelectMode, oWizHelper
 
             // N°9468 Dropdown content needs to be a few pixel shorter than the dropdown itself to avoid double scrollbar
             if(oDropdownContentElem) {
-                oDropdownContentElem.css('max-height', 'calc(30vh - 4px)');
+                oDropdownContentElem.css('max-height', `calc(30vh - ${iDropdownContentHeightDifference}px)`);
             }
 
 			/* Position dropdown above input if not enough space on the bottom part of the screen
                Doesn't seem to work with selectize as an internal plugin "auto_position" refreshes the top position after
                this method is called, input set use a custom plugin to avoid fix this issue "plugin_combodo_auto_position"
-               This would need to take the potential 4px difference into account if this is fixed.
+               This would need to take the potential 4px difference (iDropdownContentHeightDifference) into account if this is fixed.
 			 */
 			if ((fDropdownTopY / fWindowHeight) > 0.6) {
                 oDropdownElem.css({

--- a/js/extkeywidget.js
+++ b/js/extkeywidget.js
@@ -314,12 +314,13 @@ function ExtKeyWidget(id, sTargetClass, sFilter, sTitle, bSelectMode, oWizHelper
 	};
 
 	/**
-	 * Update the dropdown's position so it always fits in the screen
-	 *
-	 * @param {object} oControlElem jQuery object representing the "control" input (= where the user types) of the external key
-	 * @param {object} oDropdownElem jQuery object representing the results dropdown
-	 * @return {void}
-	 */
+     * Update the dropdown's position so it always fits in the screen
+     *
+     * @param {object} oControlElem jQuery object representing the "control" input (= where the user types) of the external key
+     * @param {object} oDropdownElem jQuery object representing the results dropdown
+     * @param {object|undefined} oDropdownContentElem
+     * @return {void}
+     */
 	this.UpdateDropdownPosition = function (oControlElem, oDropdownElem, oDropdownContentElem) {
 		// First fix width to ensure it's not too long
 		const fControlWidth = oControlElem.outerWidth();
@@ -327,6 +328,13 @@ function ExtKeyWidget(id, sTargetClass, sFilter, sTitle, bSelectMode, oWizHelper
 
 		// Then, fix height / position to ensure it's within the viewport
 		const fWindowHeight = window.innerHeight;
+
+        // Clear previously set rule so the comparison is done with dropdown real height
+        oDropdownElem.css('max-height', '');
+
+        if(oDropdownContentElem) {
+            oDropdownContentElem.css('max-height', '');
+        }
 
 		const fControlTopY = oControlElem.offset().top;
 		const fControlHeight = oControlElem.outerHeight();
@@ -338,7 +346,9 @@ function ExtKeyWidget(id, sTargetClass, sFilter, sTitle, bSelectMode, oWizHelper
 
 		if (fDropdownBottomY > fWindowHeight) {
 			// Set dropdown max-height to 1/3 of the screen, this way we are sure the dropdown will fit in either the top / bottom half of the screen
-			oDropdownElem.css('max-height', '30vh');
+			oDropdownElem.css({
+                maxHeight: '30vh',
+            });
 			fDropdownHeight = oDropdownElem.outerHeight();
 
             // N°9468 Dropdown content needs to be a few pixel shorter than the dropdown itself to avoid double scrollbar
@@ -346,11 +356,28 @@ function ExtKeyWidget(id, sTargetClass, sFilter, sTitle, bSelectMode, oWizHelper
                 oDropdownContentElem.css('max-height', 'calc(30vh - 4px)');
             }
 
-			// Position dropdown above input if not enough space on the bottom part of the screen
+			/* Position dropdown above input if not enough space on the bottom part of the screen
+               Doesn't seem to work with selectize as an internal plugin "auto_position" refreshes the top position after
+               this method is called, input set use a custom plugin to avoid fix this issue "plugin_combodo_auto_position"
+               This would need to take the potential 4px difference into account if this is fixed.
+			 */
 			if ((fDropdownTopY / fWindowHeight) > 0.6) {
-				oDropdownElem.css('top', fDropdownTopY - fDropdownHeight - fControlHeight);
-			}
+                oDropdownElem.css({
+                    top: fDropdownTopY - fDropdownHeight - fControlHeight,
+                    borderTop: oDropdownElem.css('border-bottom')
+                });
+            }
+            else {
+                oDropdownElem.css({
+                    borderTop: 'none'
+                })
+            }
 		}
+        else {
+            oDropdownElem.css({
+                borderTop: 'none'
+            })
+        }
 	};
 	this.ManageScroll = function () {
 		if ($('#label_'+me.id).scrollParent()[0].tagName != 'HTML') {

--- a/js/selectize/plugin_combodo_auto_position.js
+++ b/js/selectize/plugin_combodo_auto_position.js
@@ -33,15 +33,31 @@ Selectize.define("combodo_auto_position", function (aOptions) {
 	// Override position dropdown function
 	oSelf.positionDropdown = (function () {
 		return function () {
-			let iRefHeight = oSelf.$dropdown.outerHeight();
-			if(oSelf.$control.offset().top + oSelf.$control.outerHeight() + iRefHeight > window.innerHeight){
+            // Clear previously set rules so the comparison is done with dropdown real height
+            oSelf.$dropdown.css({
+                'max-height': '',
+            });
 
-				oSelf.$dropdown.css({
-					top: oSelf.$control.offset().top - iRefHeight,
-					left: oSelf.$control.offset().left,
+            oSelf.$dropdown_content.css({
+                'max-height': '',
+            });
+
+            let iDropdownHeight = oSelf.$dropdown.outerHeight();
+			if(oSelf.$control.offset().top + oSelf.$control.outerHeight() + iDropdownHeight > window.innerHeight){
+
+                // Apply max-height as we are overflowing, that'll allow us to calculate where we should place ourselves later
+                oSelf.$dropdown.css({
+                    maxHeight: `${aOptions.maxDropDownHeight}`,
+                })
+
+                iDropdownHeight = oSelf.$dropdown.outerHeight();
+
+                oSelf.$dropdown.css({
+                    top: oSelf.$control.offset().top - iDropdownHeight + 4, // Content will be shorter, so our real height too
+                    left: oSelf.$control.offset().left,
 					width: oSelf.$wrapper.outerWidth(),
-					'max-height': `${aOptions.maxDropDownHeight}`,
-					'overflow-y': 'auto',
+					overflowY: 'auto',
+                    borderTop : oSelf.$dropdown.css('border-bottom')
 				});
 
                 // N°9468 Dropdown content needs to be a few pixel shorter than the dropdown itself to avoid double scrollbar
@@ -55,8 +71,9 @@ Selectize.define("combodo_auto_position", function (aOptions) {
 					top: oSelf.$control.offset().top + oSelf.$control.outerHeight(),
 					left: oSelf.$control.offset().left,
 					width: oSelf.$wrapper.outerWidth(),
-					'overflow-y': 'auto'
-				});
+					overflowY: 'auto',
+                    borderTop: 'none'
+            });
 			}
 		};
 	}());

--- a/js/selectize/plugin_combodo_auto_position.js
+++ b/js/selectize/plugin_combodo_auto_position.js
@@ -22,7 +22,7 @@ Selectize.define("combodo_auto_position", function (aOptions) {
 
 	// Plugin options
 	aOptions = $.extend({
-			maxDropDownHeight: 200,
+			maxDropDownHeight: '200px',
 		},
 		aOptions
 	);
@@ -33,26 +33,28 @@ Selectize.define("combodo_auto_position", function (aOptions) {
 	// Override position dropdown function
 	oSelf.positionDropdown = (function () {
 		return function () {
-			let iRefHeight = oSelf.$dropdown.outerHeight() < aOptions.maxDropDownHeight ?
-				oSelf.$dropdown.outerHeight() : aOptions.maxDropDownHeight;
-
+			let iRefHeight = oSelf.$dropdown.outerHeight();
 			if(oSelf.$control.offset().top + oSelf.$control.outerHeight() + iRefHeight > window.innerHeight){
 
 				oSelf.$dropdown.css({
 					top: oSelf.$control.offset().top - iRefHeight,
 					left: oSelf.$control.offset().left,
 					width: oSelf.$wrapper.outerWidth(),
-					'max-height': `${aOptions.maxDropDownHeight}px`,
+					'max-height': `${aOptions.maxDropDownHeight}`,
 					'overflow-y': 'auto',
-					'border-top': '1px solid #d0d0d0',
 				});
+
+                // N°9468 Dropdown content needs to be a few pixel shorter than the dropdown itself to avoid double scrollbar
+                oSelf.$dropdown_content.css({
+                    'max-height': `calc(${aOptions.maxDropDownHeight} - 4px)`
+                });
+
 			}
 			else{
 				oSelf.$dropdown.css({
 					top: oSelf.$control.offset().top + oSelf.$control.outerHeight(),
 					left: oSelf.$control.offset().left,
 					width: oSelf.$wrapper.outerWidth(),
-					'max-height': `${aOptions.maxDropDownHeight}px`,
 					'overflow-y': 'auto'
 				});
 			}

--- a/js/selectize/plugin_combodo_auto_position.js
+++ b/js/selectize/plugin_combodo_auto_position.js
@@ -19,6 +19,7 @@ Selectize.define("combodo_auto_position", function (aOptions) {
 
 	// Selectize instance
 	let oSelf = this;
+    const iDropdownContentHeightDifference = 4;
 
 	// Plugin options
 	aOptions = $.extend({
@@ -53,7 +54,7 @@ Selectize.define("combodo_auto_position", function (aOptions) {
                 iDropdownHeight = oSelf.$dropdown.outerHeight();
 
                 oSelf.$dropdown.css({
-                    top: oSelf.$control.offset().top - iDropdownHeight + 4, // Content will be shorter, so our real height too
+                    top: oSelf.$control.offset().top - iDropdownHeight + iDropdownContentHeightDifference, // Content will be shorter, so our real height too
                     left: oSelf.$control.offset().left,
 					width: oSelf.$wrapper.outerWidth(),
 					overflowY: 'auto',
@@ -62,7 +63,7 @@ Selectize.define("combodo_auto_position", function (aOptions) {
 
                 // N°9468 Dropdown content needs to be a few pixel shorter than the dropdown itself to avoid double scrollbar
                 oSelf.$dropdown_content.css({
-                    'max-height': `calc(${aOptions.maxDropDownHeight} - 4px)`
+                    'max-height': `calc(${aOptions.maxDropDownHeight} - ${iDropdownContentHeightDifference}px)`
                 });
 
 			}

--- a/templates/base/components/input/set/layout.ready.js.twig
+++ b/templates/base/components/input/set/layout.ready.js.twig
@@ -23,7 +23,7 @@ let oWidget{{ oUIBlock.GetId() }} = $('#{{ oUIBlock.GetId() }}').selectize({
         },
         {# PLUGIN combodo auto position  #}
         'combodo_auto_position' : {
-            maxDropDownHeight: 300, {# in px #}
+            maxDropDownHeight: '30vh', {# same value as external key widget #}
         },
         {# PLUGIN combodo add button #}
         {% if oUIBlock.HasAddOptionButton() %}


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N°9468
| Type of change?                                               | Bug fix 


## Symptom (bug) / Objective (enhancement)
When opening an input set since the commit of 5df936c, input set were displaying double scrollbars in their dropdown


## Reproduction procedure (bug)
<!--
Remove this section only if it's NOT a bug.

Otherwise, explain step by step how to reproduce the issue on a standard iTop Community.

If it requires a custom datamodel, provide the minimal XML delta to reproduce it on a standard iTop Community.
-->

1. On an support/3.2 iTop
2. Using Chrome
3. With a user account with Administrator profiles
4. Create an "iTop user"
5. Open the profile selection list
6. Observe the double scrolling


## Cause (bug)
2 causes:
* Dropdown content needs to be slighly shorter that the dropdown itself to avoid displaying an almost full secondary scrollbar
* Some specific code for input set was setting the max height of the dropdown to an hardcoded 300px, which made it harder for the 5df936c fix to be consistent across all selectizes


## Proposed solution (bug and enhancement)
* Make sure the CSS max height set to dropdown and dropdown content is consistent (in SCSS or in JS)
* Remove unnecessary max height when the dropdown didn't need a resize


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand digging in the code?
