### PR TITLE
feat(PowerConnection): Add dashboard to list all connected devices

### DIFF
--- a/datamodels/2.x/itop-datacenter-mgmt/datamodel.itop-datacenter-mgmt.xml
+++ b/datamodels/2.x/itop-datacenter-mgmt/datamodel.itop-datacenter-mgmt.xml
@@ -495,7 +495,49 @@
           </attributes>
         </reconciliation>
       </properties>
-      <fields/>
+      <fields>
+        <field id="powered_devices" xsi:type="AttributeDashboard">
+          <is_user_editable>false</is_user_editable>
+          <definition>
+            <title>Class:PowerConnection/Attribute:powered_devices+</title>
+            <layout>DashboardLayoutOneCol</layout>
+            <cells>
+              <cell id="pdu">
+                <rank>10</rank>
+                <dashlets>
+                  <dashlet id="pdu_header" xsi:type="DashletHeaderStatic">
+                    <rank>10</rank>
+                    <title>Class:PDU</title>
+                    <icon>../images/icons/icons8-plug-socket.svg</icon>
+                  </dashlet>
+                  <dashlet id="pdu_list" xsi:type="DashletObjectList">
+                    <rank>20</rank>
+                    <title>Class:PowerConnection/Attribute:pdus_list+</title>
+                    <query>SELECT PDU WHERE powerstart_id = :this-&gt;id</query>
+                    <menu>false</menu>
+                  </dashlet>
+                </dashlets>
+              </cell>
+              <cell id="datacenterdevice">
+                <rank>20</rank>
+                <dashlets>
+                  <dashlet id="datacenterdevice_header" xsi:type="DashletHeaderStatic">
+                    <rank>0</rank>
+                    <title>Class:DatacenterDevice</title>
+                    <icon>../images/icons/icons8-server.svg</icon>
+                  </dashlet>
+                  <dashlet id="datacenterdevice_list" xsi:type="DashletObjectList">
+                    <rank>1</rank>
+                    <title>Class:PowerConnection/Attribute:datacenterdevices_list+</title>
+                    <query>SELECT DatacenterDevice WHERE powerA_id = :this->id OR powerB_id = :this->id</query>
+                    <menu>false</menu>
+                  </dashlet>
+                </dashlets>
+              </cell>
+            </cells>
+          </definition>
+        </field>0
+      </fields>
       <methods/>
       <presentation>
         <details>
@@ -568,6 +610,9 @@
                   </items>
                 </item>
               </items>
+            </item>
+            <item id="powered_devices">
+              <rank>100</rank>
             </item>
             <item id="contacts_list">
               <rank>140</rank>
@@ -772,8 +817,8 @@
                 </item>
               </items>
             </item>
-            <item id="pdus_list">
-              <rank>140</rank>
+            <item id="powered_devices">
+              <rank>100</rank>
             </item>
             <item id="contacts_list">
               <rank>150</rank>
@@ -1000,6 +1045,9 @@
                   </items>
                 </item>
               </items>
+            </item>
+            <item id="powered_devices">
+              <rank>100</rank>
             </item>
             <item id="contacts_list">
               <rank>160</rank>

--- a/datamodels/2.x/itop-datacenter-mgmt/dictionaries/en.dict.itop-datacenter-mgmt.php
+++ b/datamodels/2.x/itop-datacenter-mgmt/dictionaries/en.dict.itop-datacenter-mgmt.php
@@ -3,7 +3,7 @@
 /**
  * Localized data
  *
- * @copyright Copyright (C) 2010-2024 Combodo SAS
+ * @copyright Copyright (C) 2010-2026 Combodo SAS
  * @license	http://opensource.org/licenses/AGPL-3.0
  *
  * This file is part of iTop.
@@ -22,6 +22,13 @@
  * along with iTop. If not, see <http://www.gnu.org/licenses/>
  */
 
+//
+// Class: PowerConnection
+//
+
 Dict::Add('EN US', 'English', 'English', [
-	// Dictionary entries go here
+	'Class:PowerConnection/Attribute:datacenterdevices_list+' => 'All the datacenter devices using this power connection',
+	'Class:PowerConnection/Attribute:pdus_list+' => 'All the PDUs using this power connection',
+	'Class:PowerConnection/Attribute:powered_devices' => 'Powered Devices',
+	'Class:PowerConnection/Attribute:powered_devices+' => '',
 ]);


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | #891
| Type of change?                                               | Enhancement

## Objective

To be able to see all directly connected devices on the power connection. Currently, only the list of PDUs is presented.

## Proposed solution

Replace the PDU list tab with a dashboard that has a list for both PDUs and connected datacenter devices.

A unit test doesn't seem relevant as it's only a datamodel change.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?
