### PR TITLE
N°8638 - Adapt mysqldump calls to follow iTop SSL configuration

### DIFF
--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -1592,6 +1592,8 @@ class CMDBSource
 		if (static::GetDBVendor() === static::ENUM_DB_VENDOR_MYSQL) {
 			//Mysql 5.7.0 and upper deprecated --ssl and uses --ssl-mode instead
 			return version_compare(static::GetDBVersion(), '5.7.11', '>=');
+		} elseif (static::GetDBVendor() === static::ENUM_DB_VENDOR_MARIADB) {
+			return version_compare(static::GetDBVersion(), '10.2.6', '>=');
 		}
 		return false;
 	}

--- a/setup/backup.class.inc.php
+++ b/setup/backup.class.inc.php
@@ -511,7 +511,7 @@ EOF;
 	{
 		$bDbTlsEnabled = $oConfig->Get('db_tls.enabled');
 		if (!$bDbTlsEnabled) {
-			return '';
+			return CMDBSource::IsSslModeDBVersion() ? '  --skip-ssl' : '';
 		}
 		$sTlsOptions = '';
 		// Mysql 5.7.11 and upper deprecated --ssl and uses --ssl-mode instead


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? |  https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=8638#ObjectProperties=tab_UIPropertiesTab
| Type of change?                                               | Enhancement


## Symptom (bug) / Objective (enhancement)
see related ticket
