### PR TITLE
N°3472 - Refactor LDAP debug level handling to ensure proper logging during connection attempts

### DIFF
--- a/datamodels/2.x/authent-ldap/datamodel.authent-ldap.xml
+++ b/datamodels/2.x/authent-ldap/datamodel.authent-ldap.xml
@@ -97,17 +97,18 @@
 			$bDebug = isset($aServerParams['debug']) ? $aServerParams['debug'] : false;
 		}
 
+		if (array_key_exists(LDAP_OPT_DEBUG_LEVEL, $aOptions))
+		{
+			// Set debug level before trying to connect, so that debug info appear in the PHP error log if ldap_connect goes wrong
+			$bRet = ldap_set_option(null, LDAP_OPT_DEBUG_LEVEL, $aOptions[LDAP_OPT_DEBUG_LEVEL]);
+			$this->LogInfo($bDebug, "ldap_set_option('LDAP_OPT_DEBUG_LEVEL', '{$aOptions[LDAP_OPT_DEBUG_LEVEL]}') returned ".($bRet ? 'true' : 'false'));
+		}
+
 		$hDS = @ldap_connect($sURI);
 		if ($hDS === false)
 		{
 			$this->LogIssue($bDebug, "ldap_authentication: can not connect to the LDAP server '$sURI'. Check the configuration file config-itop.php.");
 			return false;
-		}
-		if (array_key_exists(LDAP_OPT_DEBUG_LEVEL, $aOptions))
-		{
-			// Set debug level before trying to connect, so that debug info appear in the PHP error log if ldap_connect goes wrong
-			$bRet = ldap_set_option($hDS, LDAP_OPT_DEBUG_LEVEL, $aOptions[LDAP_OPT_DEBUG_LEVEL]);
-			$this->LogInfo($bDebug, "ldap_set_option('LDAP_OPT_DEBUG_LEVEL', '{$aOptions[LDAP_OPT_DEBUG_LEVEL]}') returned ".($bRet ? 'true' : 'false'));
 		}
 		foreach($aOptions as $name => $value)
 		{


### PR DESCRIPTION
## Base information

| Question                                                       | Answer 
|----------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | [N°3472](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=3472)                |
| Type of change?                                                | Enhancement

##  Objective

Be able to debug the LDAP connection in the logs

## Proposed solution

Move the `ldap_set_option(null, LDAP_OPT_DEBUG_LEVEL, $aOptions[LDAP_OPT_DEBUG_LEVEL]);` line before the `ldap_connect`

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?