### PR TITLE
N°9549 - Fix emails with mime type different than text/plain or text/…

### DIFF
--- a/sources/Core/Email/EmailSymfony.php
+++ b/sources/Core/Email/EmailSymfony.php
@@ -389,6 +389,26 @@ class EMailSymfony extends Email
 	 */
 	public function SetBody($sBody, $sMimeType = 'text/html', $sCustomStyles = null)
 	{
+		// Some mime types can have options, let's retrieve the different parts so we can extract the primary mime type
+		$aMimeTypeParts = array_map('trim', explode(';', $sMimeType));
+		$sPrimaryMimeType = strtolower(array_shift($aMimeTypeParts));
+
+		$aMimeTypeParams = [];
+		foreach ($aMimeTypeParts as $sPart) {
+			// Parse key=value parameters (eg method=REQUEST, charset=UTF-8) after the semicolon.
+			// Stored in $aMimeTypeParams so they can be added to the Content-Type header.
+			if ($sPart === '') {
+				continue;
+			}
+			$aPair = explode('=', $sPart, 2);
+			$sKey = strtolower(trim($aPair[0]));
+			// Normalize and unquote the parameter value for Content-Type (eg charset=UTF-8).
+			$sValue = isset($aPair[1]) ? trim($aPair[1], " \t\n\r\0\x0B\"") : '';
+			if ($sKey !== '') {
+				$aMimeTypeParams[$sKey] = $sValue;
+			}
+		}
+
 		// Inline CSS if needed
 		if ($sMimeType === 'text/html') {
 			$sBody = static::InlineCssIntoBodyContent($sBody, $sCustomStyles);
@@ -411,8 +431,20 @@ class EMailSymfony extends Email
 				$oRootPart = new RelatedPart(...$aRelatedParts);
 			}
 		} else {
-			// Default root part is the text body
-			$oRootPart = $oTextPart;
+			// Default root part is a TextPart with the right mimetype
+			$sSubtype = 'plain';
+			// Extract subtype for text/* content; default to plain otherwise.
+			if (strpos($sPrimaryMimeType, '/') !== false) {
+				list($sType, $sSubtype) = explode('/', $sPrimaryMimeType, 2);
+				if ($sType !== 'text') {
+					$sSubtype = 'plain';
+				}
+			}
+			$oRootPart = new TextPart($sBody, 'utf-8', $sSubtype, 'base64');
+			// Add parsed Content-Type parameters like method/charset if provided.
+			if (!empty($aMimeTypeParams)) {
+				$oRootPart->getHeaders()->addParameterizedHeader('Content-Type', $sPrimaryMimeType, $aMimeTypeParams);
+			}
 		}
 
 		$this->m_oMessage->setBody($oRootPart);
@@ -432,9 +464,13 @@ class EMailSymfony extends Email
 
 	/**
 	 * Add a new part to the existing body
+	 *
+	 * @deprecated 3.2.3 3.3.0 N°9549 This worked with the previous mail lib (Laminas) but it no longer works with SymfonyMailer and needs to be split in specific methods
 	 */
 	public function AddPart($sText, $sMimeType = 'text/html')
 	{
+		\DeprecatedCallsLog::NotifyDeprecatedPhpMethod('No generic alternative yet, if you want to add an attachment use `self::AddAttachment()`');
+
 		$sMimeSubtype = $this->GetMimeSubtype($sMimeType);
 
 		if (!array_key_exists('parts', $this->m_aData)) {

--- a/sources/Core/Email/EmailSymfony.php
+++ b/sources/Core/Email/EmailSymfony.php
@@ -410,7 +410,7 @@ class EMailSymfony extends Email
 		}
 
 		// Inline CSS if needed
-		if ($sMimeType === 'text/html') {
+		if ($sPrimaryMimeType === 'text/html') {
 			$sBody = static::InlineCssIntoBodyContent($sBody, $sCustomStyles);
 		}
 
@@ -419,7 +419,7 @@ class EMailSymfony extends Email
 		$oTextPart = new TextPart(strip_tags($sBody), 'utf-8', 'plain', 'base64');
 
 		// Embed inline images and store them in attachments (so BuildSymfonyMessageFromInternal can pick them)
-		if ($sMimeType === 'text/html') {
+		if ($sPrimaryMimeType === 'text/html') {
 			$aAdditionalParts = $this->EmbedInlineImages($sBody);
 			$oHtmlPart = new TextPart($sBody, 'utf-8', 'html', 'base64');
 			$oAlternativePart = new AlternativePart($oHtmlPart, $oTextPart);


### PR DESCRIPTION
## Base information

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | N°9549                 |
| Type of change?                                                                 | Bug fix |

### Symptom (bug)

When receiving an email with a calendar invitation, the user is unable to accept or decline the invitation.
All that is displayed is the source code of the invitation in the email body.

Example:
<img width="1470" height="726" alt="image" src="https://github.com/user-attachments/assets/d6ccc4b7-d1c9-4a82-b9b4-2a1736bff5ea" />


### Reproduction procedure (bug only)

1. *On iTop Community 3.2.3-dev with PHP 8.3*
2. *With the Calendar Invitations extension in its latest version*
3. *With an administrator user*
4. *Configure a "calendar invitation" notification, for example:*
   1. *Create a trigger on public log update of a User Request*
   2. *Associate an action of type "calendar invitation" with the following information:*
      1. *Start date: creation date*
      2. *End date: last update*
5. *Trigger the notification*
6. *In an email client (not Mailpit), open the email*
7. *Observe that the invitation cannot be accepted or declined*

### Cause (bug only)

Hypothesis:

- The issue may stem from the library change for sending emails in iTop 3.2.3: Laminas → SymfonyMailer
- The extension adds the invitation by replacing the entire mail body rather than adding it as a dedicated "part", which may be unsupported behavior in the new library.