### PR TITLE
N°9574 - fix(email): Prevent CSS leaking into plain-text emails

### DIFF
--- a/sources/Core/Email/EmailSymfony.php
+++ b/sources/Core/Email/EmailSymfony.php
@@ -30,6 +30,7 @@ use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mime\Email as SymfonyEmail;
+use Symfony\Component\Mime\HtmlToTextConverter\DefaultHtmlToTextConverter;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\Multipart\RelatedPart;
 use Symfony\Component\Mime\Part\Multipart\MixedPart;
@@ -416,13 +417,12 @@ class EMailSymfony extends Email
 
 		$this->m_aData['body'] = ['body' => $sBody, 'mimeType' => $sMimeType];
 
-		$oTextPart = new TextPart(strip_tags($sBody), 'utf-8', 'plain', 'base64');
-
 		// Embed inline images and store them in attachments (so BuildSymfonyMessageFromInternal can pick them)
 		if ($sPrimaryMimeType === 'text/html') {
 			$aAdditionalParts = $this->EmbedInlineImages($sBody);
+			$oTextPart = new TextPart((new DefaultHtmlToTextConverter())->convert($sBody, 'utf-8'), 'utf-8', 'plain', 'base64');
 			$oHtmlPart = new TextPart($sBody, 'utf-8', 'html', 'base64');
-			$oAlternativePart = new AlternativePart($oHtmlPart, $oTextPart);
+			$oAlternativePart = new AlternativePart($oTextPart, $oHtmlPart);
 			// Default root part is the HTML body
 			$oRootPart = $oAlternativePart;
 

--- a/sources/Core/Email/EmailSymfony.php
+++ b/sources/Core/Email/EmailSymfony.php
@@ -422,6 +422,7 @@ class EMailSymfony extends Email
 			$aAdditionalParts = $this->EmbedInlineImages($sBody);
 			$oTextPart = new TextPart((new DefaultHtmlToTextConverter())->convert($sBody, 'utf-8'), 'utf-8', 'plain', 'base64');
 			$oHtmlPart = new TextPart($sBody, 'utf-8', 'html', 'base64');
+			// It's important de order parts from least prefered to most prefered as per RFC 2046 {@see https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.4}
 			$oAlternativePart = new AlternativePart($oTextPart, $oHtmlPart);
 			// Default root part is the HTML body
 			$oRootPart = $oAlternativePart;

--- a/tests/php-unit-tests/unitary-tests/sources/core/Email/EmailSymfonyTest.php
+++ b/tests/php-unit-tests/unitary-tests/sources/core/Email/EmailSymfonyTest.php
@@ -1,6 +1,11 @@
 <?php
 
+use Combodo\iTop\Core\Email\EMailSymfony;
 use Combodo\iTop\Test\UnitTest\ItopTestCase;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Component\Mime\Part\Multipart\AlternativePart;
+use Symfony\Component\Mime\Part\Multipart\RelatedPart;
+use Symfony\Component\Mime\Part\TextPart;
 
 class EmailSymfonyTest extends ItopTestCase
 {
@@ -134,5 +139,159 @@ HTML;
 		$sActualBody = $this->InvokeNonPublicStaticMethod(EMailSymfony::class, 'InlineCssIntoBodyContent', [$sInputBody, $sInputCss]);
 
 		$this->assertSame($sExpectedBody, $sActualBody);
+	}
+
+	/**
+	 * Returns the parts of the AlternativePart produced by SetBody() for an HTML email.
+	 *
+	 * Handles both the simple case (AlternativePart at root) and the inline-images case
+	 * where the root is a RelatedPart whose first child is the AlternativePart.
+	 *
+	 * @return AbstractPart[]
+	 */
+	private function GetAlternativePartsFromHtmlEmail(EMailSymfony $oEmail): array
+	{
+		$oSymfonyMessage = $this->GetNonPublicProperty($oEmail, 'm_oMessage');
+		$oBody = $oSymfonyMessage->getBody();
+
+		// With inline images the root is a RelatedPart; the AlternativePart is its first child.
+		if ($oBody instanceof RelatedPart) {
+			$oBody = $oBody->getParts()[0];
+		}
+
+		$this->assertInstanceOf(AlternativePart::class, $oBody, 'Body should be a multipart/alternative for HTML emails');
+
+		return $oBody->getParts();
+	}
+
+	/**
+	 * RFC 2046 §5.1.4: parts in multipart/alternative must be ordered from least to most preferred.
+	 * Email clients display the last part they support, so text/plain must come first and text/html last.
+	 *
+	 * @see https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.4
+	 * @since N°9574
+	 */
+	public function testSetBodyAlternativePartOrderForHtmlEmailIsPlainThenHtml(): void
+	{
+		$oEmail = new EMailSymfony();
+		$oEmail->SetBody('<p>Hello there!</p>', 'text/html');
+
+		[$oFirstPart, $oSecondPart] = $this->GetAlternativePartsFromHtmlEmail($oEmail);
+
+		$this->assertSame('plain', $oFirstPart->getMediaSubtype(), 'First part must be text/plain (least preferred per RFC 2046)');
+		$this->assertSame('html', $oSecondPart->getMediaSubtype(), 'Last part must be text/html (most preferred per RFC 2046)');
+	}
+
+	/**
+	 * @dataProvider provideSetBodyPlainTextDoesNotContainCss
+	 *
+	 * @since N°9574
+	 */
+	public function testSetBodyPlainTextDoesNotContainCss(string $sHtml, ?string $sCustomStyles): void
+	{
+		$oEmail = new EMailSymfony();
+		$oEmail->SetBody($sHtml, 'text/html', $sCustomStyles);
+
+		// We locate the plain text part by subtype to be order-agnostic and isolate this assertion from the order bug.
+		$aParts = $this->GetAlternativePartsFromHtmlEmail($oEmail);
+		$oPlainPart = null;
+		foreach ($aParts as $oPart) {
+			if ($oPart instanceof TextPart && $oPart->getMediaSubtype() === 'plain') {
+				$oPlainPart = $oPart;
+				break;
+			}
+		}
+		$this->assertNotNull($oPlainPart, 'No text/plain part found in the message');
+
+		$sPlainText = $oPlainPart->getBody();
+
+		$this->assertStringNotContainsString('<style>', $sPlainText, 'Style tag must not appear in plain text');
+		$this->assertStringNotContainsString('color:', $sPlainText, 'CSS color rule must not appear in plain text');
+		$this->assertStringNotContainsString('font-size:', $sPlainText, 'CSS font-size rule must not appear in plain text');
+		$this->assertStringNotContainsString('@media', $sPlainText, 'CSS @media rule must not appear in plain text');
+		$this->assertStringContainsString('Hello there!', $sPlainText, 'Actual content must be preserved in plain text');
+	}
+
+	/**
+	 * The HTML part must contain the body content and the CSS inlined by Emogrifier.
+	 * This guards against regressions where the wrong body (e.g. the plain-text version)
+	 * would end up in the HTML part.
+	 *
+	 * @since N°9574
+	 */
+	public function testSetBodyHtmlPartContainsBodyAndInlinedCss(): void
+	{
+		$oEmail = new EMailSymfony();
+		$oEmail->SetBody('<html><body><p>Hello there!</p></body></html>', 'text/html', 'p { color: red; }');
+
+		$aParts = $this->GetAlternativePartsFromHtmlEmail($oEmail);
+
+		$oHtmlPart = null;
+		foreach ($aParts as $oPart) {
+			if ($oPart instanceof TextPart && $oPart->getMediaSubtype() === 'html') {
+				$oHtmlPart = $oPart;
+				break;
+			}
+		}
+		$this->assertNotNull($oHtmlPart, 'No text/html part found in the message');
+
+		$sHtmlContent = $oHtmlPart->getBody();
+		$this->assertStringContainsString('Hello there!', $sHtmlContent, 'HTML part must preserve the original text content');
+		$this->assertStringContainsString('color: red', $sHtmlContent, 'HTML part must contain the CSS inlined by Emogrifier');
+	}
+
+	/**
+	 * With inline images, SetBody() wraps the AlternativePart in a RelatedPart.
+	 * The AlternativePart must still be correctly ordered (plain first, HTML last)
+	 * and the plain-text part must not contain CSS.
+	 *
+	 * @see https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.4
+	 * @since N°9574
+	 */
+	public function testSetBodyWithInlineImagesHasCorrectPartStructure(): void
+	{
+		// Anonymous subclass so we can inject a fake inline image part without a real inline image in DB
+		$oEmail = new class () extends EMailSymfony {
+			protected function EmbedInlineImages(string &$sBody): array
+			{
+				return [new DataPart('fake-image-data', 'image.png', 'image/png')];
+			}
+		};
+		$oEmail->SetBody('<html><head><style>p { color: red; }</style></head><body><p>Hello there!</p></body></html>', 'text/html');
+
+		$oSymfonyMessage = $this->GetNonPublicProperty($oEmail, 'm_oMessage');
+		$oBody = $oSymfonyMessage->getBody();
+
+		// Root must be a RelatedPart when inline images are present
+		$this->assertInstanceOf(RelatedPart::class, $oBody, 'Root part must be multipart/related when inline images are present');
+
+		// The AlternativePart must be the first child of the RelatedPart
+		$aRelatedParts = $oBody->getParts();
+		$this->assertInstanceOf(AlternativePart::class, $aRelatedParts[0], 'First child of RelatedPart must be the AlternativePart');
+
+		// Order and CSS checks are delegated to the shared helper, which now handles RelatedPart
+		[$oFirstPart, $oSecondPart] = $this->GetAlternativePartsFromHtmlEmail($oEmail);
+		$this->assertSame('plain', $oFirstPart->getMediaSubtype(), 'First part must be text/plain (least preferred per RFC 2046)');
+		$this->assertSame('html', $oSecondPart->getMediaSubtype(), 'Last part must be text/html (most preferred per RFC 2046)');
+	}
+
+	public function provideSetBodyPlainTextDoesNotContainCss(): array
+	{
+		$sCustomStyles = 'p { color: blue; font-size: 14px; }';
+
+		return [
+			'<style> tag in HTML, no custom styles' => [
+				'<html><head><style>body { color: red; font-size: 12px; } @media print { p { color: black; } }</style></head><body><p>Hello there!</p></body></html>',
+				null,
+			],
+			'<style> tag in HTML with custom styles' => [
+				'<html><head><style>body { color: red; font-size: 12px; } @media print { p { color: black; } }</style></head><body><p>Hello there!</p></body></html>',
+				$sCustomStyles,
+			],
+			'custom styles only, no <style> tag' => [
+				'<html><body><p>Hello there!</p></body></html>',
+				$sCustomStyles,
+			],
+		];
 	}
 }

--- a/tests/php-unit-tests/unitary-tests/sources/core/Email/EmailSymfonyTest.php
+++ b/tests/php-unit-tests/unitary-tests/sources/core/Email/EmailSymfonyTest.php
@@ -169,6 +169,7 @@ HTML;
 	 * Email clients display the last part they support, so text/plain must come first and text/html last.
 	 *
 	 * @see https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.4
+     * @covers \Combodo\iTop\Core\Email\EmailSymfony::SetBody()
 	 * @since N°9574
 	 */
 	public function testSetBodyAlternativePartOrderForHtmlEmailIsPlainThenHtml(): void
@@ -185,6 +186,7 @@ HTML;
 	/**
 	 * @dataProvider provideSetBodyPlainTextDoesNotContainCss
 	 *
+	 * @covers \Combodo\iTop\Core\Email\EmailSymfony::SetBody()
 	 * @since N°9574
 	 */
 	public function testSetBodyPlainTextDoesNotContainCss(string $sHtml, ?string $sCustomStyles): void
@@ -217,6 +219,7 @@ HTML;
 	 * This guards against regressions where the wrong body (e.g. the plain-text version)
 	 * would end up in the HTML part.
 	 *
+	 * @covers \Combodo\iTop\Core\Email\EmailSymfony::SetBody()
 	 * @since N°9574
 	 */
 	public function testSetBodyHtmlPartContainsBodyAndInlinedCss(): void
@@ -246,6 +249,7 @@ HTML;
 	 * and the plain-text part must not contain CSS.
 	 *
 	 * @see https://www.rfc-editor.org/rfc/rfc2046.html#section-5.1.4
+	 * @covers \Combodo\iTop\Core\Email\EmailSymfony::SetBody()
 	 * @since N°9574
 	 */
 	public function testSetBodyWithInlineImagesHasCorrectPartStructure(): void


### PR DESCRIPTION
## Base information

| Question                                                       | Answer |
|----------------------------------------------------------------|--------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | TBD |
| Type of change?                                                | Bug fix |

## Symptom (bug) / Objective (enhancement)

When an HTML email notification is sent, the generated `text/plain` alternative can contain inlined stylesheet contents.

After updating from iTop 3.2.2-1 to 3.2.3, public log update emails may expose CKEditor CSS such as `@keyframes ck-input-shake`, `@keyframes ck-dialog-fade-in`, `.ck-reset_all`, etc. before the actual email text.

**Before fix:**
<img width="1894" height="1744" alt="image" src="https://github.com/user-attachments/assets/f201e7d1-2a41-4b7a-bd1d-04ef33fb6e07" />

**After fix:**
<img width="1746" height="712" alt="image" src="https://github.com/user-attachments/assets/be313d9e-546d-43e3-bfbf-629cd7af9e40" />


## Reproduction procedure (bug)

1. On iTop 3.2.3
2. Configure an email notification for ticket public log updates
3. Update the public log of a ticket
4. Receive the notification email
5. Open/read the email in a client that displays the `text/plain` alternative (e.g. Gmail)
6. See CKEditor CSS content before the expected notification body

**Expected result:** the email body only contains the notification content.

**Actual result:** stylesheet content is visible before the notification content.

## Cause (bug)

The Symfony mailer implementation builds the `text/plain` alternative from `$sBody` after `InlineCssIntoBodyContent()` has injected CSS into the HTML body.

The previous implementation used:

```php
$oTextPart = new TextPart(strip_tags($sBody), 'utf-8', 'plain', 'base64');
```

At that point, `$sBody` can contain `<style>...</style>` content. `strip_tags()` removes the tags but keeps their text content, so CSS rules leak into the plain-text part.

Also, the `multipart/alternative` parts were ordered as HTML first and plain text second:

```php
new AlternativePart($oHtmlPart, $oTextPart)
```

For `multipart/alternative`, the preferred representation must be last, so the expected order is `text/plain` first, then `text/html`.

This was introduced with the Symfony mailer migration in `428d2c6356a33c92e5b78c23559cfdd531a63b0f`.

## Proposed solution (bug and enhancement)

Build the plain-text body from the original HTML before CSS inlining, using Symfony's `DefaultHtmlToTextConverter`.

Then inline CSS only for the HTML part.

Finally, build `multipart/alternative` in the standard order:

```php
new AlternativePart($oTextPart, $oHtmlPart)
```

This prevents CSS from leaking into the plain-text part and makes HTML the preferred alternative for clients that support it.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?

Unit test note: I did not add a unit test because this mail rendering path depends on the iTop email/MIME assembly and notification flow. The fix has been verified manually on an iTop instance by comparing the generated/received email before and after the change.
