### PR TITLE
N°9584 - Fix "Unable to connect with STARTTLS" error when sending emails

### DIFF
--- a/sources/Core/Email/EmailSymfony.php
+++ b/sources/Core/Email/EmailSymfony.php
@@ -29,6 +29,7 @@ use Symfony\Component\CssSelector\Exception\ParseException;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Symfony\Component\Mime\Email as SymfonyEmail;
 use Symfony\Component\Mime\HtmlToTextConverter\DefaultHtmlToTextConverter;
 use Symfony\Component\Mime\Part\DataPart;
@@ -184,24 +185,7 @@ class EMailSymfony extends Email
 					$sDsn = sprintf('smtp://%s%s@%s%s', $sDsnUser, $sDsnPassword, $sDsnPort, $sEncQuery);
 				}
 
-				$oTransport = Transport::fromDsn($sDsn);
-
-				// Handle peer verification
-				$oStream = $oTransport->getStream();
-				$aOptions = $oStream->getStreamOptions();
-				/*
-				 * N°9584 Connection with the SMTP server always starts unencrypted, so there won't be any `ssl` option at first.
-				 *        But we have to force them if certificate should not be verified so they can be used when the connection is "upgraded" to TLS via STARTTLS
-				 * @see https://datatracker.ietf.org/doc/html/rfc3207
-				 * @see https://www.php.net/manual/en/function.stream-socket-enable-crypto.php
-				 */
-				if (!$bVerifyPeer) {
-					// Disable verification - must set even when 'ssl' key is absent (e.g. STARTTLS starts plain and upgrades later)
-					$aOptions['ssl']['verify_peer'] = false;
-					$aOptions['ssl']['verify_peer_name'] = false;
-					$aOptions['ssl']['allow_self_signed'] = true;
-				}
-				$oStream->setStreamOptions($aOptions);
+				$oTransport = $this->CreateSmtpTransport($sDsn, $bVerifyPeer);
 
 				$oMailer = new Mailer($oTransport);
 				break;
@@ -265,6 +249,36 @@ class EMailSymfony extends Email
 			$oKPI->ComputeStats('Email Sent', 'Error received');
 			throw $e;
 		}
+	}
+
+	/**
+	 * Build and configure an SMTP transport from a DSN string.
+	 *
+	 * Extracted from {@see SendSynchronous} to make SSL option handling independently testable.
+	 * When $bVerifyPeer is false, the ssl stream context options must be written unconditionally:
+	 * with STARTTLS the connection starts unencrypted, so the 'ssl' key is absent from the stream
+	 * options at construction time and only used later when stream_socket_enable_crypto() is called.
+	 *
+	 * @param string $sDsn       Full Symfony Mailer DSN (smtp:// or smtps://)
+	 * @param bool   $bVerifyPeer Whether to verify the peer SSL certificate
+	 *
+	 * @return \Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport
+	 */
+	protected function CreateSmtpTransport(string $sDsn, bool $bVerifyPeer): EsmtpTransport
+	{
+		/** @var EsmtpTransport $oTransport */
+		$oTransport = Transport::fromDsn($sDsn);
+
+		$oStream = $oTransport->getStream();
+		$aOptions = $oStream->getStreamOptions();
+		if (!$bVerifyPeer) {
+			$aOptions['ssl']['verify_peer'] = false;
+			$aOptions['ssl']['verify_peer_name'] = false;
+			$aOptions['ssl']['allow_self_signed'] = true;
+		}
+		$oStream->setStreamOptions($aOptions);
+
+		return $oTransport;
 	}
 
 	/**

--- a/sources/Core/Email/EmailSymfony.php
+++ b/sources/Core/Email/EmailSymfony.php
@@ -189,8 +189,14 @@ class EMailSymfony extends Email
 				// Handle peer verification
 				$oStream = $oTransport->getStream();
 				$aOptions = $oStream->getStreamOptions();
-				if (!$bVerifyPeer && array_key_exists('ssl', $aOptions)) {
-					// Disable verification
+				/*
+				 * N°9584 Connection with the SMTP server always starts unencrypted, so there won't be any `ssl` option at first.
+				 *        But we have to force them if certificate should not be verified so they can be used when the connection is "upgraded" to TLS via STARTTLS
+				 * @see https://datatracker.ietf.org/doc/html/rfc3207
+				 * @see https://www.php.net/manual/en/function.stream-socket-enable-crypto.php
+				 */
+				if (!$bVerifyPeer) {
+					// Disable verification - must set even when 'ssl' key is absent (e.g. STARTTLS starts plain and upgrades later)
 					$aOptions['ssl']['verify_peer'] = false;
 					$aOptions['ssl']['verify_peer_name'] = false;
 					$aOptions['ssl']['allow_self_signed'] = true;

--- a/tests/php-unit-tests/unitary-tests/sources/core/Email/EmailSymfonyTest.php
+++ b/tests/php-unit-tests/unitary-tests/sources/core/Email/EmailSymfonyTest.php
@@ -2,6 +2,7 @@
 
 use Combodo\iTop\Core\Email\EMailSymfony;
 use Combodo\iTop\Test\UnitTest\ItopTestCase;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\Multipart\AlternativePart;
 use Symfony\Component\Mime\Part\Multipart\RelatedPart;
@@ -295,6 +296,65 @@ HTML;
 			'custom styles only, no <style> tag' => [
 				'<html><body><p>Hello there!</p></body></html>',
 				$sCustomStyles,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider provideCreateSmtpTransportSslOptions
+	 */
+	public function testCreateSmtpTransportSslOptions(string $sDsn, bool $bVerifyPeer, array $aExpectedSslOptions): void
+	{
+		$oEmail = new EMailSymfony();
+		/** @var EsmtpTransport $oTransport */
+		$oTransport = $this->InvokeNonPublicMethod(EMailSymfony::class, 'CreateSmtpTransport', $oEmail, [$sDsn, $bVerifyPeer]);
+
+		$aActualSslOptions = $oTransport->getStream()->getStreamOptions()['ssl'] ?? [];
+
+		$this->assertSame($aExpectedSslOptions, $aActualSslOptions);
+	}
+
+	public function provideCreateSmtpTransportSslOptions(): array
+	{
+		$aDisabledVerification = [
+			'verify_peer'      => false,
+			'verify_peer_name' => false,
+			'allow_self_signed' => true,
+		];
+
+		return [
+			// Regression scenario (N°9584): STARTTLS starts the connection unencrypted, so the 'ssl' key
+			// is absent from stream options at construction time. verify_peer=false must still be applied.
+			'STARTTLS, verify_peer=false' => [
+				'smtp://localhost:587?encryption=starttls',
+				false,
+				$aDisabledVerification,
+			],
+			'implicit TLS (smtps), verify_peer=false' => [
+				'smtps://localhost:465',
+				false,
+				$aDisabledVerification,
+			],
+			'plain SMTP, verify_peer=false' => [
+				'smtp://localhost:25',
+				false,
+				$aDisabledVerification,
+			],
+			// Default behavior: verify_peer=true must leave stream options untouched (empty).
+			'STARTTLS, verify_peer=true (default)' => [
+				'smtp://localhost:587?encryption=starttls',
+				true,
+				[],
+			],
+			'implicit TLS (smtps), verify_peer=true (default)' => [
+				'smtps://localhost:465',
+				true,
+				[],
+			],
+			'plain SMTP, verify_peer=true (default)' => [
+				'smtp://localhost:25',
+				true,
+				[],
 			],
 		];
 	}


### PR DESCRIPTION
## Base information

| Question | Answer |
|---|---|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | N°9584 |
| Type of change? | Bug fix |

## Symptom (bug)

When sending an email from iTop with SMTP transport, the following error occurs if the SMTP server presents a certificate whose CN does not match the configured host:

```
Unable to connect with STARTTLS: stream_socket_enable_crypto(): Peer certificate CN='some.vertified.domain' did not match expected CN='some.uncertified.domain.alias'
```

## Reproduction procedure (bug)

1. On iTop Community 3.2.3
2. With an Administrator account
3. Set the email configuration to use SMTP transport to an host which is an alias of the real SMTP host, encryption `tls`, and `verify_peer = false`
4. Go to the notification test page: Menu **Configuration > Notifications > email.test.php**
5. Enter a destination email address in the TO field
6. Click **Next**
7. Observe the error above

## Cause (bug)

This issue appeared after the migration from Laminas to Symfony Mailer. The `email_transport_smtp.verify_peer` configuration parameter (default `true`) is supposed to allow disabling certificate verification, but has no longer any effect.

The `array_key_exists('ssl', $aOptions)` condition is the root cause. When using **STARTTLS** (`encryption=tls`), the connection starts **unencrypted** on a plain socket and only upgrades to TLS later (via the `STARTTLS` SMTP command, see [RFC 3207 section 4](https://datatracker.ietf.org/doc/html/rfc3207)). At the time `getStreamOptions()` is called, the `'ssl'` key does not yet exist in the stream context, so the condition silently fails and the options are never written.

When PHP later calls [`stream_socket_enable_crypto()`](https://www.php.net/manual/en/function.stream-socket-enable-crypto.php) to upgrade the connection, it uses the SSL context options as-is — with peer verification still enabled by default — causing the CN mismatch error.

This worked with Laminas because that library configured SSL options through a dedicated configuration object, independently of whether the connection had already established an SSL context.

## Proposed solution (bug and enhancement)

Remove the `array_key_exists('ssl', $aOptions)` guard so that SSL options are unconditionally written when `verify_peer` is `false`, regardless of whether the `'ssl'` key is pre-populated which does no harm is the connection is not encrypted:

This ensures the options are present in the stream context before `stream_socket_enable_crypto()` is called, both for STARTTLS and for implicit TLS (smtps).

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [X] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand without digging in the code?

## Checklist before requesting a review

- [X] Check how to make a unit that could ensure we don't have a regression on that