### PR TITLE
fix(CMDBSource): getFieldSpec returns NULL as a string

### DIFF
--- a/core/cmdbsource.class.inc.php
+++ b/core/cmdbsource.class.inc.php
@@ -1279,20 +1279,19 @@ class CMDBSource
 		}
 
 		if (is_numeric($aFieldData["Default"])) {
-			if (strtolower(substr($aFieldData["Type"], 0, 5)) == 'enum(') {
-				// Force quotes to match the column declaration statement
-				$sRet .= ' DEFAULT '.self::Quote($aFieldData["Default"], true);
+			if (self::IsNumericType($aFieldData)) {
+				$sRet .= ' DEFAULT '.$aFieldData["Default"];
 			} else {
-				if (self::IsNumericType($aFieldData)) {
-					$sRet .= ' DEFAULT '.$aFieldData["Default"];
-				} else {
-					$default = $aFieldData["Default"] + 0; // Coerce to a numeric variable
-					$sRet .= ' DEFAULT '.self::Quote($default);
-				}
+				$default = $aFieldData["Default"] + 0; // Coerce to a numeric variable
+				$sRet .= ' DEFAULT '.self::Quote($default, true);
 			}
-		} elseif (is_string($aFieldData["Default"]) == 'string') {
-			$sDefaultValue = static::RemoveSurroundingQuotes($aFieldData["Default"]);
-			$sRet .= ' DEFAULT '.self::Quote($sDefaultValue);
+		} elseif (is_string($aFieldData["Default"])) {
+			if ($aFieldData["Null"] === 'YES' && $aFieldData["Default"] === 'NULL') {
+				$sRet .= ' DEFAULT NULL';
+			} else {
+				$sDefaultValue = static::RemoveSurroundingQuotes($aFieldData["Default"]);
+				$sRet .= ' DEFAULT '.self::Quote($sDefaultValue);
+			}
 		}
 
 		return $sRet;

--- a/tests/php-unit-tests/unitary-tests/core/CMDBSource/CMDBSourceTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/CMDBSource/CMDBSourceTest.php
@@ -148,6 +148,7 @@ class CMDBSourceTest extends ItopTestCase
 			'String simple default' => ['ticket', 'finalclass', "varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT 'Ticket'"],
 			'String numeric default' => ['datacenterdevice', 'redundancy', "varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT '1'"],
 //			'String required' => ['', '', "varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT ''"], // does not seem to exist in iTop model?
+			'Text nullable' => ['ticket', 'private_log', 'longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL'],
 			'Enum simple' => ['physicaldevice', 'status', "enum('stock','implementation','production','obsolete') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT 'production'"],
 			'Enum numbers' => ['ticket_request', 'priority', "enum('1','2','3','4') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT '4'"],
 			'Datetime nullable' => ['ticket', 'last_update', "datetime DEFAULT NULL"],

--- a/tests/php-unit-tests/unitary-tests/core/CMDBSource/CMDBSourceTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/CMDBSource/CMDBSourceTest.php
@@ -8,6 +8,7 @@ use Combodo\iTop\Test\UnitTest\ItopTestCase;
 use Exception;
 use IssueLog;
 use LogChannels;
+use MetaModel;
 use utils;
 
 /**
@@ -23,6 +24,10 @@ class CMDBSourceTest extends ItopTestCase
 
 		parent::setUp();
 		$this->RequireOnceItopFile('/core/cmdbsource.class.inc.php');
+		$sEnv = 'production';
+		$sConfigFile = APPCONF.$sEnv.'/config-itop.php';
+
+		MetaModel::Startup($sConfigFile, false, true, false, $sEnv);
 	}
 
 	protected function tearDown(): void
@@ -119,6 +124,33 @@ class CMDBSourceTest extends ItopTestCase
 				"ENUM('value 1 (with parenthesis)','value 2') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",
 				"enum('value 1 (with parenthesis)','value 3') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",
 			],
+		];
+	}
+
+	/**
+	 * @covers       CMDBSource::GetFieldSpec
+	 * @dataProvider fieldSpecsProvider
+	 */
+	public function testGetFieldSpec(string $sTable, string $sField, false|string $expected): void
+	{
+		$this->assertEquals($expected, CMDBSource::getFieldSpec($sTable, $sField));
+	}
+
+	public function fieldSpecsProvider(): array
+	{
+		return [
+			'Unknown table' => ['unknown', 'unknown', false],
+			'Unknown field' => ['ticket', 'unknown', false],
+			'Primary key' => ['ticket', 'id', 'int(11) NOT NULL'],
+			'External key' => ['ticket', 'org_id', 'int(11) DEFAULT 0'],
+			'Integer nullable' => ['datacenterdevice' , 'nb_u', 'int(11) DEFAULT NULL'],
+			'String empty default' => ['ticket', 'ref', "varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT ''"],
+			'String simple default' => ['ticket', 'finalclass', "varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT 'Ticket'"],
+			'String numeric default' => ['datacenterdevice', 'redundancy', "varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT '1'"],
+//			'String required' => ['', '', "varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT ''"], // does not seem to exist in iTop model?
+			'Enum simple' => ['physicaldevice', 'status', "enum('stock','implementation','production','obsolete') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT 'production'"],
+			'Enum numbers' => ['ticket_request', 'priority', "enum('1','2','3','4') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT '4'"],
+			'Datetime nullable' => ['ticket', 'last_update', "datetime DEFAULT NULL"],
 		];
 	}
 


### PR DESCRIPTION
## Base information

| Question                                                       | Answer 
|----------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | N/A
| Type of change?                                                | Bug fix 

## Symptom

Not able to use `ModuleInstallerAPI::MoveColumnInDB` when the destination field is not yet present and it is a nullable integer, date, datetime.

> Module xxxx : error when calling module installer class xxxx for BeforeDatabaseCreation handler: ModulelId = xxxx, ModuleInstallerClass = xxxx, ModuleInstallerHandler = BeforeDatabaseCreation, ExceptionClass = MySQLException, ExceptionMessage = Failed to issue SQL query: query = ALTER TABLE \`ticket\` ADD \`resolution_date\` datetime DEFAULT 'NULL', mysql_errno = 1067, mysql_error = Invalid default value for 'resolution_date'

## Reproduction procedure

1. On iTop 3.2.2
2. With PHP 8.3.20
3. Add `static::MoveColumnInDB('ticket_request', 'resolution_date', 'ticket', 'resolution_date');` to a installer class.
4. Run setup
5. Finally, see error as above.

## Cause

The code in `CMDBSource::getFieldSpec` makes wrong assumptions.

## Proposed solution

First add tests that prove some scenario's fail, then update the mentioned method to better handle `NULL` defaults.

Test results before change: [CMDBSourceTest_testGetFieldSpec.html](https://github.com/user-attachments/files/27340448/CMDBSourceTest_testGetFieldSpec.html)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?