### PR TITLE
N°9603 - Fix transitions applied when editing only caselog are not working

### DIFF
--- a/sources/Application/UI/Base/Layout/ActivityPanel/CaseLogEntryForm/CaseLogEntryFormFactory.php
+++ b/sources/Application/UI/Base/Layout/ActivityPanel/CaseLogEntryForm/CaseLogEntryFormFactory.php
@@ -39,7 +39,7 @@ class CaseLogEntryFormFactory
 			->AddMainActionButtons(static::PrepareCancelButton());
 
 		$oSaveButton = static::PrepareSaveButton();
-		$oTransitionsMenu = static::PrepareTransitionsSelectionPopoverMenu($oObject, $sCaseLogAttCode);
+		$oTransitionsMenu = static::PrepareTransitionsSelectionPopoverMenu($oObject, $sCaseLogAttCode, $oCaseLogEntryForm->GetId());
 		// Prevent popover menu from landing behind caselog editor
 		$oTransitionsMenu->SetContainer(PopoverMenu::ENUM_CONTAINER_BODY);
 		if (true === $oTransitionsMenu->HasItems()) {
@@ -71,7 +71,16 @@ class CaseLogEntryFormFactory
 		return $oButton;
 	}
 
-	protected static function PrepareTransitionsSelectionPopoverMenu(DBObject $oObject, string $sCaseLogAttCode): PopoverMenu
+	/**
+	 * @param DBObject $oObject
+	 * @param string $sCaseLogAttCode
+	 * @param string $sCaseLogEntryFormId
+	 * @since 3.2.3 Add mandatory $sCaseLogEntryFormId parameter
+	 * @return PopoverMenu
+	 * @throws \ArchivedObjectException
+	 * @throws \CoreException
+	 */
+	protected static function PrepareTransitionsSelectionPopoverMenu(DBObject $oObject, string $sCaseLogAttCode, string $sCaseLogEntryFormId): PopoverMenu
 	{
 		$sObjClass = get_class($oObject);
 
@@ -99,7 +108,7 @@ class CaseLogEntryFormFactory
 								CaseLogEntryForm::BLOCK_CODE.'--add-action--'.$sCaseLogAttCode.'--stimulus--'.$sStimulusCode,
 								Dict::Format('UI:Button:SendAnd', $aStimuli[$sStimulusCode]->GetLabel()),
 								<<<JS
-$(this).closest('[data-role="{$sCaseLogEntryFormDataRole}"]').trigger('save_entry.caselog_entry_form.itop', {stimulus_code: '{$sStimulusCode}'});
+$('#$sCaseLogEntryFormId').trigger('save_entry.caselog_entry_form.itop', {stimulus_code: '{$sStimulusCode}'});
 JS
 							)
 						);

--- a/sources/Application/UI/Base/Layout/ActivityPanel/CaseLogEntryForm/CaseLogEntryFormFactory.php
+++ b/sources/Application/UI/Base/Layout/ActivityPanel/CaseLogEntryForm/CaseLogEntryFormFactory.php
@@ -13,7 +13,6 @@ use Combodo\iTop\Application\UI\Base\Component\Button\ButtonUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Component\ButtonGroup\ButtonGroupUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Component\PopoverMenu\PopoverMenu;
 use Combodo\iTop\Application\UI\Base\Component\PopoverMenu\PopoverMenuItem\PopoverMenuItemFactory;
-use Combodo\iTop\Application\UI\Base\Layout\ActivityPanel\CaseLogEntryForm\CaseLogEntryForm;
 use DBObject;
 use DBObjectSet;
 use Dict;
@@ -87,8 +86,6 @@ class CaseLogEntryFormFactory
 		$oMenu = new PopoverMenu();
 		$sSectionId = 'send-actions';
 		$oMenu->AddSection($sSectionId);
-
-		$sCaseLogEntryFormDataRole = CaseLogEntryForm::BLOCK_CODE;
 
 		// Note: This code is inspired from cmdbAbstract::DisplayModifyForm(), it might be better to factorize it
 		$aTransitions = $oObject->EnumTransitions();


### PR DESCRIPTION
<!--
IMPORTANT: Before creating your PR, please create an issue first to know if Combodo is interested in your contribution (not needed for translations PR).
Since we may refuse a PR, it's preferable to create an issue first, to avoid spending time coding something that won't be accepted.

Once you've done it, and we confirmed we're interested in it, please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.
-->

## Base information

| Question                                                       | Answer 
|----------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | N°9603                |
| Type of change?                                                | Bug fix

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | <!-- Put the URL -->                 |
| Type of change?                                                                 | Bug fix / Enhancement / Translations |

## Symptom (bug) / Objective (enhancement)

When the transition popup is used while editing a caselog, its actions aren't working

## Reproduction procedure (bug)

<!--
Please explain step by step how to reproduce the issue on a standard iTop Community.
If it requires a custom datamodel, provide the minimal XML delta to reproduce it on a standard iTop Community.
-->

1. On iTop 3.2.3-1
3. Open an object, edit its caselog
4. Open the popup from the send button
5. Use a transition action
6. Finally, see that nothing happens

## Cause (bug)

829857e commit moved the popup from inside the form to the body.
This lead the selector that triggers the transition to miss the form as this uses `$(this).closest('[data-role="ibo-caselog-entry-form"]')` and it's not in the same HTML tree anymore

## Proposed solution (bug and enhancement)

<!--
Explain in details how you are proposing to solve this:
  - What did you do in the code and why
  - If you changed something in the UI, put before / after screenshots (you can paste image directly in this editor)
-->

A quick solution is to use the id of the form that we already know, to trigger the transition

## Checklist before requesting a review

<!--
Don't remove these lines, check them once done.
-->

- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand without digging in the code?