### PR TITLE
N°9614 - Add a specific route to display the icons for an EventNotificationNewsroom

### DIFF
--- a/core/ormdocument.class.inc.php
+++ b/core/ormdocument.class.inc.php
@@ -340,13 +340,14 @@ class ormDocument
 	 * @param string $sContentDisposition Either 'inline' or 'attachment'
 	 * @param string $sSecretField The attcode of the field containing a "secret" to be provided in order to retrieve the file
 	 * @param string $sSecretValue The value of the secret to be compared with the value of the attribute $sSecretField
+	 * @param bool $bAllowAllData If true, no rights filtering is applied
 	 *
 	 * @return void
 	 */
-	public static function DownloadDocument(WebPage $oPage, $sClass, $id, $sAttCode, $sContentDisposition = 'attachment', $sSecretField = null, $sSecretValue = null)
+	public static function DownloadDocument(WebPage $oPage, $sClass, $id, $sAttCode, $sContentDisposition = 'attachment', $sSecretField = null, $sSecretValue = null, $bAllowAllData = false)
 	{
 		try {
-			$oObj = MetaModel::GetObject($sClass, $id, false, false);
+			$oObj = MetaModel::GetObject($sClass, $id, false, $bAllowAllData);
 			if (!is_object($oObj)) {
 				// If access to the document is not granted, check if the access to the host object is allowed
 				$oObj = MetaModel::GetObject($sClass, $id, false, true);

--- a/sources/Controller/Newsroom/iTopNewsroomController.php
+++ b/sources/Controller/Newsroom/iTopNewsroomController.php
@@ -21,6 +21,7 @@ use Combodo\iTop\Application\WebPage\iTopWebPage;
 use Combodo\iTop\Application\WebPage\JsonPage;
 use Combodo\iTop\Application\WebPage\JsonPPage;
 use Combodo\iTop\Controller\Notifications\NotificationsCenterController;
+use Combodo\iTop\Service\Notification\Event\EventNotificationNewsroomService;
 use Combodo\iTop\Service\Notification\NotificationsRepository;
 use Combodo\iTop\Service\Router\Router;
 use CoreException;
@@ -28,8 +29,8 @@ use DBObjectSearch;
 use DBObjectSet;
 use Dict;
 use EventNotificationNewsroom;
+use Exception;
 use MetaModel;
-use ormDocument;
 use SecurityException;
 use UserRights;
 use utils;
@@ -715,17 +716,8 @@ HTML;
 				$oPage->add_header('Content-Security-Policy: sandbox;');
 			}
 
-			$oEvent = MetaModel::GetObject(EventNotificationNewsroom::class, $sId, false, true);
-			if (($oEvent !== null) && ($oEvent->Get('contact_id') === UserRights::GetContactId())) {
-				ormDocument::DownloadDocument(
-					$oPage,
-					EventNotificationNewsroom::class,
-					$sId,
-					'icon',
-					ormDocument::ENUM_CONTENT_DISPOSITION_INLINE,
-					bAllowAllData: true
-				);
-				$oPage->output();
+			if (EventNotificationNewsroomService::DownloadIcon($oPage, $sId, UserRights::GetContactId()) === true) {
+				$oPage->Output();
 			}
 		}
 	}

--- a/sources/Controller/Newsroom/iTopNewsroomController.php
+++ b/sources/Controller/Newsroom/iTopNewsroomController.php
@@ -715,15 +715,18 @@ HTML;
 				$oPage->add_header('Content-Security-Policy: sandbox;');
 			}
 
-			ormDocument::DownloadDocument(
-				$oPage,
-				EventNotificationNewsroom::class,
-				$sId,
-				'icon',
-				ormDocument::ENUM_CONTENT_DISPOSITION_INLINE,
-				bAllowAllData: true
-			);
-			$oPage->output();
+			$oEvent = MetaModel::GetObject(EventNotificationNewsroom::class, $sId, false, true);
+			if (($oEvent !== null) && ($oEvent->Get('contact_id') === UserRights::GetContactId())) {
+				ormDocument::DownloadDocument(
+					$oPage,
+					EventNotificationNewsroom::class,
+					$sId,
+					'icon',
+					ormDocument::ENUM_CONTENT_DISPOSITION_INLINE,
+					bAllowAllData: true
+				);
+				$oPage->output();
+			}
 		}
 	}
 

--- a/sources/Controller/Newsroom/iTopNewsroomController.php
+++ b/sources/Controller/Newsroom/iTopNewsroomController.php
@@ -16,6 +16,7 @@ use Combodo\iTop\Application\UI\Base\Component\Title\TitleUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Component\Toolbar\ToolbarUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Layout\Object\ObjectSummary;
 use Combodo\iTop\Application\UI\Base\Layout\UIContentBlock;
+use Combodo\iTop\Application\WebPage\DownloadPage;
 use Combodo\iTop\Application\WebPage\iTopWebPage;
 use Combodo\iTop\Application\WebPage\JsonPage;
 use Combodo\iTop\Application\WebPage\JsonPPage;
@@ -28,6 +29,7 @@ use DBObjectSet;
 use Dict;
 use EventNotificationNewsroom;
 use MetaModel;
+use ormDocument;
 use SecurityException;
 use UserRights;
 use utils;
@@ -376,9 +378,10 @@ JS
 			$oEventBlock->SetCSSColorClass($sReadColor);
 			$oEventBlock->SetSubTitle($sReadLabel);
 			$oEventBlock->SetClassLabel('');
+			/** @var \ormDocument $oImage */
 			$oImage = $oEvent->Get('icon');
 			if (!$oImage->IsEmpty()) {
-				$sIconUrl = $oImage->GetDisplayURL(get_class($oEvent), $iEventId, 'icon');
+				$sIconUrl = self::GetDisplayIconUrl($iEventId, $oImage->GetSignature());
 				$oEventBlock->SetIcon($sIconUrl, Panel::ENUM_ICON_COVER_METHOD_COVER, true);
 			}
 
@@ -542,7 +545,7 @@ $sMessage
 HTML;
 
 				$sIcon = $oMessage->Get('icon') !== null ?
-					$oMessage->Get('icon')->GetDisplayURL(EventNotificationNewsroom::class, $oMessage->GetKey(), 'icon') :
+					$this->GetDisplayIconUrl($oMessage->GetKey(), $oMessage->Get('icon')->GetSignature()) :
 					Branding::GetCompactMainLogoAbsoluteUrl();
 				$aMessages[] = [
 					'id'         => $oMessage->GetKey(),
@@ -690,6 +693,41 @@ HTML;
 	}
 
 	/**
+	 * Display the icon of an EventNotificationNewsroom
+	 * (copy of ajax.render.php?operation=display_document but with the bAllowAllData parameter set to true in order to bypass the data access restrictions since the icon is not a critical information)
+	 * @return void
+	 * @throws \ConfigException
+	 * @throws \CoreException
+	 */
+	public function OperationViewIcon(): void
+	{
+		$sId = utils::ReadParam('id', '');
+		if (!empty($sId)) {
+			$oPage = new DownloadPage('');
+			// X-Frame http header : set in page constructor, but we need to allow frame integration for this specific page
+			// so we're resetting its value ! (see N°3416)
+			$oPage->add_xframe_options('');
+			$iCacheSec = (int)utils::ReadParam('cache', 0);
+			$oPage->set_cache($iCacheSec);
+
+			// N°4129 - Prevent XSS attacks & other script executions
+			if (utils::GetConfig()->Get('security.disable_inline_documents_sandbox') === false) {
+				$oPage->add_header('Content-Security-Policy: sandbox;');
+			}
+
+			ormDocument::DownloadDocument(
+				$oPage,
+				EventNotificationNewsroom::class,
+				$sId,
+				'icon',
+				ormDocument::ENUM_CONTENT_DISPOSITION_INLINE,
+				bAllowAllData: true
+			);
+			$oPage->output();
+		}
+	}
+
+	/**
 	 * @param string $sAction
 	 *
 	 * @return string[]
@@ -780,5 +818,10 @@ HTML;
 		}
 
 		return $aReturnData;
+	}
+
+	protected function GetDisplayIconUrl(string $sId, string $sSignature): string
+	{
+		return utils::GetAbsoluteUrlAppRoot()."pages/UI.php?route=itopnewsroom.view_icon&id=$sId&s=$sSignature&cache=86400";
 	}
 }

--- a/sources/Service/Notification/Event/EventNotificationNewsroomService.php
+++ b/sources/Service/Notification/Event/EventNotificationNewsroomService.php
@@ -4,8 +4,10 @@ namespace Combodo\iTop\Service\Notification\Event;
 
 use Action;
 use Combodo\iTop\Application\Branding;
+use Combodo\iTop\Application\WebPage\WebPage;
 use EventNotificationNewsroom;
 use MetaModel;
+use ormDocument;
 use utils;
 
 /**
@@ -69,5 +71,32 @@ class EventNotificationNewsroomService
 		}
 
 		return $oEvent;
+	}
+
+	/**
+	 * @param \Combodo\iTop\Application\WebPage\WebPage $oPage
+	 * @param string $sId
+	 * @param int $iContactId
+	 *
+	 * @return bool Returns true if the download has been launched, false otherwise (e.g. if the event doesn't exist or doesn't belong to the current user)
+	 * @throws \ArchivedObjectException
+	 * @throws \CoreException
+	 */
+	public static function DownloadIcon(WebPage $oPage, string $sId, int $iContactId): bool
+	{
+		$oEvent = MetaModel::GetObject(EventNotificationNewsroom::class, $sId, false, true);
+		if (($oEvent !== null) && ($oEvent->Get('contact_id') === $iContactId)) {
+			ormDocument::DownloadDocument(
+				$oPage,
+				EventNotificationNewsroom::class,
+				$sId,
+				'icon',
+				ormDocument::ENUM_CONTENT_DISPOSITION_INLINE,
+				bAllowAllData: true
+			);
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/tests/php-unit-tests/unitary-tests/core/ormDocumentTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/ormDocumentTest.php
@@ -198,6 +198,21 @@ class ormDocumentTest extends ItopDataTestCase
 		$this->assertStringNotContainsString('the object does not exist or you are not allowed to view it', $sAllowedHtml, 'Unexpected error message when rights are sufficient.');
 	}
 
+	/**
+	 * @dataProvider DownloadDocumentRightsProvider
+	 */
+	public function testAllowsDownloadingDocumentWhenBypassingRightsChecksWithAllowAllData(string $sTargetClass, string $sAttCode, string $sData, string $sFileName, ?string $sHostClass)
+	{
+		$iDeniedDocumentId = $this->CreateDownloadTargetInOrg($sTargetClass, $sAttCode, $this->iOrgDifferentFromUser, $sData, $sFileName, $sHostClass);
+
+		$oPageAllowed = new CaptureWebPage();
+		ormDocument::DownloadDocument($oPageAllowed, $sTargetClass, $iDeniedDocumentId, $sAttCode, ormDocument::ENUM_CONTENT_DISPOSITION_INLINE, bAllowAllData: true);
+		$sAllowedHtml = $oPageAllowed->GetHtml();
+
+		$this->assertStringContainsString($sData, $sAllowedHtml, 'Expected file data present when bypassing rights checks.');
+		$this->assertStringNotContainsString("Invalid id ($iDeniedDocumentId) for class '$sTargetClass' - the object does not exist or you are not allowed to view it", $sAllowedHtml, 'Unexpected invalid id error message when bypassing rights checks.');
+	}
+
 	public function DownloadDocumentRightsProvider(): array
 	{
 		return [

--- a/tests/php-unit-tests/unitary-tests/sources/Service/Notification/Event/EventNotificationNewsroomServiceTest.php
+++ b/tests/php-unit-tests/unitary-tests/sources/Service/Notification/Event/EventNotificationNewsroomServiceTest.php
@@ -14,6 +14,7 @@ use Ticket;
 use Trigger;
 use TriggerOnObjectMention;
 use UserRequest;
+use UserRights;
 
 class EventNotificationNewsroomServiceTest extends ItopDataTestCase
 {
@@ -117,5 +118,37 @@ class EventNotificationNewsroomServiceTest extends ItopDataTestCase
 
 		$this->assertFalse($bDownloadIcon);
 		$this->assertEquals('', $sHtml);
+	}
+
+	public function testDownloadIconIsTriggeredEvenWhenUserCannotReadIconAttribute(): void
+	{
+		// Create a user with Support Agent Profile
+		$sLogin = uniqid('EventNotificationNewsroomServiceTest');
+		$oUser = $this->CreateContactlessUser($sLogin, self::$aURP_Profiles['Support Agent'], '1234@Abcdefg');
+		$oUser->Set('contactid', $this->oContact->GetKey());
+		UserRights::Login($sLogin);
+
+		$this->oEvent = EventNotificationNewsroomService::MakeEventFromAction(
+			oAction: $this->oAction,
+			iContactId: $this->oContact->GetKey(),
+			iTriggerId: $this->oTrigger->GetKey(),
+			sMessage: 'Test message',
+			sTitle: 'Test event',
+			sUrl: 'https://localhost/itop/pages/UI.php?operation=details&class=UserRequest&id=1',
+			iObjectId: $this->oTicket->GetKey(),
+			sObjectClass: UserRequest::class,
+		);
+		$this->oEvent->DBInsert();
+
+		$iURValue = UserRights::IsActionAllowedOnAttribute(EventNotificationNewsroom::class, 'icon', UR_ACTION_READ, $this->oEvent, $oUser);
+		$this->assertEquals(UR_ALLOWED_NO, $iURValue);
+
+		$oPage = new CaptureWebPage();
+		$bDownloadIcon = EventNotificationNewsroomService::DownloadIcon($oPage, $this->oEvent->GetKey(), $this->oContact->GetKey());
+		$sHtml = $oPage->GetHtml();
+
+		$this->assertTrue($bDownloadIcon);
+		$this->assertNotEquals('', $sHtml);
+		$this->assertStringNotContainsString('the object does not exist or you are not allowed to view it', $sHtml);
 	}
 }

--- a/tests/php-unit-tests/unitary-tests/sources/Service/Notification/Event/EventNotificationNewsroomServiceTest.php
+++ b/tests/php-unit-tests/unitary-tests/sources/Service/Notification/Event/EventNotificationNewsroomServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Combodo\iTop\Test\UnitTest\Service\Notification\Event;
+
+use Action;
+use ActionNewsroom;
+use Combodo\iTop\Application\WebPage\CaptureWebPage;
+use Combodo\iTop\Service\Notification\Event\EventNotificationNewsroomService;
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use Contact;
+use EventNotificationNewsroom;
+use Person;
+use Ticket;
+use Trigger;
+use TriggerOnObjectMention;
+use UserRequest;
+
+class EventNotificationNewsroomServiceTest extends ItopDataTestCase
+{
+	public const CREATE_TEST_ORG = true;
+
+	private Contact $oContact;
+	private Trigger $oTrigger;
+	private Action $oAction;
+	private Ticket $oTicket;
+	private EventNotificationNewsroom $oEvent;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		/** @var Contact $oContact */
+		$oContact = $this->createObject(Person::class, [
+			'name' => 'Khalo',
+			'first_name' => 'Frida',
+			'org_id' => $this->getTestOrgId(),
+		]);
+		$this->oContact = $oContact;
+
+		/** @var Trigger $oTrigger */
+		$oTrigger = $this->createObject(TriggerOnObjectMention::class, [
+			'description' => 'Person mentioned on Ticket',
+			'target_class' => 'Ticket',
+		]);
+		$this->oTrigger = $oTrigger;
+
+		/** @var Action $oAction */
+		$oAction = $this->createObject(ActionNewsroom::class, [
+			'name' => 'Notification to persons mentioned in logs',
+			'status' => 'enabled',
+			'title' => '$this->friendlyname$',
+			'message' => 'You have been mentioned by $current_contact->friendlyname$',
+			'recipients' => 'SELECT Person WHERE id = :mentioned->id',
+		]);
+		$this->oAction = $oAction;
+
+		/** @var Ticket $oTicket */
+		$oTicket = $this->createObject(UserRequest::class, [
+			'org_id' => $this->getTestOrgId(),
+			'title' => 'Houston, got a problem',
+			'description' => 'Test description',
+		]);
+		$this->oTicket = $oTicket;
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+
+		$this->oEvent->DBDelete();
+	}
+
+	public function testDownloadIsTriggeredWhenDownloaderIsNotificationRecipient(): void
+	{
+		$this->oEvent = EventNotificationNewsroomService::MakeEventFromAction(
+			oAction: $this->oAction,
+			iContactId: $this->oContact->GetKey(),
+			iTriggerId: $this->oTrigger->GetKey(),
+			sMessage: 'Test message',
+			sTitle: 'Test event',
+			sUrl: 'https://localhost/itop/pages/UI.php?operation=details&class=UserRequest&id=1',
+			iObjectId: $this->oTicket->GetKey(),
+			sObjectClass: UserRequest::class,
+		);
+		$this->oEvent->DBInsert();
+
+		$oPage = new CaptureWebPage();
+		$bDownloadIcon = EventNotificationNewsroomService::DownloadIcon($oPage, $this->oEvent->GetKey(), $this->oContact->GetKey());
+		$sHtml = $oPage->GetHtml();
+
+		$this->assertTrue($bDownloadIcon);
+		$this->assertNotEquals('', $sHtml);
+	}
+
+	public function testDownloadIsNotTriggeredWhenDownloaderIsNotNotificationRecipient(): void
+	{
+		$oContact = $this->createObject(Person::class, [
+			'name' => 'Doe',
+			'first_name' => 'John',
+			'org_id' => $this->getTestOrgId(),
+		]);
+		$this->oEvent = EventNotificationNewsroomService::MakeEventFromAction(
+			oAction: $this->oAction,
+			iContactId: $oContact->GetKey(),
+			iTriggerId: $this->oTrigger->GetKey(),
+			sMessage: 'Test message',
+			sTitle: 'Test event',
+			sUrl: 'https://localhost/itop/pages/UI.php?operation=details&class=UserRequest&id=1',
+			iObjectId: $this->oTicket->GetKey(),
+			sObjectClass: UserRequest::class,
+		);
+		$this->oEvent->DBInsert();
+
+		$oPage = new CaptureWebPage();
+		$bDownloadIcon = EventNotificationNewsroomService::DownloadIcon($oPage, $this->oEvent->GetKey(), $this->oContact->GetKey());
+		$sHtml = $oPage->GetHtml();
+
+		$this->assertFalse($bDownloadIcon);
+		$this->assertEquals('', $sHtml);
+	}
+}


### PR DESCRIPTION
## Base information

| Question                                                       | Answer 
|----------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | [N°9614](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=9614)                 |
| Type of change?                                                | Bug fix


## Symptom

If an user doesn't have read permissions for the EventNotificationNewsroom class, the associated icons are no longer displayed

## Reproduction procedure (bug)

1. On iTop 3.2.3-1
2. Generate a "news" notification (for example, with a mention in a caselog) for the current user
3. Click on the "News" menu in the main menu
4. Note that the icon for each "news" item doesn't appear
5. Click on "View all messages"
6. Note that the news doesn't display any icons

## Cause

In the iTop 3.2 release, we have added user permission controls for all classes derived from Event (including EventNotificationNewsroom)
By default, the user does not have permission to access the news content; if the ‘news’ icon is stored in this object, attempting to access the "icon" attribute of the news item will automatically block the user

## Proposed solution 

Add a specific route to display the icons for an EventNotificationNewsroom which doesn't perform a rights check specifically for the EventNotificationNewsroom icon

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?