### PR TITLE
:bug: Skip empty result section when accelerator has enable_enlarge=false

### DIFF
--- a/pages/ajax.render.php
+++ b/pages/ajax.render.php
@@ -1423,12 +1423,19 @@ EOF;
 						}
 					} else {
 						if (array_key_exists($sClassName, $aAccelerators)) {
-							$oPage->add("<div class=\"search-class-result search-class-$sClassName\">\n");
-							$oPage->add("<div class=\"page_header\">\n");
-							$oPage->add('<h2 class="ibo-global-search--result--title">'.MetaModel::GetClassIcon($sClassName).Dict::Format('UI:Search:Count_ObjectsOf_Class_Found', 0, Metamodel::GetName($sClassName)).$sEnlargeButton."</h2>\n");
-							$oPage->add("</div>\n");
-							$oPage->add("</div>\n");
-							$oPage->p('&nbsp;'); // Some space ?
+							// Skip the empty result section when enlarge is disabled:
+							// the block has no actionable content (no Enlarge button) and only
+							// adds visual clutter on instances with many accelerators.
+							$bEnlargeEnabled = !array_key_exists('enable_enlarge', $aAccelerators[$sClassName])
+								|| $aAccelerators[$sClassName]['enable_enlarge'] !== false;
+							if ($bEnlargeEnabled) {
+								$oPage->add("<div class=\"search-class-result search-class-$sClassName\">\n");
+								$oPage->add("<div class=\"page_header\">\n");
+								$oPage->add('<h2 class="ibo-global-search--result--title">'.MetaModel::GetClassIcon($sClassName).Dict::Format('UI:Search:Count_ObjectsOf_Class_Found', 0, Metamodel::GetName($sClassName)).$sEnlargeButton."</h2>\n");
+								$oPage->add("</div>\n");
+								$oPage->add("</div>\n");
+								$oPage->p('&nbsp;'); // Some space ?
+							}
 						}
 					}
 					if ($iTune > 0) {


### PR DESCRIPTION
## Summary

Fixes #919.

When `full_text_accelerators` is configured with `enable_enlarge => false` for a class, the global search still rendered an empty "0 result" section for that class. The block contained no actionable content (no Enlarge button, by configuration) and only added visual clutter, especially on instances with several accelerators configured this way.

This PR aligns the rendering with the existing `enable_enlarge` semantic: when the action is explicitly disabled, the empty section is no longer rendered.

## Cause

In `pages/ajax.render.php` (~ line 1424), the empty result block was rendered for every accelerated class regardless of the `enable_enlarge` value. The flag only governed whether the button was shown inside the header, not whether the section itself should appear when there was no match.

## Fix

Wrap the empty-section rendering in a check for `enable_enlarge !== false`. The check defaults to ``enabled`` when the key is absent, preserving the current behavior for any configuration that doesn't opt into the new behavior.

## Compatibility

| `enable_enlarge` | 0 result | N > 0 results |
|---|---|---|
| not set (default) | rendered (unchanged) | rendered (unchanged) |
| `true` | rendered (unchanged) | rendered (unchanged) |
| `false` | **not rendered (this PR)** | rendered (unchanged) |

Strictly opt-in via existing configuration. Only impacts configurations that explicitly set `enable_enlarge => false`, where the current behavior was arguably a bug.

## Test plan

- [x] PHP lint passes on the modified file
- [x] Manual: accelerator with `enable_enlarge => false`, search with no match → empty section no longer appears
- [x] Manual: accelerator with `enable_enlarge => true` (or omitted), search with no match → empty section still appears with the Enlarge button
- [x] Manual: results page with N>0 matches is unchanged in both cases