### PR TITLE
N°9734 - Fix bulk modify timeout on AttributeLinkedSetIndirect

### DIFF
--- a/sources/Core/AttributeDefinition/AttributeDefinition.php
+++ b/sources/Core/AttributeDefinition/AttributeDefinition.php
@@ -373,9 +373,11 @@ abstract class AttributeDefinition
 	 *
 	 * @return bool
 	 * @since 3.1.0 N°3190
-	 *
+	 * @since 3.3.x Changed from static to non-static so that subclasses can decide
+	 *              based on instance-level configuration (e.g. display_style on LinkedSets).
+	 *              Overriding implementations in extensions must drop the `static` modifier.
 	 */
-	public static function IsBulkModifyCompatible(): bool
+	public function IsBulkModifyCompatible(): bool
 	{
 		return static::IsScalar();
 	}

--- a/sources/Core/AttributeDefinition/AttributeLinkedSet.php
+++ b/sources/Core/AttributeDefinition/AttributeLinkedSet.php
@@ -64,7 +64,7 @@ class AttributeLinkedSet extends AttributeDefinition
 	}
 
 	/** @inheritDoc */
-	public static function IsBulkModifyCompatible(): bool
+	public function IsBulkModifyCompatible(): bool
 	{
 		return false;
 	}

--- a/sources/Core/AttributeDefinition/AttributeLinkedSetIndirect.php
+++ b/sources/Core/AttributeDefinition/AttributeLinkedSetIndirect.php
@@ -100,10 +100,18 @@ class AttributeLinkedSetIndirect extends AttributeLinkedSet
 		return $oRet;
 	}
 
-	/** @inheritDoc */
-	public static function IsBulkModifyCompatible(): bool
+	/**
+	 * Bulk modify is only meaningful for the property-style (tagset-like) widget.
+	 * The tab-style widget cannot be rendered inside the bulk modify form, and
+	 * eagerly materialising large indirect link sets for every selected object
+	 * caused timeouts.
+	 *
+	 * @inheritDoc
+	 * @since 3.3.x
+	 */
+	public function IsBulkModifyCompatible(): bool
 	{
-		return true;
+		return $this->GetDisplayStyle() === LINKSET_DISPLAY_STYLE_PROPERTY;
 	}
 
 }

--- a/tests/php-unit-tests/unitary-tests/core/AttributeDefinitionTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/AttributeDefinitionTest.php
@@ -340,4 +340,45 @@ PHP
 		return $oAttribute;
 	}
 
+	/**
+	 * @dataProvider IsBulkModifyCompatibleProvider
+	 * @covers       \AttributeDefinition::IsBulkModifyCompatible
+	 * @covers       \Combodo\iTop\Core\AttributeDefinition\AttributeLinkedSet::IsBulkModifyCompatible
+	 * @covers       \Combodo\iTop\Core\AttributeDefinition\AttributeLinkedSetIndirect::IsBulkModifyCompatible
+	 *
+	 * Regression test for the bulk modify timeout caused by N°3190: indirect link sets
+	 * displayed as a tab (the default) used to declare themselves bulk-modify-compatible,
+	 * triggering eager materialisation of every link for every selected object. The
+	 * predicate must now depend on the instance-level display_style.
+	 */
+	public function testIsBulkModifyCompatible(string $sClass, string $sAttCode, bool $bExpected): void
+	{
+		$oAttDef = MetaModel::GetAttributeDef($sClass, $sAttCode);
+		$this->assertSame(
+			$bExpected,
+			$oAttDef->IsBulkModifyCompatible(),
+			"IsBulkModifyCompatible() mismatch for $sClass::$sAttCode"
+		);
+	}
+
+	public static function IsBulkModifyCompatibleProvider(): array
+	{
+		return [
+			'Scalar attribute (AttributeString)' => [
+				'UserRequest', 'title', true,
+			],
+			'AttributeLinkedSet (1:n) is never bulk compatible' => [
+				'UserRequest', 'workorders_list', false,
+			],
+			'AttributeLinkedSetIndirect with default (tab) display_style' => [
+				// Regression: must be false to avoid the bulk modify timeout
+				'UserRequest', 'contacts_list', false,
+			],
+			'AttributeLinkedSetIndirect with property display_style' => [
+				// Preserves the N°3190 feature (tagset-like inline editor in bulk form)
+				'FunctionalCI', 'groups_list', true,
+			],
+		];
+	}
+
 }


### PR DESCRIPTION
## Base information

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | n/a                                  |
| Type of change?                                                                 | Bug fix                              |

## Symptom (bug)

Bulk-modifying records that contain large `AttributeLinkedSetIndirect` fields times out before the bulk modify form is rendered.

Field report: bulk-modifying 4 `ProviderContract` records with ~5400 linked CIs each (≈21,600 link materialisations + HTML renders per request) reliably exceeds the PHP request timeout. Profiling shows the time is spent inside `DisplayBulkModifyForm()` materialising the indirect link sets of every selected object.

The defect was introduced by [N°3190 commit fb1ceeba](https://github.com/Combodo/iTop/commit/fb1ceebaa481b0ff111a589d6ef47d53e02d9747), which added `AttributeLinkedSetIndirect::IsBulkModifyCompatible()` returning `true` unconditionally to support the new `display_style=property` (tagset-like) widget. The same return value, however, also enables bulk processing for the default tab display style, which is what triggers the timeout.

## Reproduction procedure (bug)

1. On iTop 3.1.x or 3.2.x (any version including the N°3190 fix)
2. With PHP 7.4+ (any supported version)
3. Pick any class with an indirect link set rendered as a tab — e.g. `UserRequest::contacts_list`, or `ProviderContract::functionalcis_list` from a populated dataset. For a reliable reproduction, populate at least 4 objects with ≈5000 links each.
4. List view → select multiple objects → "Other actions" → "Modify all..."
5. Observe: the bulk modify form takes very long to render and eventually triggers a PHP request timeout (HTTP 504 / blank page).

Workaround that confirms the cause: temporarily change `AttributeLinkedSetIndirect::IsBulkModifyCompatible()` to `return false;` — the bulk modify form renders immediately.

## Cause (bug)

`IsBulkModifyCompatible()` is checked in `application/cmdbabstract.class.inc.php::DisplayBulkModifyForm()` for every attribute of every selected object (lines 4544, 4550, 4613):

```php
while ($oObj = $oSet->Fetch()) {
    foreach ($aList as $sAttCode => $oAttDef) {
        if ($oAttDef->IsBulkModifyCompatible() && $oAttDef->IsWritable()) {
            $currValue   = $oObj->Get($sAttCode);              // materialises ormLinkSet
            ...
            $sHtmlValue  = $oAttDef->GetAsHTML($currValue);    // renders the whole widget
            $editValue   = $oAttDef->GetEditValue($currValue, $oObj);
        }
    }
}
```

For tab-style indirect link sets this work is entirely wasted: `cmdbabstract.class.inc.php:2134` and `:4065` already gate the bulk-context rendering path on `LINKSET_DISPLAY_STYLE_PROPERTY`, so a tab-style indirect link set is not editable in the bulk form at all.

`IsBulkModifyCompatible()` is declared `static`, which is why the N°3190 override could not read the per-instance `display_style` XML property. As a consequence the override returns a class-level constant — `true` for all indirect link sets, regardless of the actual rendering mode.

A repository-wide check confirms that all four call sites (`cmdbabstract.class.inc.php:1854, 4544, 4550, 4613`) already use instance dispatch (`\$oAttDef->IsBulkModifyCompatible()`); there is no static caller. The `static` modifier is therefore historical, not load-bearing.

## Proposed solution

Make `IsBulkModifyCompatible()` a regular instance method across the `AttributeDefinition` hierarchy. `AttributeLinkedSetIndirect` then gates on the per-instance `display_style`:

- `sources/Core/AttributeDefinition/AttributeDefinition.php` — drop `static` from the base declaration; document the migration in the docblock.
- `sources/Core/AttributeDefinition/AttributeLinkedSet.php` — drop `static` from the override (return value unchanged: `false`).
- `sources/Core/AttributeDefinition/AttributeLinkedSetIndirect.php` — drop `static`, return `$this->GetDisplayStyle() === LINKSET_DISPLAY_STYLE_PROPERTY`.

The property-style path (the original N°3190 feature) is preserved; the tab-style path is excluded from the bulk form with the "IncompatibleAttribute" notice, matching pre-fb1ceeba behaviour.

**Breaking change for extensions:** overrides of `IsBulkModifyCompatible()` must drop the `static` modifier from the override declaration, otherwise PHP raises a fatal error (`Cannot make non-static method ... static in class ...`). The method is not marked `@api` and is not part of any documented extension API; expected blast radius is small. A note has been added to the base class docblock to document the migration.

## Regression coverage

`tests/php-unit-tests/unitary-tests/core/AttributeDefinitionTest.php::testIsBulkModifyCompatible` (data-provider, 4 cases):

- scalar (`UserRequest::title`) → `true`
- `AttributeLinkedSet` (`UserRequest::workorders_list`) → `false`
- `AttributeLinkedSetIndirect`, default tab style (`UserRequest::contacts_list`) → `false` (regression case)
- `AttributeLinkedSetIndirect`, `display_style=property` (`FunctionalCI::groups_list`) → `true` (preserves N°3190)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?