### PR TITLE
N°9597 - Switch environment to a build environment must not be available

### DIFF
--- a/application/startup.inc.php
+++ b/application/startup.inc.php
@@ -70,7 +70,7 @@ $oKPI->ComputeAndReport("Session Start");
 
 $sSwitchEnv = utils::ReadParam('switch_env', null);
 $bAllowCache = true;
-$sEnv = StartupService::SetItopEnvironment($sSwitchEnv, $bAllowCache);
+$sEnv = (new StartupService())->SetItopEnvironment($sSwitchEnv, $bAllowCache);
 $sConfigFile = APPCONF.$sEnv.'/'.ITOP_CONFIG_FILE;
 try {
 	MetaModel::Startup($sConfigFile, false /* $bModelOnly */, $bAllowCache, false /* $bTraceSourceFiles */, $sEnv);

--- a/application/startup.inc.php
+++ b/application/startup.inc.php
@@ -17,6 +17,7 @@
 //   You should have received a copy of the GNU Affero General Public License
 //   along with iTop. If not, see <http://www.gnu.org/licenses/>
 use Combodo\iTop\Application\Helper\Session;
+use Combodo\iTop\Service\Startup\StartupService;
 
 require_once(APPROOT.'core/cmdbobject.class.inc.php');
 require_once(APPROOT.'application/utils.inc.php');
@@ -69,26 +70,7 @@ $oKPI->ComputeAndReport("Session Start");
 
 $sSwitchEnv = utils::ReadParam('switch_env', null);
 $bAllowCache = true;
-if (($sSwitchEnv != null) && file_exists(APPCONF.$sSwitchEnv.'/'.ITOP_CONFIG_FILE) && (Session::Get('itop_env') !== $sSwitchEnv)) {
-	Session::Set('itop_env', $sSwitchEnv);
-	$sEnv = $sSwitchEnv;
-	$bAllowCache = false;
-	// Reset the opcache since otherwise the PHP "model" files may still be cached !!
-	if (function_exists('opcache_reset')) {
-		// Zend opcode cache
-		opcache_reset();
-	}
-	if (function_exists('apc_clear_cache')) {
-		// APC(u) cache
-		apc_clear_cache();
-	}
-	// TODO: reset the credentials as well ??
-} elseif (Session::IsSet('itop_env')) {
-	$sEnv = Session::Get('itop_env');
-} else {
-	$sEnv = ITOP_DEFAULT_ENV;
-	Session::Set('itop_env', ITOP_DEFAULT_ENV);
-}
+$sEnv = StartupService::SetItopEnvironment($sSwitchEnv, $bAllowCache);
 $sConfigFile = APPCONF.$sEnv.'/'.ITOP_CONFIG_FILE;
 try {
 	MetaModel::Startup($sConfigFile, false /* $bModelOnly */, $bAllowCache, false /* $bTraceSourceFiles */, $sEnv);

--- a/lib/composer/autoload_classmap.php
+++ b/lib/composer/autoload_classmap.php
@@ -638,6 +638,7 @@ return array(
     'Combodo\\iTop\\Service\\Router\\Exception\\RouteNotFoundException' => $baseDir . '/sources/Service/Router/Exception/RouteNotFoundException.php',
     'Combodo\\iTop\\Service\\Router\\Exception\\RouterException' => $baseDir . '/sources/Service/Router/Exception/RouterException.php',
     'Combodo\\iTop\\Service\\Router\\Router' => $baseDir . '/sources/Service/Router/Router.php',
+    'Combodo\\iTop\\Service\\Startup\\StartupService' => $baseDir . '/sources/Service/Startup/StartupService.php',
     'Combodo\\iTop\\Service\\SummaryCard\\SummaryCardService' => $baseDir . '/sources/Service/SummaryCard/SummaryCardService.php',
     'Combodo\\iTop\\Service\\TemporaryObjects\\TemporaryObjectConfig' => $baseDir . '/sources/Service/TemporaryObjects/TemporaryObjectConfig.php',
     'Combodo\\iTop\\Service\\TemporaryObjects\\TemporaryObjectGC' => $baseDir . '/sources/Service/TemporaryObjects/TemporaryObjectGC.php',

--- a/lib/composer/autoload_static.php
+++ b/lib/composer/autoload_static.php
@@ -1039,6 +1039,7 @@ class ComposerStaticInitfc0e9e9dea11dcbb6272414776c30685
         'Combodo\\iTop\\Service\\Router\\Exception\\RouteNotFoundException' => __DIR__ . '/../..' . '/sources/Service/Router/Exception/RouteNotFoundException.php',
         'Combodo\\iTop\\Service\\Router\\Exception\\RouterException' => __DIR__ . '/../..' . '/sources/Service/Router/Exception/RouterException.php',
         'Combodo\\iTop\\Service\\Router\\Router' => __DIR__ . '/../..' . '/sources/Service/Router/Router.php',
+        'Combodo\\iTop\\Service\\Startup\\StartupService' => __DIR__ . '/../..' . '/sources/Service/Startup/StartupService.php',
         'Combodo\\iTop\\Service\\SummaryCard\\SummaryCardService' => __DIR__ . '/../..' . '/sources/Service/SummaryCard/SummaryCardService.php',
         'Combodo\\iTop\\Service\\TemporaryObjects\\TemporaryObjectConfig' => __DIR__ . '/../..' . '/sources/Service/TemporaryObjects/TemporaryObjectConfig.php',
         'Combodo\\iTop\\Service\\TemporaryObjects\\TemporaryObjectGC' => __DIR__ . '/../..' . '/sources/Service/TemporaryObjects/TemporaryObjectGC.php',

--- a/sources/Service/Startup/StartupService.php
+++ b/sources/Service/Startup/StartupService.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Combodo\iTop\Service\Startup;
+
+use Combodo\iTop\Application\Helper\Session;
+use CoreException;
+use IssueLog;
+
+class StartupService
+{
+	/**
+	 * @param string|null $sSwitchEnv
+	 * @param bool $bAllowCache
+	 *
+	 * @return string
+	 * @throws CoreException
+	 */
+	public static function SetItopEnvironment(?string $sSwitchEnv, bool &$bAllowCache): string
+	{
+		if (static::IsBuildEnvironment($sSwitchEnv)) {
+			$oException = new CoreException("Switching to environment '$sSwitchEnv' is not allowed since it is a build environment");
+			IssueLog::Exception("Trying to switch to environment '$sSwitchEnv' is not allowed since it is a build environment", $oException);
+			throw $oException;
+		}
+
+		if (
+			($sSwitchEnv != null)
+			&& file_exists(APPCONF.$sSwitchEnv.'/'.ITOP_CONFIG_FILE)
+			&& (Session::Get('itop_env') !== $sSwitchEnv)
+		) {
+			Session::Set('itop_env', $sSwitchEnv);
+			$sEnv = $sSwitchEnv;
+			$bAllowCache = false;
+			// Reset the opcache since otherwise the PHP "model" files may still be cached !!
+			if (function_exists('opcache_reset')) {
+				// Zend opcode cache
+				opcache_reset();
+			}
+			if (function_exists('apc_clear_cache')) {
+				// APC(u) cache
+				apc_clear_cache();
+			}
+			// TODO: reset the credentials as well ??
+		} elseif (Session::IsSet('itop_env')) {
+			$sEnv = Session::Get('itop_env');
+		} else {
+			$sEnv = ITOP_DEFAULT_ENV;
+			Session::Set('itop_env', ITOP_DEFAULT_ENV);
+		}
+
+		return $sEnv;
+	}
+
+	public static function IsBuildEnvironment(?string $sEnv): bool
+	{
+		return $sEnv != null && str_ends_with($sEnv, '-build');
+	}
+}

--- a/sources/Service/Startup/StartupService.php
+++ b/sources/Service/Startup/StartupService.php
@@ -10,14 +10,14 @@ class StartupService
 {
 	/**
 	 * @param string|null $sSwitchEnv
-	 * @param bool $bAllowCache
+	 * @param bool $bAllowCache - whether to allow cache or not (will be set to false if the environment is switched)
 	 *
 	 * @return string
 	 * @throws CoreException
 	 */
-	public static function SetItopEnvironment(?string $sSwitchEnv, bool &$bAllowCache): string
+	public function SetItopEnvironment(?string $sSwitchEnv, bool &$bAllowCache): string
 	{
-		if (static::IsBuildEnvironment($sSwitchEnv)) {
+		if ($this->IsBuildEnvironment($sSwitchEnv)) {
 			$oException = new CoreException("Switching to environment '$sSwitchEnv' is not allowed since it is a build environment");
 			IssueLog::Exception("Trying to switch to environment '$sSwitchEnv' is not allowed since it is a build environment", $oException);
 			throw $oException;
@@ -51,7 +51,7 @@ class StartupService
 		return $sEnv;
 	}
 
-	public static function IsBuildEnvironment(?string $sEnv): bool
+	public function IsBuildEnvironment(?string $sEnv): bool
 	{
 		return $sEnv != null && str_ends_with($sEnv, '-build');
 	}

--- a/tests/php-unit-tests/unitary-tests/sources/Service/Startup/StartupServiceTest.php
+++ b/tests/php-unit-tests/unitary-tests/sources/Service/Startup/StartupServiceTest.php
@@ -8,16 +8,19 @@ use CoreException;
 
 class StartupServiceTest extends ItopTestCase
 {
+	private StartupService $oStartupService;
+
 	protected function setUp(): void
 	{
 		parent::setUp();
 		$this->RequireOnceItopFile('application/utils.inc.php');
+		$this->oStartupService = new StartupService();
 	}
 
 	public function testSetItopEnvironmentUsesDefaultWhenEnvironmentIsNull(): void
 	{
 		$bAllowCache = true;
-		$sEnv = StartupService::SetItopEnvironment(null, $bAllowCache);
+		$sEnv = $this->oStartupService->SetItopEnvironment(null, $bAllowCache);
 		$this->assertEquals(ITOP_DEFAULT_ENV, $sEnv);
 		$this->assertTrue($bAllowCache);
 	}
@@ -25,7 +28,7 @@ class StartupServiceTest extends ItopTestCase
 	public function testSetItopEnvironmentWithValidEnvironment(): void
 	{
 		$bAllowCache = true;
-		$sEnv = StartupService::SetItopEnvironment('test', $bAllowCache);
+		$sEnv =  $this->oStartupService->SetItopEnvironment('test', $bAllowCache);
 		$this->assertEquals('test', $sEnv);
 		$this->assertFalse($bAllowCache);
 	}
@@ -35,13 +38,13 @@ class StartupServiceTest extends ItopTestCase
 		$bAllowCache = true;
 		$this->expectException(CoreException::class);
 		$this->expectExceptionMessage("Switching to environment 'test-build' is not allowed since it is a build environment");
-		StartupService::SetItopEnvironment('test-build', $bAllowCache);
+		$this->oStartupService->SetItopEnvironment('test-build', $bAllowCache);
 	}
 
 	public function testIsBuildEnvironment()
 	{
-		$this->assertTrue(StartupService::IsBuildEnvironment('test-build'));
-		$this->assertFalse(StartupService::IsBuildEnvironment('test'));
-		$this->assertFalse(StartupService::IsBuildEnvironment(null));
+		$this->assertTrue($this->oStartupService->IsBuildEnvironment('test-build'));
+		$this->assertFalse($this->oStartupService->IsBuildEnvironment('test'));
+		$this->assertFalse($this->oStartupService->IsBuildEnvironment(null));
 	}
 }

--- a/tests/php-unit-tests/unitary-tests/sources/Service/Startup/StartupServiceTest.php
+++ b/tests/php-unit-tests/unitary-tests/sources/Service/Startup/StartupServiceTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Service\Startup;
+
+use Combodo\iTop\Service\Startup\StartupService;
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+use CoreException;
+
+class StartupServiceTest extends ItopTestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->RequireOnceItopFile('application/utils.inc.php');
+	}
+
+	public function testSetItopEnvironmentUsesDefaultWhenEnvironmentIsNull(): void
+	{
+		$bAllowCache = true;
+		$sEnv = StartupService::SetItopEnvironment(null, $bAllowCache);
+		$this->assertEquals(ITOP_DEFAULT_ENV, $sEnv);
+		$this->assertTrue($bAllowCache);
+	}
+
+	public function testSetItopEnvironmentWithValidEnvironment(): void
+	{
+		$bAllowCache = true;
+		$sEnv = StartupService::SetItopEnvironment('test', $bAllowCache);
+		$this->assertEquals('test', $sEnv);
+		$this->assertFalse($bAllowCache);
+	}
+
+	public function testSetItopEnvironmentThrowsForBuildEnvironment()
+	{
+		$bAllowCache = true;
+		$this->expectException(CoreException::class);
+		$this->expectExceptionMessage("Switching to environment 'test-build' is not allowed since it is a build environment");
+		StartupService::SetItopEnvironment('test-build', $bAllowCache);
+	}
+
+	public function testIsBuildEnvironment()
+	{
+		$this->assertTrue(StartupService::IsBuildEnvironment('test-build'));
+		$this->assertFalse(StartupService::IsBuildEnvironment('test'));
+		$this->assertFalse(StartupService::IsBuildEnvironment(null));
+	}
+}


### PR DESCRIPTION
## Base information

| Question                                                       | Answer 
|----------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | [N°9597](https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=9597)                 |
| Type of change?                                                | Bug fix

## Symptom

When checking compatibility during setup, a build environment is created. It should not be possible to switch to this environment via the system

## Proposed solution

Add an exception if the target environment of `switch_env` ends with `*-build`

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?