### PR TITLE
N°9687 - Fix incorrect return type for the DBObjectSearch::ApplyDataFilter() function

### DIFF
--- a/core/dbobjectsearch.class.php
+++ b/core/dbobjectsearch.class.php
@@ -1928,9 +1928,8 @@ class DBObjectSearch extends DBSearch
 
 	/**
 	 * @inheritDoc
-	 * @return DBObjectSearch
 	 */
-	protected function ApplyDataFilters(): DBObjectSearch
+	protected function ApplyDataFilters(): DBSearch
 	{
 		if ($this->IsAllDataAllowed() || $this->IsDataFiltered()) {
 			return $this;

--- a/core/dbunionsearch.class.php
+++ b/core/dbunionsearch.class.php
@@ -676,9 +676,8 @@ class DBUnionSearch extends DBSearch
 
 	/**
 	 * @inheritDoc
-	 * @return DBUnionSearch
 	 */
-	protected function ApplyDataFilters(): DBUnionSearch
+	protected function ApplyDataFilters(): DBSearch
 	{
 		if ($this->IsAllDataAllowed() || $this->IsDataFiltered()) {
 			return $this;

--- a/tests/php-unit-tests/unitary-tests/core/DBSearch/DBSearchApplyDataFiltersTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBSearch/DBSearchApplyDataFiltersTest.php
@@ -29,6 +29,7 @@ class DBSearchApplyDataFiltersTest extends ItopDataTestCase
 	public function testApplyDataFiltersOnDBObjectSearchShouldAcceptGetSelectFilterClassReturningDBUnionSearch()
 	{
 		// Use custom select filter that returns a DBUnionSearch
+		$sPreviousSelectModuleClass = get_class(UserRights::GetModuleInstance());
 		UserRights::SelectModule('\\Combodo\\iTop\\Test\\UnitTest\\Core\\Fixtures\\N9687_CustomGetSelectFilterClass');
 
 		// Create a user and login, otherwise the select filter won't apply
@@ -41,6 +42,9 @@ class DBSearchApplyDataFiltersTest extends ItopDataTestCase
 		// Try to retrieve it using the select filter
 		$oSearch = DBObjectSearch::FromOQL("SELECT Person WHERE id = {$oCreatedPerson->GetKey()}");
 		$oFilteredSearch = $this->InvokeNonPublicMethod(DBObjectSearch::class, 'ApplyDataFilters', $oSearch);
+
+		// Restore original select module to not interfere with next tests
+		UserRights::SelectModule($sPreviousSelectModuleClass);
 
 		$this->assertEquals(DBUnionSearch::class, get_class($oFilteredSearch), "DBObjectSearch::ApplyDataFilters() should be able to return a \DBUnionSearch");
 	}

--- a/tests/php-unit-tests/unitary-tests/core/DBSearch/DBSearchApplyDataFiltersTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBSearch/DBSearchApplyDataFiltersTest.php
@@ -16,6 +16,8 @@ class DBSearchApplyDataFiltersTest extends ItopDataTestCase
 {
 	public const CREATE_TEST_ORG = true;
 
+	protected string $sOriginalUserRightsSelectModuleClass = '';
+
 	/**
 	 * @throws \Exception
 	 */
@@ -23,7 +25,21 @@ class DBSearchApplyDataFiltersTest extends ItopDataTestCase
 	{
 		parent::setUp();
 
+		// Backup original UserRights select module as it will changed in some tests
+		$this->sOriginalUserRightsSelectModuleClass = get_class(UserRights::GetModuleInstance());
+
 		$this->RequireOnceUnitTestFile('Fixtures/N9687_CustomGetSelectFilterClass.php');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function tearDown(): void
+	{
+		// Restore original UserRights select module to not interfere with next tests
+		UserRights::SelectModule($this->sOriginalUserRightsSelectModuleClass);
+
+		parent::tearDown();
 	}
 
 	public function testApplyDataFiltersOnDBObjectSearchShouldAcceptGetSelectFilterClassReturningDBUnionSearch()

--- a/tests/php-unit-tests/unitary-tests/core/DBSearch/DBSearchApplyDataFiltersTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBSearch/DBSearchApplyDataFiltersTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * @copyright   Copyright (C) 2010-2026 Combodo SAS
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\Test\UnitTest\Core;
+
+use Combodo\iTop\Test\UnitTest\ItopDataTestCase;
+use DBObjectSearch;
+use DBUnionSearch;
+use UserRights;
+
+class DBSearchApplyDataFiltersTest extends ItopDataTestCase
+{
+	public const CREATE_TEST_ORG = true;
+
+	/**
+	 * @throws \Exception
+	 */
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->RequireOnceUnitTestFile('Fixtures/N9687_CustomGetSelectFilterClass.php');
+	}
+
+	public function testApplyDataFiltersOnDBObjectSearchShouldAcceptGetSelectFilterClassReturningDBUnionSearch()
+	{
+		// Use custom select filter that returns a DBUnionSearch
+		UserRights::SelectModule('\\Combodo\\iTop\\Test\\UnitTest\\Core\\Fixtures\\N9687_CustomGetSelectFilterClass');
+
+		// Create a user and login, otherwise the select filter won't apply
+		self::CreateUser('test_dbsearch_applydatafilters', 3);
+		UserRights::Login('test_dbsearch_applydatafilters');
+
+		// Create a person
+		$oCreatedPerson = $this->CreatePerson(microtime());
+
+		// Try to retrieve it using the select filter
+		$oSearch = DBObjectSearch::FromOQL("SELECT Person WHERE id = {$oCreatedPerson->GetKey()}");
+		$oFilteredSearch = $this->InvokeNonPublicMethod(DBObjectSearch::class, 'ApplyDataFilters', $oSearch);
+
+		$this->assertEquals(DBUnionSearch::class, get_class($oFilteredSearch), "DBObjectSearch::ApplyDataFilters() should be able to return a \DBUnionSearch");
+	}
+}

--- a/tests/php-unit-tests/unitary-tests/core/DBSearch/Fixtures/N9687_CustomGetSelectFilterClass.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBSearch/Fixtures/N9687_CustomGetSelectFilterClass.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * @copyright   Copyright (C) 2010-2026 Combodo SAS
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\Test\UnitTest\Core\Fixtures;
+
+use DBObjectSearch;
+use DBUnionSearch;
+use UserRightsProfile;
+
+class N9687_CustomGetSelectFilterClass extends UserRightsProfile
+{
+	public function GetSelectFilter($oUser, $sClass, $aSettings = [])
+	{
+		// We just need the method to return an union search
+		return new DBUnionSearch([
+			DBObjectSearch::FromOQL("SELECT $sClass WHERE 1!=2"),
+			DBObjectSearch::FromOQL("SELECT $sClass WHERE 1=1"),
+		]);
+	}
+}


### PR DESCRIPTION
## Base information

| Question                                                       | Answer 
|----------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | N°9687                 |
| Type of change?                                                | Bug fix |

## Symptom (bug)

Fatal error when accessing the backoffice with a non-admin user.

```
2026-06-15 09:54:55 | Error   | 3     | Uncaught TypeError: DBObjectSearch::ApplyDataFilters(): Return value must be of type DBObjectSearch, DBUnionSearch returned in /var/www/php8.1/pro322-1/core/dbobjectsearch.class.php:1960
Stack trace:
#0 /var/www/php8.1/pro322-1/core/dbsearch.class.php(1125): DBObjectSearch->ApplyDataFilters()
#1 /var/www/php8.1/pro322-1/core/dbsearch.class.php(1039): DBSearch->GetSQLQuery()
#2 /var/www/php8.1/pro322-1/core/metamodel.class.php(6181): DBSearch->MakeSelectQuery()
#3 /var/www/php8.1/pro322-1/core/metamodel.class.php(6368): MetaModel::MakeSingleRow()
#4 /var/www/php8.1/pro322-1/core/metamodel.class.php(6281): MetaModel::GetObjectWithArchive()
#5 /var/www/php8.1/pro322-1/core/userrights.class.inc.php(334): MetaModel::GetObject()
#6 /var/www/php8.1/pro322-1/core/userrights.class.inc.php(1336): User->GetContactObject()
#7 /var/www/php8.1/pro322-1/core/userrights.class.inc.php(1280): UserRights::GetContactObject()
#8 /var/www/php8.1/pro322-1/sources/Application/UI/Base/Layout/NavigationMenu/NavigationMenu.php(476): UserRights::GetContactOrganizationFriendlyname()
#9 /var/www/php8.1/pro322-1/sources/Application/UI/Base/Layout/NavigationMenu/NavigationMenu.php(130): Combodo\iTop\Application\UI\Base\Layout\NavigationMenu\NavigationMenu->ComputeUserData()
#10 /var/www/php8.1/pro322-1/sources/Application/UI/Base/Layout/NavigationMenu/NavigationMenuFactory.php(59): Combodo\iTop\Application\UI\Base\Layout\NavigationMenu\NavigationMenu->__construct()
#11 /var/www/php8.1/pro322-1/sources/Application/WebPage/iTopWebPage.php(149): Combodo\iTop\Application\UI\Base\Layout\NavigationMenu\NavigationMenuFactory::MakeStandard()
#12 /var/www/php8.1/pro322-1/pages/UI.php(267): Combodo\iTop\Application\WebPage\iTopWebPage->__construct()
#13 {main}
 thrown | IssueLog |||
array (
 'type' => 1,
 'file' => '/var/www/php8.1/pro322-1/core/dbobjectsearch.class.php',
 'line' => 1960,
)
```

## Reproduction procedure (bug)

1. On iTop 3.2.3-1
3. The XML delta below
4. A user with Support agent profile and allowed organizations
5. Log in the backoffice
6. Try to create a ticket

## Cause (bug)

Fix a fatal type mismatch in data filtering when user rights filters return a union search.

`DBObjectSearch::ApplyDataFilters()` is currently typed to return `DBObjectSearch`, but in some valid scenarios (custom rights profile / team silos), filters return `DBUnionSearch`.  
This causes a runtime `TypeError` and breaks login, impersonation, and some non-admin actions (for example ticket creation).

## Proposed solution (bug and enhancement)

The fix is to broaden the return type from `DBObjectSearch` to `DBSearch`, which matches actual behavior and accepted filter outputs.

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand without digging in the code?