### PR TITLE
 N°9723 - IsActionAllowed should work with non instantiated users objects

### DIFF
--- a/addons/userrights/userrightsprofile.class.inc.php
+++ b/addons/userrights/userrightsprofile.class.inc.php
@@ -582,16 +582,26 @@ class UserRightsProfile extends UserRightsAddOnAPI
 	 */
 	public function ListProfiles($oUser)
 	{
-		$aRet = [];
-		$oSearch = new DBObjectSearch('URP_UserProfile');
-		$oSearch->AllowAllData();
-		$oSearch->NoContextParameters();
-		$oSearch->Addcondition('userid', $oUser->GetKey(), '=');
-		$oProfiles = new DBObjectSet($oSearch);
-		while ($oUserProfile = $oProfiles->Fetch()) {
-			$aRet[$oUserProfile->Get('profileid')] = $oUserProfile->Get('profileid_friendlyname');
+		if (count($oUser->ListChanges()) === 0) { // backward compatibility
+			$aRet = [];
+			$oSearch = new DBObjectSearch('URP_UserProfile');
+			$oSearch->AllowAllData();
+			$oSearch->NoContextParameters();
+			$oSearch->Addcondition('userid', $oUser->GetKey(), '=');
+			$oProfiles = new DBObjectSet($oSearch);
+			while ($oUserProfile = $oProfiles->Fetch()) {
+				$aRet[$oUserProfile->Get('profileid')] = $oUserProfile->Get('profileid_friendlyname');
+			}
+
+			return $aRet;
+		} else {
+			$aRet = [];
+			$oProfilesSet = $oUser->Get('profile_list');
+			foreach ($oProfilesSet as $oUserProfile) {
+				$aRet[$oUserProfile->Get('profileid')] = $oUserProfile->Get('profileid_friendlyname');
+			}
+			return $aRet;
 		}
-		return $aRet;
 	}
 
 	public function GetSelectFilter($oUser, $sClass, $aSettings = [])
@@ -705,26 +715,23 @@ class UserRightsProfile extends UserRightsAddOnAPI
 	protected function GetUserActionGrant($oUser, $sClass, $iActionCode)
 	{
 		$this->LoadCache();
-
-		// load and cache permissions for the current user on the given class
-		//
-		$iUser = $oUser->GetKey();
-		if (isset($this->m_aObjectActionGrants[$iUser][$sClass][$iActionCode])) {
-			$aTest = $this->m_aObjectActionGrants[$iUser][$sClass][$iActionCode];
-			if (is_array($aTest)) {
-				return $aTest;
+		if (count($oUser->ListChanges()) === 0) {
+			// load and cache permissions for the current user on the given class
+			if (isset($this->m_aObjectActionGrants[$oUser->GetKey()][$sClass][$iActionCode])) {
+				$aTest = $this->m_aObjectActionGrants[$oUser->GetKey()][$sClass][$iActionCode];
+				if (is_array($aTest)) {
+					return $aTest;
+				}
 			}
 		}
 
 		$sAction = self::$m_aActionCodes[$iActionCode];
 
 		$bStatus = null;
-		// Cache user's profiles
-		if (false === array_key_exists($iUser, $this->aUsersProfilesList)) {
-			$this->aUsersProfilesList[$iUser] = UserRights::ListProfiles($oUser);
-		}
+
+		$aProfileList = $this->GetProfileList($oUser);
 		// Call the API of UserRights because it caches the list for us
-		foreach ($this->aUsersProfilesList[$iUser] as $iProfile => $oProfile) {
+		foreach ($aProfileList as $iProfile => $oProfile) {
 			$bGrant = $this->GetProfileActionGrant($iProfile, $sClass, $sAction);
 			if (!is_null($bGrant)) {
 				if ($bGrant) {
@@ -742,7 +749,9 @@ class UserRightsProfile extends UserRightsAddOnAPI
 		$aRes = [
 			'permission' => $iPermission,
 		];
-		$this->m_aObjectActionGrants[$iUser][$sClass][$iActionCode] = $aRes;
+		if (count($oUser->ListChanges()) === 0) {
+			$this->m_aObjectActionGrants[$oUser->GetKey()][$sClass][$iActionCode] = $aRes;
+		}
 		return $aRes;
 	}
 
@@ -824,18 +833,14 @@ class UserRightsProfile extends UserRightsAddOnAPI
 	{
 		$this->LoadCache();
 		// Note: this code is VERY close to the code of IsActionAllowed()
-		$iUser = $oUser->GetKey();
 
-		// Cache user's profiles
-		if (false === array_key_exists($iUser, $this->aUsersProfilesList)) {
-			$this->aUsersProfilesList[$iUser] = UserRights::ListProfiles($oUser);
-		}
+		$aProfileList  = $this->GetProfileList($oUser);
 
 		// Note: The object set is ignored because it was interesting to optimize for huge data sets
 		//       and acceptable to consider only the root class of the object set
 		$bStatus = null;
 		// Call the API of UserRights because it caches the list for us
-		foreach ($this->aUsersProfilesList[$iUser] as $iProfile => $oProfile) {
+		foreach ($aProfileList as $iProfile => $oProfile) {
 			$bGrant = $this->GetClassStimulusGrant($iProfile, $sClass, $sStimulusCode);
 			if (!is_null($bGrant)) {
 				if ($bGrant) {
@@ -892,6 +897,25 @@ class UserRightsProfile extends UserRightsAddOnAPI
 			$bHasSharing = class_exists('SharedObject');
 		}
 		return $bHasSharing;
+	}
+
+	/**
+	 * @param \User $oUser
+	 *
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function GetProfileList(User $oUser): array
+	{
+		if (count($oUser->ListChanges()) === 0) { // if user is already in db and not changed
+			$iUser = $oUser->GetKey();
+			if (false === array_key_exists($iUser, $this->aUsersProfilesList)) {
+				$aProfiles = UserRights::ListProfiles($oUser);
+				$this->aUsersProfilesList[$iUser] = $aProfiles;
+			}
+			return $this->aUsersProfilesList[$iUser];
+		}
+		return UserRights::ListProfiles($oUser);
 	}
 }
 

--- a/tests/php-unit-tests/unitary-tests/core/UserRightsTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/UserRightsTest.php
@@ -81,6 +81,16 @@ class UserRightsTest extends ItopDataTestCase
 		return $oUser;
 	}
 
+	public function testReadOnlyUserObject()
+	{
+		$oUser = $this->GivenUserWithProfiles('test1', [3]); // not a readonly profile
+		$oAdminUser = $this->GivenUserWithProfiles('test2', [1]);
+		$oAdminUser->DBInsert();
+		$_SESSION = [];
+		UserRights::Login($oAdminUser->Get('login'));
+
+		self::assertTrue(UserRights::IsActionAllowed('Server', UR_ACTION_MODIFY, null, $oUser) === UR_ALLOWED_YES);
+	}
 	protected function GivenUserWithProfiles(string $sLogin, array $aProfileIds): DBObject
 	{
 		$oProfiles = new \ormLinkSet(\UserLocal::class, 'profile_list', \DBObjectSet::FromScratch(\URP_UserProfile::class));

--- a/tests/php-unit-tests/unitary-tests/core/UserRightsTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/UserRightsTest.php
@@ -81,10 +81,10 @@ class UserRightsTest extends ItopDataTestCase
 		return $oUser;
 	}
 
-	public function testReadOnlyUserObject()
+	public function testIsActionAllowedWithNonInstantiatedUserObject()
 	{
-		$oUser = $this->GivenUserWithProfiles('test1', [3]); // not a readonly profile
-		$oAdminUser = $this->GivenUserWithProfiles('test2', [1]);
+		$oUser = $this->GivenUserWithProfiles('test1', [self::$aURP_Profiles['Configuration Manager']]); // not a readonly profile
+		$oAdminUser = $this->GivenUserWithProfiles('test2', [self::$aURP_Profiles['Administrator']]);
 		$oAdminUser->DBInsert();
 		$_SESSION = [];
 		UserRights::Login($oAdminUser->Get('login'));


### PR DESCRIPTION
## Base information

| Question                                                       | Answer 
|----------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | N°9723              |
| Type of change?                                                | Bug fix / Enhancement / Translations

## Symptom (bug) / Objective (enhancement)

The method for calculating permissions (on which the permission's matrix is based) works only on user objects that are instantiated in the database.

This should not be necessary, but it causes a blockage when calculating permissions on non-instantiated user objects.

The method needs to be improved or corrected so that it can calculate the permissions of a non-instantiated user object.

## Reproduction procedure

With iTop 3.2.3, on PHP 8.3, try to compute user permission (with UserRights::IsActionAllowed) on a non instantiated User objects, and see that the method returns wrong values.
See related test case to reproduce the issue (the added test doesn't work with current state of iTop but works with the fix)

## Cause

Methods relies on user key, which can not exist if user is not existing yet.

## Proposed solution (bug and enhancement)

Replace part of code that relies on user key by methods that do equivalent actions (e.g. get profile list of a user object).

## Checklist before requesting a review

<!--
Don't remove these lines, check them once done.
-->

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?