### PR TITLE
N°9699 - Enable AddMeToContact without write access on Ticket

### DIFF
--- a/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
+++ b/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
@@ -340,7 +340,8 @@
             foreach ($oContactsSet as $oLnk) {
                 if ($oLnk->Get('contact_id') == $iPersonId) {
                     $oLnk->DBDelete();
-                }
+                    return;
+               }
             }
         }
 	  }]]></code>

--- a/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
+++ b/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
@@ -300,7 +300,7 @@
             *
             * Add the current contact associated Person to the contacts_list of this Ticket
             * No error if there is no associated Person or if the Person is already in the list
-            * @return bool Return true on success
+            * @return bool Return true if link was created, false otherwise
             */
           </comment>
           <static>false</static>
@@ -314,12 +314,11 @@
                 $oLnk = MetaModel::NewObject('lnkContactToTicket');
                 $oLnk->Set('contact_id', $iPersonId);
                 $oLnk->Set('ticket_id', $this->GetKey());
-                $oContactsSet->AddItem($oLnk);
-                $this->Set('contacts_list', $oContactsSet);
-                $this->DBUpdate();
+                $oLnk->DBInsert();
+                return true;
             }
 	      }
-		    return true;
+	      return false;
 	  }]]></code>
           <arguments/>
         </method>
@@ -328,7 +327,7 @@
             *
             * Remove the current user associated Person from the contacts_list of this Ticket
             * No error if there is no associated Person or if the Person is not in the list
-            * @return bool Return true
+            * @return bool Return true if link was deleted, false otherwise
             */
           </comment>
           <static>false</static>
@@ -340,14 +339,12 @@
             $oContactsSet = $this->Get('contacts_list');
             foreach ($oContactsSet as $oLnk) {
                 if ($oLnk->Get('contact_id') == $iPersonId) {
-                    $oContactsSet->RemoveItem($oLnk->GetKey());
-                    $this->Set('contacts_list', $oContactsSet);
-                    $this->DBUpdate();
+                    $oLnk->DBDelete();
                     return true;
                 }
             }
         }
-      return true;
+        return false;
 	  }]]></code>
           <arguments/>
         </method>

--- a/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
+++ b/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
@@ -299,8 +299,9 @@
           <comment>/**
             *
             * Add the current contact associated Person to the contacts_list of this Ticket
-            * No error if there is no associated Person or if the Person is already in the list
-            * @return bool Return true if link was created, false otherwise
+            * Must be called while the Ticket is not under modification by the current user
+            * Can fail if the person was linked to the Ticket by another user since the Ticket was last loaded by the current user (concurrent access)
+            * @return void
             */
           </comment>
           <static>false</static>
@@ -315,10 +316,8 @@
                 $oLnk->Set('contact_id', $iPersonId);
                 $oLnk->Set('ticket_id', $this->GetKey());
                 $oLnk->DBInsert();
-                return true;
             }
 	      }
-	      return false;
 	  }]]></code>
           <arguments/>
         </method>
@@ -326,8 +325,9 @@
           <comment>/**
             *
             * Remove the current user associated Person from the contacts_list of this Ticket
-            * No error if there is no associated Person or if the Person is not in the list
-            * @return bool Return true if link was deleted, false otherwise
+            * Must be called while the Ticket is not under modification by the current user
+            * Can fail if the person was removed from the Ticket by another user since the Ticket was last loaded by the current user (concurrent access)
+            * @return void
             */
           </comment>
           <static>false</static>
@@ -340,11 +340,9 @@
             foreach ($oContactsSet as $oLnk) {
                 if ($oLnk->Get('contact_id') == $iPersonId) {
                     $oLnk->DBDelete();
-                    return true;
                 }
             }
         }
-        return false;
 	  }]]></code>
           <arguments/>
         </method>

--- a/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
+++ b/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
@@ -295,7 +295,7 @@
         }
         ]]></code>
         </method>
-        <method id="AddCurrentUserToContacts" _revision_id="294">
+        <method id="AddCurrentUserToContacts">
           <comment>/**
             *
             * Add the current contact associated Person to the contacts_list of this Ticket
@@ -321,7 +321,7 @@
 	  }]]></code>
           <arguments/>
         </method>
-        <method id="RemoveCurrentUserFromContacts" _revision_id="296">
+        <method id="RemoveCurrentUserFromContacts">
           <comment>/**
             *
             * Remove the current user associated Person from the contacts_list of this Ticket


### PR DESCRIPTION
## Base information

| Question                                                       | Answer 
|----------------------------------------------------------------|--------
| Related to a Combodo ticket? | N°9699                 |
| Type of change?                                                | Enhancement 

## Symptom (bug) / Objective (enhancement)

A User which cannot edit Ticket, but can edit Person, such as a Configuration Manager, currently cannot add himself to a Ticket using an Hyperlink Configurator action available on iTop Products

## Proposed solution (bug and enhancement)

Stop modifying the Ticket, but directly create or delete the link object

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?