### PR TITLE
N°9628 - Fix issue following 5b9e0a1d being applied to non-jQuery elements

### DIFF
--- a/datamodels/2.x/itop-oauth-client/assets/js/oauth_connect.js
+++ b/datamodels/2.x/itop-oauth-client/assets/js/oauth_connect.js
@@ -50,13 +50,13 @@ const oOpenSignInWindow = function (url, name) {
 		 then we load it in the already opened secondary window, and then
 		 we bring such window back on top/in front of its parent window. */
 		oWindowObjectReference = window.open(url, name, sWindowFeatures);
-		oWindowObjectReference.trigger('focus');
+        oWindowObjectReference.focus();
 	} else {
 		/* Else the window reference must exist and the window
 		 is not closed; therefore, we can bring it back on top of any other
 		 window with the focus() method. There would be no need to re-create
 		 the window or to reload the referenced resource. */
-		oWindowObjectReference.trigger('focus');
+        oWindowObjectReference.focus();
 	}
 	/* Let know every second our child window that we're waiting for it to complete,
 	once we reach our landing page, it'll send us a reply

--- a/js/ckeditor.handler.js
+++ b/js/ckeditor.handler.js
@@ -58,11 +58,11 @@ const CombodoCKEditorHandler = {
 				// Adjust size if passed in configuration
 				// - Width
 				if (aConfiguration.width !== undefined) {
-					editor.editing.view.on('change', writer => { writer.setStyle( 'width', aConfiguration.width, editor.editing.view.document.getRoot() ); } );
+                    editor.editing.view.change( writer => { writer.setStyle( 'width', aConfiguration.width, editor.editing.view.document.getRoot() ); } );
 				}
 				// - Height
 				if (aConfiguration.height !== undefined) {
-					editor.editing.view.on('change',  writer => { writer.setStyle( 'height', aConfiguration.height, editor.editing.view.document.getRoot() ); } );
+                    editor.editing.view.change( writer => { writer.setStyle( 'height', aConfiguration.height, editor.editing.view.document.getRoot() ); } );
 				}
 
 				this.instances[sElem] = editor;

--- a/pages/UniversalSearch.php
+++ b/pages/UniversalSearch.php
@@ -51,7 +51,7 @@ $sOperation = utils::ReadParam('operation', '');
 $oP->SetBreadCrumbEntry('ui-tool-universalsearch', Dict::S('Menu:UniversalSearchMenu'), Dict::S('Menu:UniversalSearchMenu+'), '', 'fas fa-search', iTopWebPage::ENUM_BREADCRUMB_ENTRY_ICON_TYPE_CSS_CLASSES);
 
 //$sSearchHeaderForceDropdown
-$sSearchHeaderForceDropdown = '<select  id="select_class" name="baseClass" onChange="this.form.trigger(\'submit\');">';
+$sSearchHeaderForceDropdown = '<select  id="select_class" name="baseClass" onChange="this.form.submit();">';
 $aClassLabels = [];
 foreach (MetaModel::GetClasses('bizmodel, grant_by_profile') as $sCurrentClass) {
 	if ((MetaModel::HasCategory($sCurrentClass, 'grant_by_profile') && UserRights::IsActionAllowed($sCurrentClass, UR_ACTION_BULK_MODIFY))

--- a/pages/tagadmin.php
+++ b/pages/tagadmin.php
@@ -54,7 +54,7 @@ try {
 
 	$oP->SetBreadCrumbEntry('ui-tool-tag-admin', Dict::S('Menu:TagAdminMenu'), Dict::S('Menu:TagAdminMenu+'), '', 'fas fa-tags', iTopWebPage::ENUM_BREADCRUMB_ENTRY_ICON_TYPE_CSS_CLASSES);
 
-	$sSearchHeaderForceDropdown = '<select  id="select_class" name="class" onChange="this.form.trigger(\'submit\');">';
+	$sSearchHeaderForceDropdown = '<select  id="select_class" name="class" onChange="this.form.submit();">';
 	$aClassLabels = [];
 	foreach (MetaModel::EnumChildClasses($sBaseClass, ENUM_CHILD_CLASSES_EXCLUDETOP) as $sCurrentClass) {
 		$aClassLabels[$sCurrentClass] = MetaModel::GetName($sCurrentClass);

--- a/templates/base/components/input/select/select.html.twig
+++ b/templates/base/components/input/select/select.html.twig
@@ -5,7 +5,7 @@
         {% include "base/components/input/inputlabel.html.twig" %}
     {% endif %}
     <select id="{{ oUIBlock.GetId() }}" name="{{ oUIBlock.GetName() }}"
-            {% if oUIBlock.GetSubmitOnChange() %} onChange="$(this).parents('form:first').trigger('submit');" {% endif %}
+            {% if oUIBlock.GetSubmitOnChange() %} onChange="$(this).parents('form').first().trigger('submit');" {% endif %}
             {% if oUIBlock.IsMultiple() %} multiple {% endif %}
             class="{% if oUIBlock.IsHidden() %}ibo-is-hidden{% endif %}{% if oUIBlock.GetAdditionalCSSClassesAsString() %} {{ oUIBlock.GetAdditionalCSSClassesAsString() }}{% endif %}"
             {% if oUIBlock.GetDataAttributes() %}


### PR DESCRIPTION

<!--
IMPORTANT: Before creating your PR, please create an issue first to know if Combodo is interested in your contribution (not needed for translations PR).
Since we may refuse a PR, it's preferable to create an issue first, to avoid spending time coding something that won't be accepted.

Once you've done it, and we confirmed we're interested in it, please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.
-->

## Base information

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | N°9628                 |
| Type of change?                                                                 | Bug fix  |

## Symptom (bug) / Objective (enhancement)

Some changes made to support jQuery 3.4 were applied to non jQuery elements, leading to js errors or weird behaviour.


## Cause (bug)

5b9e0a1d was commited without checking if every instance modifies were jQuery elements

## Proposed solution (bug and enhancement)

Revert changes for some elements, or apply 5b9e0a1d to elements that have changed since to accommodate behaviour changes  

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?