### PR TITLE
N°9759 - Truncate AttributeText don't work as expected in case of multibytes characters

### DIFF
--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -898,6 +898,26 @@ abstract class AttributeDefinition
 	}
 
 	/**
+	 * Helper to set a value that fits the attribute max size
+	 *
+	 * Default behavior is what DBObject::SetTrim used to do, now delegated to AttributeDefinition
+	 *
+	 * @param string $sValue
+	 *
+	 * @return string
+	 * @since 3.2.0 N°9643
+	 */
+	public function TrimValue(string $sValue)
+	{
+        $iMaxSize = $this->GetMaxSize();
+        if ($iMaxSize && (strlen($sValue) > $iMaxSize))
+        {
+            $sValue = substr($sValue, 0, $iMaxSize);
+        }
+        return $sValue;
+    }
+
+	/**
 	 * @return mixed|null
 	 * @deprecated never used
 	 */

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -910,9 +910,13 @@ abstract class AttributeDefinition
 	public function TrimValue(string $sValue)
 	{
 		$iMaxSize = $this->GetMaxSize();
-		if ($iMaxSize && (strlen($sValue) > $iMaxSize)) {
-			$sValue = substr($sValue, 0, $iMaxSize);
+		$iLength = mb_strlen($sValue);
+		if ($iMaxSize && ($iLength > $iMaxSize)) {
+			$sMessage = " -truncated ($iLength chars)";
+
+			return mb_substr($sValue, 0, $iMaxSize - mb_strlen($sMessage)).$sMessage;
 		}
+
 		return $sValue;
 	}
 
@@ -4266,10 +4270,15 @@ class AttributeText extends AttributeString
 		$iLengthChar = mb_strlen($sValue);
 		if ($iMaxSize && ($iLength > $iMaxSize)) {
 			$sMessage = " -truncated ($iLengthChar chars)";
-			$sVal = substr($sValue, 0, $iMaxSize - strlen($sMessage));
+			$iTruncatedValueMaxSize = $iMaxSize - strlen($sMessage);
+			$sTruncatedValue = substr($sValue, 0, $iTruncatedValueMaxSize);
 
-			//executes the "mb_substr" function to ensure a character is not truncated in the middle.
-			return mb_substr($sValue, 0, mb_strlen($sVal) - 1).$sMessage;
+			// Keep trimming bytes until we have valid UTF-8 to avoid returning a broken multibyte sequence.
+			while (($sTruncatedValue !== '') && !mb_check_encoding($sTruncatedValue, 'UTF-8')) {
+				$sTruncatedValue = substr($sTruncatedValue, 0, -1);
+			}
+
+			return $sTruncatedValue.$sMessage;
 		}
 
 		return $sValue;

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -3510,12 +3510,9 @@ class AttributeString extends AttributeDBField
 	public function TrimValue(string $sValue)
 	{
 		$iMaxSize = $this->GetMaxSize();
-		if ($iMaxSize == null) {
-			return $sValue;
-		}
-		$sLength = mb_strlen($sValue);
-		if ($iMaxSize && ($sLength > $iMaxSize)) {
-			$sMessage = " -truncated ($sLength chars)";
+		$iLength = mb_strlen($sValue);
+		if ($iMaxSize && ($iLength > $iMaxSize)) {
+			$sMessage = " -truncated ($iLength chars)";
 
 			return mb_substr($sValue, 0, $iMaxSize - mb_strlen($sMessage)).$sMessage;
 		}

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -4268,6 +4268,10 @@ class AttributeText extends AttributeString
 	}
 	/**
 	 * @inheritDoc
+	 *
+	 * Truncation is performed on a **byte** budget (MySQL TEXT limit) without ever cutting through a multibyte
+	 * UTF-8 sequence: the returned value is always valid UTF-8 and never exceeds GetMaxSize() bytes,
+	 * truncation suffix included.
 	 */
 	public function TrimValue(?string $sValue)
 	{

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -4261,6 +4261,9 @@ class AttributeText extends AttributeString
 
 	/**
 	 * @inheritDoc
+	 *
+	 * Unlike the default implementation, the size is expressed in **bytes**: MySQL TEXT columns are limited
+	 * in bytes (65535), not in characters, and {@see static::GetMaxSize()} for this class returns a number of bytes.
 	 */
 	public function GetSize($value)
 	{

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -897,19 +897,6 @@ abstract class AttributeDefinition
 		return null;
 	}
 
-	public function TrimValue(string $sValue)
-	{
-		$iMaxSize = $this->GetMaxSize();
-		$sLength = mb_strlen($sValue);
-		if ($iMaxSize && ($sLength > $iMaxSize)) {
-			$sMessage = " -truncated ($sLength chars)";
-
-			return mb_substr($sValue, 0, $iMaxSize - mb_strlen($sMessage)).$sMessage;
-		}
-
-		return $sValue;
-	}
-
 	/**
 	 * @return mixed|null
 	 * @deprecated never used
@@ -2599,6 +2586,11 @@ class AttributeDBFieldVoid extends AttributeDefinition
 			.($bFullSpec ? $this->GetSQLColSpec() : '');
 	}
 
+	public function GetSize($value)
+	{
+		return mb_strlen($value);
+	}
+
 	protected function GetSQLColSpec()
 	{
 		$default = $this->ScalarToSQL($this->GetDefaultValue());
@@ -3496,6 +3488,21 @@ class AttributeString extends AttributeDBField
 			.($bFullSpec ? $this->GetSQLColSpec() : '');
 	}
 
+	public function TrimValue(string $sValue)
+	{
+		$iMaxSize = $this->GetMaxSize();
+		if ($iMaxSize == null) {
+			return $sValue;
+		}
+		$sLength = mb_strlen($sValue);
+		if ($iMaxSize && ($sLength > $iMaxSize)) {
+			$sMessage = " -truncated ($sLength chars)";
+
+			return mb_substr($sValue, 0, $iMaxSize - mb_strlen($sMessage)).$sMessage;
+		}
+
+		return $sValue;
+	}
 	public function GetValidationPattern()
 	{
 		$sPattern = $this->GetOptional('validation_pattern', '');
@@ -4232,12 +4239,17 @@ class AttributeText extends AttributeString
 		return "TEXT".CMDBSource::GetSqlStringColumnDefinition();
 	}
 
+	public function GetSize($value)
+	{
+		return strlen($value);
+	}
 	public function TrimValue(string $sValue)
 	{
 		$iMaxSize = $this->GetMaxSize();
 		$sLength = strlen($sValue);
+		$sLengthChar = mb_strlen($sValue);
 		if ($iMaxSize && ($sLength > $iMaxSize)) {
-			$sMessage = " -truncated ($sLength chars)";
+			$sMessage = " -truncated ($sLengthChar chars)";
 			$sVal = substr($sValue, 0, $iMaxSize - strlen($sMessage));
 
 			//executes the "mb_substr" function to ensure a character is not truncated in the middle.

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -904,32 +904,42 @@ abstract class AttributeDefinition
 	 * Byte-based attributes (e.g. {@see AttributeText}, stored as MySQL TEXT which is limited to 65535 **bytes**,
 	 * not characters) MUST override both this method and {@see TrimValue()} consistently.
 	 *
-	 * @param string|null $value
+	 * @param string|null $sValue
 	 *
 	 * @return int Size of $value in the unit of GetMaxSize() (characters by default)
 	 * @since 3.2.3-2 3.2.4 3.3.0 N°9759
 	 */
-	public function GetSize($value)
+	public function GetSize(?string $sValue)
 	{
-		return mb_strlen($value);
+		// If the value is null, we return 0
+		if ($sValue === null) {
+			return 0;
+		}
+
+		return mb_strlen($sValue);
 	}
 
 	/**
 	 * Helper to set a value that fits the attribute max size
-	 * 
+	 *
 	 * Truncation is performed in the same unit as GetMaxSize() / {@see GetSize()}: a number of **characters**
 	 * by default (VARCHAR-based attributes). When truncated, a " -truncated (N chars)" suffix is appended and
 	 * the returned value (suffix included) still fits within GetMaxSize().
 	 *
 	 * Default behavior is what DBObject::SetTrim used to do, now delegated to AttributeDefinition
 	 *
-	 * @param string $sValue
+	 * @param string|null $sValue
 	 *
 	 * @return string $sValue truncated so that it fits within {@see GetMaxSize()}.
 	 * @since 3.2.3-2 3.2.4 3.3.0 N°9759
 	 */
 	public function TrimValue(?string $sValue)
 	{
+		// If the value is null, we return an empty string
+		if ($sValue === null) {
+			return '';
+		}
+
 		$iMaxSize = $this->GetMaxSize();
 		$iLength = mb_strlen($sValue);
 		if ($iMaxSize && ($iLength > $iMaxSize)) {
@@ -4269,9 +4279,14 @@ class AttributeText extends AttributeString
 	 * Unlike the default implementation, the size is expressed in **bytes**: MySQL TEXT columns are limited
 	 * in bytes (65535), not in characters, and {@see static::GetMaxSize()} for this class returns a number of bytes.
 	 */
-	public function GetSize($value)
+	public function GetSize(?string $sValue)
 	{
-		return strlen($value);
+		// If the value is null, we return 0
+		if ($sValue === null) {
+			return 0;
+		}
+
+		return strlen($sValue);
 	}
 	/**
 	 * @inheritDoc
@@ -4282,6 +4297,11 @@ class AttributeText extends AttributeString
 	 */
 	public function TrimValue(?string $sValue)
 	{
+		// If the value is null, we return an empty string
+		if ($sValue === null) {
+			return '';
+		}
+
 		$iMaxSize = $this->GetMaxSize();
 		$iLength = strlen($sValue);
 		$iLengthChar = mb_strlen($sValue);

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -909,13 +909,12 @@ abstract class AttributeDefinition
 	 */
 	public function TrimValue(string $sValue)
 	{
-        $iMaxSize = $this->GetMaxSize();
-        if ($iMaxSize && (strlen($sValue) > $iMaxSize))
-        {
-            $sValue = substr($sValue, 0, $iMaxSize);
-        }
-        return $sValue;
-    }
+		$iMaxSize = $this->GetMaxSize();
+		if ($iMaxSize && (strlen($sValue) > $iMaxSize)) {
+			$sValue = substr($sValue, 0, $iMaxSize);
+		}
+		return $sValue;
+	}
 
 	/**
 	 * @return mixed|null
@@ -4266,10 +4265,10 @@ class AttributeText extends AttributeString
 	public function TrimValue(string $sValue)
 	{
 		$iMaxSize = $this->GetMaxSize();
-		$sLength = strlen($sValue);
-		$sLengthChar = mb_strlen($sValue);
-		if ($iMaxSize && ($sLength > $iMaxSize)) {
-			$sMessage = " -truncated ($sLengthChar chars)";
+		$iLength = strlen($sValue);
+		$iLengthChar = mb_strlen($sValue);
+		if ($iMaxSize && ($iLength > $iMaxSize)) {
+			$sMessage = " -truncated ($iLengthChar chars)";
 			$sVal = substr($sValue, 0, $iMaxSize - strlen($sMessage));
 
 			//executes the "mb_substr" function to ensure a character is not truncated in the middle.

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -915,7 +915,7 @@ abstract class AttributeDefinition
 	 * @return string
 	 * @since 3.2.3-2 3.2.4 3.3.0 N°9759
 	 */
-	public function TrimValue(string $sValue)
+	public function TrimValue(?string $sValue)
 	{
 		$iMaxSize = $this->GetMaxSize();
 		$iLength = mb_strlen($sValue);

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -4281,12 +4281,9 @@ class AttributeText extends AttributeString
 		if ($iMaxSize && ($iLength > $iMaxSize)) {
 			$sMessage = " -truncated ($iLengthChar chars)";
 			$iTruncatedValueMaxSize = $iMaxSize - strlen($sMessage);
-			$sTruncatedValue = substr($sValue, 0, $iTruncatedValueMaxSize);
-
-			// Keep trimming bytes until we have valid UTF-8 to avoid returning a broken multibyte sequence.
-			while (($sTruncatedValue !== '') && !mb_check_encoding($sTruncatedValue, 'UTF-8')) {
-				$sTruncatedValue = substr($sTruncatedValue, 0, -1);
-			}
+			// mb_strcut cuts on a byte budget but moves the cut point back to a character boundary,
+			// so it never returns a broken multibyte sequence at the end of the value
+			$sTruncatedValue = mb_strcut($sValue, 0, $iTruncatedValueMaxSize, 'UTF-8');
 
 			return $sTruncatedValue.$sMessage;
 		}

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -910,7 +910,7 @@ abstract class AttributeDefinition
 	 * @param string $sValue
 	 *
 	 * @return string
-	 * @since 3.2.0 N°9643
+	 * @since 3.2.3-2 N°9759
 	 */
 	public function TrimValue(string $sValue)
 	{
@@ -3511,18 +3511,6 @@ class AttributeString extends AttributeDBField
 			.($bFullSpec ? $this->GetSQLColSpec() : '');
 	}
 
-	public function TrimValue(string $sValue)
-	{
-		$iMaxSize = $this->GetMaxSize();
-		$iLength = mb_strlen($sValue);
-		if ($iMaxSize && ($iLength > $iMaxSize)) {
-			$sMessage = " -truncated ($iLength chars)";
-
-			return mb_substr($sValue, 0, $iMaxSize - mb_strlen($sMessage)).$sMessage;
-		}
-
-		return $sValue;
-	}
 	public function GetValidationPattern()
 	{
 		$sPattern = $this->GetOptional('validation_pattern', '');

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -898,6 +898,15 @@ abstract class AttributeDefinition
 	}
 
 	/**
+	 * Return the size of $value, expressed in the same unit as {@see static::GetMaxSize()} for this attribute class.
+	 *
+	 * Default unit is a number of **characters**, matching MySQL VARCHAR(M) semantics for VARCHAR-based attributes.
+	 * Byte-based attributes (e.g. {@see AttributeText}, stored as MySQL TEXT which is limited to 65535 **bytes**,
+	 * not characters) MUST override both this method and {@see TrimValue()} consistently.
+	 *
+	 * @param string|null $value
+	 *
+	 * @return int Size of $value in the unit of GetMaxSize() (characters by default)
 	 * @since 3.2.3-2 3.2.4 3.3.0 N°9759
 	 */
 	public function GetSize($value)

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -897,6 +897,9 @@ abstract class AttributeDefinition
 		return null;
 	}
 
+	/**
+	 * @since 3.2.3-2 3.2.4 3.3.0 N°9759
+	 */
 	public function GetSize($value)
 	{
 		return mb_strlen($value);
@@ -910,7 +913,7 @@ abstract class AttributeDefinition
 	 * @param string $sValue
 	 *
 	 * @return string
-	 * @since 3.2.3-2 N°9759
+	 * @since 3.2.3-2 3.2.4 3.3.0 N°9759
 	 */
 	public function TrimValue(string $sValue)
 	{
@@ -4247,6 +4250,9 @@ class AttributeText extends AttributeString
 		return "TEXT".CMDBSource::GetSqlStringColumnDefinition();
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public function GetSize($value)
 	{
 		return strlen($value);

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -916,12 +916,16 @@ abstract class AttributeDefinition
 
 	/**
 	 * Helper to set a value that fits the attribute max size
+	 * 
+	 * Truncation is performed in the same unit as GetMaxSize() / {@see GetSize()}: a number of **characters**
+	 * by default (VARCHAR-based attributes). When truncated, a " -truncated (N chars)" suffix is appended and
+	 * the returned value (suffix included) still fits within GetMaxSize().
 	 *
 	 * Default behavior is what DBObject::SetTrim used to do, now delegated to AttributeDefinition
 	 *
 	 * @param string $sValue
 	 *
-	 * @return string
+	 * @return string $sValue truncated so that it fits within {@see GetMaxSize()}.
 	 * @since 3.2.3-2 3.2.4 3.3.0 N°9759
 	 */
 	public function TrimValue(?string $sValue)

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -897,6 +897,19 @@ abstract class AttributeDefinition
 		return null;
 	}
 
+	public function TrimValue(string $sValue)
+	{
+		$iMaxSize = $this->GetMaxSize();
+		$sLength = mb_strlen($sValue);
+		if ($iMaxSize && ($sLength > $iMaxSize)) {
+			$sMessage = " -truncated ($sLength chars)";
+
+			return mb_substr($sValue, 0, $iMaxSize - mb_strlen($sMessage)).$sMessage;
+		}
+
+		return $sValue;
+	}
+
 	/**
 	 * @return mixed|null
 	 * @deprecated never used
@@ -4217,6 +4230,21 @@ class AttributeText extends AttributeString
 	protected function GetSQLCol($bFullSpec = false)
 	{
 		return "TEXT".CMDBSource::GetSqlStringColumnDefinition();
+	}
+
+	public function TrimValue(string $sValue)
+	{
+		$iMaxSize = $this->GetMaxSize();
+		$sLength = strlen($sValue);
+		if ($iMaxSize && ($sLength > $iMaxSize)) {
+			$sMessage = " -truncated ($sLength chars)";
+			$sVal = substr($sValue, 0, $iMaxSize - strlen($sMessage));
+
+			//executes the "mb_substr" function to ensure a character is not truncated in the middle.
+			return mb_substr($sValue, 0, mb_strlen($sVal) - 1).$sMessage;
+		}
+
+		return $sValue;
 	}
 
 	public function GetSQLColumns($bFullSpec = false)

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -897,6 +897,11 @@ abstract class AttributeDefinition
 		return null;
 	}
 
+	public function GetSize($value)
+	{
+		return mb_strlen($value);
+	}
+
 	/**
 	 * Helper to set a value that fits the attribute max size
 	 *
@@ -2607,11 +2612,6 @@ class AttributeDBFieldVoid extends AttributeDefinition
 		return 'VARCHAR(255)'
 			.CMDBSource::GetSqlStringColumnDefinition()
 			.($bFullSpec ? $this->GetSQLColSpec() : '');
-	}
-
-	public function GetSize($value)
-	{
-		return mb_strlen($value);
 	}
 
 	protected function GetSQLColSpec()

--- a/core/attributedef.class.inc.php
+++ b/core/attributedef.class.inc.php
@@ -4257,7 +4257,10 @@ class AttributeText extends AttributeString
 	{
 		return strlen($value);
 	}
-	public function TrimValue(string $sValue)
+	/**
+	 * @inheritDoc
+	 */
+	public function TrimValue(?string $sValue)
 	{
 		$iMaxSize = $this->GetMaxSize();
 		$iLength = strlen($sValue);

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -2035,7 +2035,7 @@ abstract class DBObject implements iDisplay
 				}
 			}
 			if (!is_null($iMaxSize = $oAtt->GetMaxSize())) {
-				$iLen = mb_strlen($toCheck);
+				$iLen = $oAtt->GetSize($toCheck);
 				if ($iLen > $iMaxSize) {
 					return "String too long (found $iLen, limited to $iMaxSize)";
 				}

--- a/core/dbobject.class.php
+++ b/core/dbobject.class.php
@@ -732,13 +732,8 @@ abstract class DBObject implements iDisplay
 	public function SetTrim($sAttCode, $sValue)
 	{
 		$oAttDef = MetaModel::GetAttributeDef(get_class($this), $sAttCode);
-		$iMaxSize = $oAttDef->GetMaxSize();
-		$sLength = mb_strlen($sValue);
-		if ($iMaxSize && ($sLength > $iMaxSize)) {
-			$sMessage = " -truncated ($sLength chars)";
-			$sValue = mb_substr($sValue, 0, $iMaxSize - mb_strlen($sMessage)).$sMessage;
-		}
-		$this->Set($sAttCode, $sValue);
+
+		$this->Set($sAttCode, $oAttDef->TrimValue($sValue));
 	}
 
 	/**

--- a/tests/php-unit-tests/unitary-tests/core/DBObject/DBObjectTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBObject/DBObjectTest.php
@@ -1388,6 +1388,17 @@ class DBObjectTest extends ItopDataTestCase
 	}
 
 	/**
+	 * @covers DBObject::SetTrim
+	 */
+	public function testSetTrimOnNonStringAttributeDoesNotTrim()
+	{
+		$oTicket = MetaModel::NewObject(UserRequest::class);
+		$oTicket->SetTrim('caller_id', '15');
+
+		$this->assertEquals(15, $oTicket->Get('caller_id'), 'SetTrim should keep non-string attributes untouched before regular Set conversion');
+	}
+
+	/**
 	 * @covers DBObject::SetComputedDate
 	 * @return void
 	 */

--- a/tests/php-unit-tests/unitary-tests/core/DBObject/DBObjectTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBObject/DBObjectTest.php
@@ -1297,19 +1297,21 @@ class DBObjectTest extends ItopDataTestCase
 	{
 		return [
 			// UserRequest.title is an AttributeString (maxsize = 255)
-			'title 250 chars' => ['title', 250],
-			'title 254 chars' => ['title', 254],
-			'title 255 chars' => ['title', 255],
-			'title 256 chars' => ['title', 256],
-			'title 300 chars' => ['title', 300],
+			'title 250 chars'            => ['title', 250, 250, true],
+			'title 254 chars'            => ['title', 254, 254, true],
+			'title 255 chars'            => ['title', 255, 255, true],
+			'title 256 chars'            => ['title', 256, 255, false],
+			'title 300 chars'            => ['title', 300, 255, false],
 
 			// UserRequest.pending_reason is an AttributeText (maxsize=65535) with format=text
-			'pending_reason 250 chars' => ['pending_reason', 250],
-			'pending_reason 60000 chars' => ['pending_reason', 60000],
-			'pending_reason 65534 chars' => ['pending_reason', 65534],
-			'pending_reason 65535 chars' => ['pending_reason', 65535],
-			'pending_reason 65536 chars' => ['pending_reason', 65536],
-			'pending_reason 70000 chars' => ['pending_reason', 70000],
+			'pending_reason 250 chars'   => ['pending_reason', 250, 250, true],
+			'pending_reason 65534 chars' => ['pending_reason', 65534, 16403, false],
+			'pending_reason 65535 chars' => ['pending_reason', 65535, 16403, false],
+			'pending_reason 65536 chars' => ['pending_reason', 65536, 16403, false],
+			'pending_reason 16385 chars' => ['pending_reason', 16385, 16403, false],
+			'pending_reason 16384 chars' => ['pending_reason', 16384, 16383, true],
+			'pending_reason 16383 chars' => ['pending_reason', 16383, 16383, true],
+			'pending_reason 16382 chars' => ['pending_reason', 16382, 16382, true],
 		];
 	}
 
@@ -1322,7 +1324,7 @@ class DBObjectTest extends ItopDataTestCase
 	 *
 	 * @since 3.1.2 N°3448 - Framework field size check not correctly implemented for multi-bytes languages/strings
 	 */
-	public function testCheckLongValueInAttribute(string $sAttrCode, int $iValueLength)
+	public function testCheckLongValueInAttribute(string $sAttrCode, int $iValueLength, int $iExpectedLength, bool $bIsValueToSetBelowAttrMaxSize): void
 	{
 		$sPrefix = 'a'; // just a small prefix so that the emoji bytes won't have a power of 2 (we want a non even value)
 		$sEmojiToRepeat = '😎'; // this emoji is 4 bytes long
@@ -1343,7 +1345,6 @@ class DBObjectTest extends ItopDataTestCase
 
 		$oAttDef = MetaModel::GetAttributeDef(UserRequest::class, $sAttrCode);
 		$iAttrMaxSize = $oAttDef->GetMaxSize();
-		$bIsValueToSetBelowAttrMaxSize = ($iValueLength <= $iAttrMaxSize);
 		/** @noinspection PhpUnusedLocalVariableInspection */
 		[$bCheckStatus, $aCheckIssues, $bSecurityIssue] = $oTicket->CheckToWrite();
 		$this->assertEquals($bIsValueToSetBelowAttrMaxSize, $bCheckStatus, "CheckResult result:".var_export($aCheckIssues, true));
@@ -1353,7 +1354,7 @@ class DBObjectTest extends ItopDataTestCase
 		if ($bIsValueToSetBelowAttrMaxSize) {
 			$this->assertEquals($sValueToSet, $sValueInObject, 'Should not alter string that is already shorter than attribute max length');
 		} else {
-			$this->assertEquals($iAttrMaxSize, mb_strlen($sValueInObject), 'Should truncate at the same length than attribute max length');
+			$this->assertEquals($iExpectedLength, mb_strlen($sValueInObject), 'Should truncate at the same length than attribute max length');
 			$sLastCharsOfValueInObject = mb_substr($sValueInObject, -30);
 			$this->assertStringContainsString(' -truncated', $sLastCharsOfValueInObject, 'Should end with "truncated" comment');
 		}

--- a/tests/php-unit-tests/unitary-tests/core/DBObject/DBObjectTest.php
+++ b/tests/php-unit-tests/unitary-tests/core/DBObject/DBObjectTest.php
@@ -37,7 +37,6 @@ use Team;
 use User;
 use UserRequest;
 use UserRights;
-use utils;
 
 /**
  * @group specificOrgInSampleData
@@ -1309,7 +1308,7 @@ class DBObjectTest extends ItopDataTestCase
 			'pending_reason 65535 chars' => ['pending_reason', 65535, 16403, false],
 			'pending_reason 65536 chars' => ['pending_reason', 65536, 16403, false],
 			'pending_reason 16385 chars' => ['pending_reason', 16385, 16403, false],
-			'pending_reason 16384 chars' => ['pending_reason', 16384, 16383, true],
+			'pending_reason 16384 chars' => ['pending_reason', 16384, 16384, true],
 			'pending_reason 16383 chars' => ['pending_reason', 16383, 16383, true],
 			'pending_reason 16382 chars' => ['pending_reason', 16382, 16382, true],
 		];
@@ -1345,16 +1344,18 @@ class DBObjectTest extends ItopDataTestCase
 
 		$oAttDef = MetaModel::GetAttributeDef(UserRequest::class, $sAttrCode);
 		$iAttrMaxSize = $oAttDef->GetMaxSize();
+		$bExpectedStatus = ($oAttDef->GetSize($sValueToSet) <= $iAttrMaxSize);
+		$this->assertSame($bExpectedStatus, $bIsValueToSetBelowAttrMaxSize, 'The data provider must stay aligned with the attribute max size logic.');
 		/** @noinspection PhpUnusedLocalVariableInspection */
 		[$bCheckStatus, $aCheckIssues, $bSecurityIssue] = $oTicket->CheckToWrite();
 		$this->assertEquals($bIsValueToSetBelowAttrMaxSize, $bCheckStatus, "CheckResult result:".var_export($aCheckIssues, true));
 
 		$oTicket->SetTrim($sAttrCode, $sValueToSet);
 		$sValueInObject = $oTicket->Get($sAttrCode);
+		$this->assertEquals($iExpectedLength, mb_strlen($sValueInObject), 'Should match expected resulting value length.');
 		if ($bIsValueToSetBelowAttrMaxSize) {
 			$this->assertEquals($sValueToSet, $sValueInObject, 'Should not alter string that is already shorter than attribute max length');
 		} else {
-			$this->assertEquals($iExpectedLength, mb_strlen($sValueInObject), 'Should truncate at the same length than attribute max length');
 			$sLastCharsOfValueInObject = mb_substr($sValueInObject, -30);
 			$this->assertStringContainsString(' -truncated', $sLastCharsOfValueInObject, 'Should end with "truncated" comment');
 		}
@@ -1385,6 +1386,50 @@ class DBObjectTest extends ItopDataTestCase
 		$oOrganisation = MetaModel::NewObject(Organization::class);
 		$oOrganisation->SetTrim('name', $sName);
 		$this->assertEquals($sResult, $oOrganisation->Get('name'), 'SetTrim must limit string to 255 characters');
+	}
+
+	/**
+	 * Check that DBObject::SetTrim doesn't cut through multibytes characters
+	 *
+	 * @covers DBObject::SetTrim
+	 * @dataProvider SetTrimAttributeTextProvider
+	 */
+	public function testSetTrimOnAttributeTextKeepsUtf8Validity(string $sChar, int $iRepeatCount, bool $bExpectExactByteFill): void
+	{
+		$oTicket = MetaModel::NewObject('UserRequest', [
+			'ref'         => 'Test Ticket',
+			'title'       => 'Create OK',
+			'description' => 'Create OK',
+			'caller_id'   => 15,
+			'org_id'      => 3,
+		]);
+
+		$sValueToSet = str_repeat($sChar, $iRepeatCount);
+		$oTicket->SetTrim('pending_reason', $sValueToSet);
+		$sValueInObject = $oTicket->Get('pending_reason');
+
+		$oAttDef = MetaModel::GetAttributeDef('UserRequest', 'pending_reason');
+		$iAttrMaxSize = $oAttDef->GetMaxSize();
+		$iOriginalCharLength = mb_strlen($sValueToSet);
+		$sMessage = " -truncated ($iOriginalCharLength chars)";
+
+		$this->assertStringEndsWith($sMessage, $sValueInObject, 'Trimmed value should keep the expected truncation suffix.');
+		$this->assertTrue(mb_check_encoding($sValueInObject, 'UTF-8'), 'Trimmed value should stay valid UTF-8.');
+		$this->assertLessThanOrEqual($iAttrMaxSize, strlen($sValueInObject), 'Trimmed value should never exceed attribute byte max size.');
+
+		if ($bExpectExactByteFill) {
+			$this->assertSame($iAttrMaxSize, strlen($sValueInObject), 'When byte cut lands on a character boundary, SetTrim should use all available bytes.');
+		}
+	}
+
+	public function SetTrimAttributeTextProvider()
+	{
+		return [
+			// 2-byte UTF-8 chars: truncation payload size is byte-aligned and should fill the max size exactly.
+			'pending_reason 2-byte chars on byte boundary' => ["\xC3\xA9", 32768, true],
+			// 4-byte UTF-8 chars: truncation payload size is not byte-aligned and must backtrack to valid UTF-8.
+			'pending_reason 4-byte chars with mid-character byte cut' => ['💃', 16385, false],
+		];
 	}
 
 	/**

--- a/webservices/webservices.class.inc.php
+++ b/webservices/webservices.class.inc.php
@@ -277,23 +277,11 @@ abstract class WebServicesBase
 		$oLog->Set('userinfo', UserRights::GetUser());
 		$oLog->Set('verb', $sVerb);
 		$oLog->Set('result', $oRes->IsOk());
-		$this->TrimAndSetValue($oLog, 'log_info', (string)$oRes->GetInfoAsText());
-		$this->TrimAndSetValue($oLog, 'log_warning', (string)$oRes->GetWarningsAsText());
-		$this->TrimAndSetValue($oLog, 'log_error', (string)$oRes->GetErrorsAsText());
-		$this->TrimAndSetValue($oLog, 'data', (string)$oRes->GetReturnedDataAsText());
+		$oLog->SetTrim('log_info', (string)$oRes->GetInfoAsText());
+		$oLog->SetTrim('log_warning', (string)$oRes->GetWarningsAsText());
+		$oLog->SetTrim('log_error', (string)$oRes->GetErrorsAsText());
+		$oLog->SetTrim('data', (string)$oRes->GetReturnedDataAsText());
 		$oLog->DBInsertNoReload();
-	}
-
-	protected function TrimAndSetValue($oLog, $sAttCode, $sValue)
-	{
-		$oAttDef = MetaModel::GetAttributeDef(get_class($oLog), $sAttCode);
-		if (is_object($oAttDef)) {
-			$iMaxSize = $oAttDef->GetMaxSize();
-			if ($iMaxSize && (mb_strlen($sValue) > $iMaxSize)) {
-				$sValue = mb_substr($sValue, 0, $iMaxSize);
-			}
-			$oLog->Set($sAttCode, $sValue);
-		}
 	}
 
 	/**


### PR DESCRIPTION
internal
