### PR TITLE
N°9625 - Add Session::UnsetAll() method to ensure that even the "welcome" session value is correctly resetted

### DIFF
--- a/application/loginwebpage.class.inc.php
+++ b/application/loginwebpage.class.inc.php
@@ -369,16 +369,7 @@ class LoginWebPage extends NiceWebPage
 	public static function ResetSession()
 	{
 		// Unset all of the session variables.
-		Session::Unset('auth_user');
-		Session::Unset('login_state');
-		Session::Unset('can_logoff');
-		Session::Unset('archive_mode');
-		Session::Unset('impersonate_user');
-		Session::Unset('PluginProperties');
-		Session::Unset('UrlMakerClass');
-		Session::Unset('itop_env');
-		Session::Unset('obj_messages');
-		Session::Unset('profile_list');
+		Session::UnsetAll();
 		UserRights::_ResetSessionCache();
 		// If it's desired to kill the session, also delete the session cookie.
 		// Note: This will destroy the session, and not just the session data!

--- a/application/loginwebpage.class.inc.php
+++ b/application/loginwebpage.class.inc.php
@@ -25,11 +25,11 @@
  */
 
 use Combodo\iTop\Application\Branding;
-use Combodo\iTop\Application\Helper\Session;
 use Combodo\iTop\Application\WebPage\ErrorPage;
 use Combodo\iTop\Application\WebPage\NiceWebPage;
 use Combodo\iTop\Service\Events\EventData;
 use Combodo\iTop\Service\Events\EventService;
+use Combodo\iTop\Service\Session\Session;
 
 /**
  * Web page used for displaying the login form

--- a/pages/logoff.php
+++ b/pages/logoff.php
@@ -49,8 +49,6 @@ if (Session::IsSet('auth_user')) {
 	UserRights::Login($sAuthUser); // Set the user's language
 }
 
-LoginWebPage::ResetSession();
-
 $bLoginDebug = MetaModel::GetConfig()->Get('login_debug');
 if ($bLoginDebug) {
 	IssueLog::Info("---------------------------------");
@@ -88,7 +86,7 @@ if ($bLoginDebug) {
 	IssueLog::Info("--> Display logout page");
 }
 
-LoginWebPage::ResetSession(true);
+LoginWebPage::ResetSession();
 if ($bLoginDebug) {
 	$sSessionLog = session_id().' '.utils::GetSessionLog();
 	IssueLog::Info("SESSION: $sSessionLog");

--- a/sources/Service/Session/Session.php
+++ b/sources/Service/Session/Session.php
@@ -196,6 +196,10 @@ class Session
 
 	public static function ListVariables(): array
 	{
+		if (!isset($_SESSION)) {
+			return [];
+		}
+
 		return array_keys($_SESSION);
 	}
 

--- a/sources/Service/Session/Session.php
+++ b/sources/Service/Session/Session.php
@@ -132,6 +132,19 @@ class Session
 	}
 
 	/**
+	 * Unset all session variables, no matter if they were set by iTop or not
+	 *
+	 * @return void
+	 * @since 3.3.0 N°9625
+	 */
+	public static function UnsetAll(): void
+	{
+		foreach (self::ListVariables() as $sKey) {
+			self::Unset($sKey);
+		}
+	}
+
+	/**
 	 * @param string|array $key key to access to the session variable. To access to $_SESSION['a']['b'] $key must be ['a', 'b']
 	 * @param $default
 	 *

--- a/sources/Service/Session/Session.php
+++ b/sources/Service/Session/Session.php
@@ -139,8 +139,12 @@ class Session
 	 */
 	public static function UnsetAll(): void
 	{
-		foreach (self::ListVariables() as $sKey) {
-			self::Unset($sKey);
+		if (session_status() !== PHP_SESSION_ACTIVE) {
+			self::Start();
+			$_SESSION = [];
+			self::WriteClose();
+		} else {
+			$_SESSION = [];
 		}
 	}
 

--- a/tests/php-unit-tests/unitary-tests/application/Session/SessionTest.php
+++ b/tests/php-unit-tests/unitary-tests/application/Session/SessionTest.php
@@ -123,6 +123,23 @@ class SessionTest extends ItopTestCase
 		$this->assertFalse(Session::IsSet(['test1', 'test2', 'test3']));
 	}
 
+	public function testUnsetAll()
+	{
+		Session::Start();
+		Session::Set('test', 'OK');
+		Session::Set(['test1', 'test2', 'test3'], 'OK');
+		Session::Set('another_test', ['foo' => 'bar']);
+		$this->assertTrue(Session::IsSet('test'));
+		$this->assertTrue(Session::IsSet(['test1', 'test2', 'test3']));
+		$this->assertTrue(Session::IsSet('another_test'));
+
+		Session::UnsetAll();
+		$this->assertEmpty($_SESSION);
+		$this->assertFalse(Session::IsSet('test'));
+		$this->assertFalse(Session::IsSet(['test1', 'test2', 'test3']));
+		$this->assertFalse(Session::IsSet('another_test'));
+	}
+
 	public function testRegenerateId()
 	{
 		Session::Start();


### PR DESCRIPTION
Internal