### PR TITLE
N°8860 - Régression Export CSV clé externe, plus de critères

### DIFF
--- a/core/tabularbulkexport.class.inc.php
+++ b/core/tabularbulkexport.class.inc.php
@@ -8,9 +8,13 @@
 use Combodo\iTop\Application\UI\Base\Component\Input\InputUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Layout\UIContentBlockUIBlockFactory;
 use Combodo\iTop\Application\WebPage\WebPage;
+use Combodo\iTop\Core\AttributeDefinition\AttributeExternalField;
 use Combodo\iTop\Core\AttributeDefinition\AttributeExternalKey;
+use Combodo\iTop\Core\AttributeDefinition\AttributeFriendlyName;
 use Combodo\iTop\Core\AttributeDefinition\AttributeHierarchicalKey;
+use Combodo\iTop\Core\AttributeDefinition\AttributeLinkedSet;
 use Combodo\iTop\Core\AttributeDefinition\AttributeStopWatch;
+use Combodo\iTop\Core\AttributeDefinition\AttributeSubItem;
 
 /**
  * Bulk export: Tabular export: abstract base class for all "tabular" exports.

--- a/core/tabularbulkexport.class.inc.php
+++ b/core/tabularbulkexport.class.inc.php
@@ -8,6 +8,9 @@
 use Combodo\iTop\Application\UI\Base\Component\Input\InputUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Layout\UIContentBlockUIBlockFactory;
 use Combodo\iTop\Application\WebPage\WebPage;
+use Combodo\iTop\Core\AttributeDefinition\AttributeExternalKey;
+use Combodo\iTop\Core\AttributeDefinition\AttributeHierarchicalKey;
+use Combodo\iTop\Core\AttributeDefinition\AttributeStopWatch;
 
 /**
  * Bulk export: Tabular export: abstract base class for all "tabular" exports.
@@ -91,8 +94,8 @@ abstract class TabularBulkExport extends BulkExport
 	{
 		$aResult = [];
 		switch (get_class($oAttDef)) {
-			case 'AttributeExternalKey':
-			case 'AttributeHierarchicalKey':
+			case AttributeExternalKey::class:
+			case AttributeHierarchicalKey::class:
 
 				$bAddFriendlyName = true;
 				$oKeyAttDef = MetaModel::GetAttributeDef($sClass, $sAttCode);
@@ -142,7 +145,7 @@ abstract class TabularBulkExport extends BulkExport
 				}
 				break;
 
-			case 'AttributeStopWatch':
+			case AttributeStopWatch::class:
 				foreach (MetaModel::ListAttributeDefs($sClass) as $sSubAttCode => $oSubAttDef) {
 					if ($oSubAttDef instanceof AttributeSubItem) {
 						if ($oSubAttDef->GetParentAttCode() == $sAttCode) {


### PR DESCRIPTION
## Base information

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=8860#ObjectProperties=tab_ClassBugAttributebugs_list                 |
| Type of change?                                                                 | Bug fix  |

## Symptom (bug) / Objective (enhancement)

Export CSV do not handle correctly attributes external key

## Reproduction procedure (bug)

Export location, organization field is not recognized as external key attribute

<img width="990" height="213" alt="image" src="https://github.com/user-attachments/assets/77fc7687-78d8-4965-939e-07dd625cd354" />


## Checklist before requesting a review

- [X ] I have performed a self-review of my code
- [X ] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [X ] Is the PR clear and detailed enough so anyone can understand without digging in the code?