### PR TITLE
N°8886 - Deprecation warning in DashetGroupBy in 3.3-dev

### DIFF
--- a/application/dashboard.class.inc.php
+++ b/application/dashboard.class.inc.php
@@ -501,7 +501,7 @@ EOF
 	 */
 	public function Render($oPage, $bEditMode = false, $aExtraParams = [], $bCanEdit = true)
 	{
-		$aExtraParams['dashboard_div_id'] = utils::Sanitize($aExtraParams['dashboard_div_id'] ?? null, $this->GetId(), utils::ENUM_SANITIZATION_FILTER_ELEMENT_IDENTIFIER);
+		$aExtraParams['dashboard_div_id'] = utils::Sanitize($aExtraParams['dashboard_div_id'] ?? $this->GetId(), $this->GetId(), utils::ENUM_SANITIZATION_FILTER_ELEMENT_IDENTIFIER);
 
 		/** @var \DashboardLayoutMultiCol $oLayout */
 		$oLayout = new $this->sLayoutClass();


### PR DESCRIPTION
## Base information

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=8886                 |
| Type of change?                                                                 | Bug fix |

## Symptom (bug) / Objective (enhancement)

PHP deprecated message on attribute dashboard edition

## Reproduction procedure (bug)

(with PHP 8.3)
Edit the dashboard of an organization objet, add a GroupByTable dashlet, you will get a deprecated message.

## Cause (bug)

'preg_replace(): Passing null to parameter #3 ($subject)

## Checklist before requesting a review

- [X ] I have performed a self-review of my code
- [X ] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [X ] Is the PR clear and detailed enough so anyone can understand without digging in the code?