### PR TITLE
fix broken cache warmup after setup

### DIFF
--- a/setup/runtimeenv.class.inc.php
+++ b/setup/runtimeenv.class.inc.php
@@ -915,9 +915,6 @@ class RunTimeEnvironment
 				utils::GetDataPath().'cache-'.$this->sFinalEnv,
 				false
 			);
-
-			SetupUtils::tidydir(utils::GetCachePath().'expressioncache/');
-
 			$this->CommitDir(
 				APPROOT.'env-'.$this->sBuildEnv,
 				APPROOT.'env-'.$this->sFinalEnv,
@@ -936,6 +933,7 @@ class RunTimeEnvironment
 			@chmod($sFinalConfig, 0440); // Read-only for owner and group, nothing for others
 
 			SetupUtils::rrmdir(dirname($sBuildConfig)); // Cleanup the temporary build dir if empty
+			MetaModel::ResetAllCaches($this->sBuildEnv);
 			MetaModel::ResetAllCaches($this->sFinalEnv);
 
 			if (! isset($_SESSION)) {

--- a/setup/runtimeenv.class.inc.php
+++ b/setup/runtimeenv.class.inc.php
@@ -915,6 +915,9 @@ class RunTimeEnvironment
 				utils::GetDataPath().'cache-'.$this->sFinalEnv,
 				false
 			);
+
+			SetupUtils::tidydir(utils::GetCachePath().'expressioncache/');
+
 			$this->CommitDir(
 				APPROOT.'env-'.$this->sBuildEnv,
 				APPROOT.'env-'.$this->sFinalEnv,


### PR DESCRIPTION
Fix below issue after setup:

```
2026-07-16 14:20:36 | Error   |       | Uncaught ReflectionException: Class "TagSetFieldDataFor_FAQ__domains" does not exist in /var/www/html/iTop/core/metamodel.class.php:3891
Stack trace:
#0 /var/www/html/iTop/core/metamodel.class.php(3891): ReflectionClass->__construct()
#1 /var/www/html/iTop/core/dbobjectsearch.class.php(1875): MetaModel::IsAbstract()
#2 /var/www/html/iTop/core/expressioncache.class.inc.php(120): DBObjectSearch::GetPolymorphicExpression()
#3 /var/www/html/iTop/core/expressioncache.class.inc.php(91): ExpressionCache::GetSerializedExpression()
#4 /var/www/html/iTop/core/metamodel.class.php(5790): ExpressionCache::Warmup()
#5 /var/www/html/iTop/application/startup.inc.php(76): MetaModel::Startup()
#6 /var/www/html/iTop/pages/UI.php(235): require_once('...')
#7 {main}
  thrown | IssueLog |||
array (
  'type' => 1,
  'file' => '/var/www/html/iTop/core/metamodel.class.php',
  'line' => 3891,
)

```
