### PR TITLE
N°9827 - Unable to launch check compatibility when a module with bad dependencies is in production-modules

### DIFF
--- a/setup/wizardsteps/WizStepModulesChoice.php
+++ b/setup/wizardsteps/WizStepModulesChoice.php
@@ -759,8 +759,8 @@ EOF
 			$bDisabled = true;
 			$bChecked = false;
 		} elseif ($bDependencyIssue) {
-			$bDisabled = true;
-			$bChecked = false;
+			$bDisabled = !$bDisableUninstallCheck;
+			$bChecked = true;
 		} elseif ($bMandatory) {
 			$bDisabled = true;
 			$bChecked = true;
@@ -813,6 +813,9 @@ EOF
 
 			if ($aFlags['disabled'] && !$aFlags['checked'] && !$bDisableUninstallCheck && (!$aFlags['uninstallable'] || $aFlags['mandatory'])) {
 				$this->bCanMoveForward = false;//Disable "Next"
+			} elseif (!$bDisableUninstallCheck && $aFlags['dependency_issue']) {
+				//If there is a dependency issue, the user cannot move forward without forced uninstall
+				$this->bCanMoveForward = false;
 			}
 
 			$this->DisplayChoice($oPage, $aChoice, $aSelectedComponents, $aDefaults, $sChoiceId, $sChoiceId, $aFlags);

--- a/setup/wizardsteps/WizStepModulesChoice.php
+++ b/setup/wizardsteps/WizStepModulesChoice.php
@@ -758,12 +758,11 @@ EOF
 		if ($bMissingFromDisk) {
 			$bDisabled = true;
 			$bChecked = false;
-		} elseif ($bDependencyIssue) {
-			$bDisabled = !$bDisableUninstallCheck;
-			$bChecked = true;
 		} elseif ($bMandatory) {
 			$bDisabled = true;
 			$bChecked = true;
+		} elseif ($bDependencyIssue) {
+			$bDisabled = !$bDisableUninstallCheck;
 		} elseif ($bInstalled && !$bCanBeUninstalled && !$bDisableUninstallCheck) {
 			$bChecked = true;
 			$bDisabled = true;

--- a/tests/php-unit-tests/unitary-tests/setup/WizStepModulesChoiceTest.php
+++ b/tests/php-unit-tests/unitary-tests/setup/WizStepModulesChoiceTest.php
@@ -394,7 +394,7 @@ class WizStepModulesChoiceTest extends ItopTestCase
 					'mandatory' => false,
 				],
 			],
-			'A non installed extension with missing dependencies should be not checked and disabled' => [
+			'A non installed extension with missing dependencies and without force uninstall should be checked and disabled' => [
 				'aExtensionsOnDiskOrDb' => [
 					'itop-ext1' => [
 						'installed' => false,
@@ -416,12 +416,12 @@ class WizStepModulesChoiceTest extends ItopTestCase
 					'missing' => false,
 					'installed' => false,
 					'disabled' => true,
-					'checked' => false,
+					'checked' => true,
 					'dependency_issue' => true,
 					'mandatory' => false,
 				],
 			],
-			'An installed extension with missing dependencies should be not checked and disabled' => [
+			'An installed extension with missing dependencies and without force uninstall should be checked and disabled' => [
 				'aExtensionsOnDiskOrDb' => [
 					'itop-ext1' => [
 						'installed' => true,
@@ -443,7 +443,61 @@ class WizStepModulesChoiceTest extends ItopTestCase
 					'missing' => false,
 					'installed' => true,
 					'disabled' => true,
-					'checked' => false,
+					'checked' => true,
+					'dependency_issue' => true,
+					'mandatory' => false,
+				],
+			],
+			'A non installed extension with missing dependencies and force uninstall should be checked and enabled' => [
+				'aExtensionsOnDiskOrDb' => [
+					'itop-ext1' => [
+						'installed' => false,
+						'missing_dependencies' => [
+							'itop-ext1-1',
+						],
+					],
+				],
+				'aWizardStepDefinition' => [
+					'extension_code' => 'itop-ext1',
+					'mandatory' => false,
+					'uninstallable' => true,
+					'missing_dependencies' => true,
+				],
+				'bCurrentSelected' => false,
+				'bDisableUninstallChecks' => true,
+				'aExpectedFlags' => [
+					'uninstallable' => true,
+					'missing' => false,
+					'installed' => false,
+					'disabled' => false,
+					'checked' => true,
+					'dependency_issue' => true,
+					'mandatory' => false,
+				],
+			],
+			'An installed extension with missing dependencies and force uninstall should be checked and enabled' => [
+				'aExtensionsOnDiskOrDb' => [
+					'itop-ext1' => [
+						'installed' => true,
+						'missing_dependencies' => [
+							'itop-ext1-1',
+						],
+					],
+				],
+				'aWizardStepDefinition' => [
+					'extension_code' => 'itop-ext1',
+					'mandatory' => false,
+					'uninstallable' => true,
+					'missing_dependencies' => true,
+				],
+				'bCurrentSelected' => false,
+				'bDisableUninstallChecks' => true,
+				'aExpectedFlags' => [
+					'uninstallable' => true,
+					'missing' => false,
+					'installed' => true,
+					'disabled' => false,
+					'checked' => true,
 					'dependency_issue' => true,
 					'mandatory' => false,
 				],

--- a/tests/php-unit-tests/unitary-tests/setup/WizStepModulesChoiceTest.php
+++ b/tests/php-unit-tests/unitary-tests/setup/WizStepModulesChoiceTest.php
@@ -394,7 +394,7 @@ class WizStepModulesChoiceTest extends ItopTestCase
 					'mandatory' => false,
 				],
 			],
-			'A non installed extension with missing dependencies and without force uninstall should be checked and disabled' => [
+			'A non installed and non mandatory extension with missing dependencies and without force uninstall should be not checked and disabled' => [
 				'aExtensionsOnDiskOrDb' => [
 					'itop-ext1' => [
 						'installed' => false,
@@ -416,12 +416,12 @@ class WizStepModulesChoiceTest extends ItopTestCase
 					'missing' => false,
 					'installed' => false,
 					'disabled' => true,
-					'checked' => true,
+					'checked' => false,
 					'dependency_issue' => true,
 					'mandatory' => false,
 				],
 			],
-			'An installed extension with missing dependencies and without force uninstall should be checked and disabled' => [
+			'An installed non mandatory extension with missing dependencies and without force uninstall should be not checked and disabled' => [
 				'aExtensionsOnDiskOrDb' => [
 					'itop-ext1' => [
 						'installed' => true,
@@ -443,12 +443,12 @@ class WizStepModulesChoiceTest extends ItopTestCase
 					'missing' => false,
 					'installed' => true,
 					'disabled' => true,
-					'checked' => true,
+					'checked' => false,
 					'dependency_issue' => true,
 					'mandatory' => false,
 				],
 			],
-			'A non installed extension with missing dependencies and force uninstall should be checked and enabled' => [
+			'A non installed and non mandatory extension with missing dependencies and force uninstall should be not checked and enabled' => [
 				'aExtensionsOnDiskOrDb' => [
 					'itop-ext1' => [
 						'installed' => false,
@@ -470,12 +470,12 @@ class WizStepModulesChoiceTest extends ItopTestCase
 					'missing' => false,
 					'installed' => false,
 					'disabled' => false,
-					'checked' => true,
+					'checked' => false,
 					'dependency_issue' => true,
 					'mandatory' => false,
 				],
 			],
-			'An installed extension with missing dependencies and force uninstall should be checked and enabled' => [
+			'An installed non mandatory extension with missing dependencies and force uninstall should be not checked and enabled' => [
 				'aExtensionsOnDiskOrDb' => [
 					'itop-ext1' => [
 						'installed' => true,
@@ -497,9 +497,63 @@ class WizStepModulesChoiceTest extends ItopTestCase
 					'missing' => false,
 					'installed' => true,
 					'disabled' => false,
-					'checked' => true,
+					'checked' => false,
 					'dependency_issue' => true,
 					'mandatory' => false,
+				],
+			],
+			'An installed mandatory extension with missing dependencies and without force uninstall should be checked and disabled' => [
+				'aExtensionsOnDiskOrDb' => [
+					'itop-ext1' => [
+						'installed' => true,
+						'missing_dependencies' => [
+							'itop-ext1-1',
+						],
+					],
+				],
+				'aWizardStepDefinition' => [
+					'extension_code' => 'itop-ext1',
+					'mandatory' => true,
+					'uninstallable' => true,
+					'missing_dependencies' => true,
+				],
+				'bCurrentSelected' => false,
+				'bDisableUninstallChecks' => true,
+				'aExpectedFlags' => [
+					'uninstallable' => true,
+					'missing' => false,
+					'installed' => true,
+					'disabled' => true,
+					'checked' => true,
+					'dependency_issue' => true,
+					'mandatory' => true,
+				],
+			],
+			'An non installed mandatory extension with missing dependencies and without force uninstall should be checked and disabled' => [
+				'aExtensionsOnDiskOrDb' => [
+					'itop-ext1' => [
+						'installed' => false,
+						'missing_dependencies' => [
+							'itop-ext1-1',
+						],
+					],
+				],
+				'aWizardStepDefinition' => [
+					'extension_code' => 'itop-ext1',
+					'mandatory' => true,
+					'uninstallable' => true,
+					'missing_dependencies' => true,
+				],
+				'bCurrentSelected' => false,
+				'bDisableUninstallChecks' => true,
+				'aExpectedFlags' => [
+					'uninstallable' => true,
+					'missing' => false,
+					'installed' => false,
+					'disabled' => true,
+					'checked' => true,
+					'dependency_issue' => true,
+					'mandatory' => true,
 				],
 			],
 		];


### PR DESCRIPTION
N°9827 - Unable to launch check compatibility when a module with bad dependencies is in production-modules