### PR TITLE
N°9831 - Fix setup error when trying to remove class with a DEL_MANUAL ext. key

### DIFF
--- a/datamodels/2.x/combodo-data-feature-removal/src/Service/DataCleanupService.php
+++ b/datamodels/2.x/combodo-data-feature-removal/src/Service/DataCleanupService.php
@@ -134,10 +134,6 @@ class DataCleanupService
 				/** @var DBObject $oDependentObj */
 				while ($oDependentObj = $oSet->Fetch()) {
 					$iDeletePropagationOption = $oExtKeyAttDef->GetDeletionPropagationOption();
-					if ($iDeletePropagationOption == DEL_MANUAL) {
-						$this->oObjectService->SetIssue(get_class($oDependentObj));
-						continue;
-					}
 
 					if ($oExtKeyAttDef->IsNullAllowed()) {
 						// Optional external key, list to reset
@@ -152,6 +148,12 @@ class DataCleanupService
 							return false;
 						}
 					} else {
+						// Mandatory external key
+						if ($iDeletePropagationOption == DEL_MANUAL) {
+							// Cannot be deleted automatically, must be handled manually
+							$this->oObjectService->SetIssue(get_class($oDependentObj));
+							continue;
+						}
 						// Propagate deletion only if not visited
 						if ($this->IsVisited($oDependentObj)) {
 							continue;

--- a/datamodels/2.x/combodo-data-feature-removal/src/Service/StaticDeletionPlan.php
+++ b/datamodels/2.x/combodo-data-feature-removal/src/Service/StaticDeletionPlan.php
@@ -59,9 +59,11 @@ class StaticDeletionPlan
 	{
 		foreach ($aClasses as $sClass) {
 			$oDeletionPlanItem = $this->GetInitialClassDeletionPlan($sClass);
-			$oDeletionPlanEntity = new DeletionPlanEntity();
-			$oDeletionPlanEntity->oDelete->Merge($oDeletionPlanItem);
-			$this->aDeletionPlan[$sClass] = $oDeletionPlanEntity;
+			// N°9831 Do not overwrite existing entity as it may already exist for this class if a previously processed class references it (issues/updates already accumulated must be kept)
+			if (false === array_key_exists($sClass, $this->aDeletionPlan)) {
+				$this->aDeletionPlan[$sClass] = new DeletionPlanEntity();
+			}
+			$this->aDeletionPlan[$sClass]->oDelete->Merge($oDeletionPlanItem);
 
 			$this->DeletionPlanForReferencingClasses($sClass);
 		}

--- a/tests/php-unit-tests/unitary-tests/datamodels/2.x/combodo-data-feature-removal/DataCleanupServiceTest.php
+++ b/tests/php-unit-tests/unitary-tests/datamodels/2.x/combodo-data-feature-removal/DataCleanupServiceTest.php
@@ -163,6 +163,58 @@ class DataCleanupServiceTest extends \AbstractCleanup
 		$this->AssertSummaryEquals($aExpected, $aRes);
 	}
 
+	/**
+	 * N°9831
+	 *
+	 * A nullable external key configured as DEL_MANUAL must NOT be treated as an issue: it is simply
+	 * reset (set to null), exactly like core DBObject::MakeDeletionPlan does. DEL_MANUAL only blocks
+	 * for mandatory keys. This mirrors the real "Hypervisor.farm_id -> Farm" case (nullable + DEL_MANUAL).
+	 *
+	 * Regression guard for the ordering of the IsNullAllowed()/DEL_MANUAL checks in RecursiveDeletion:
+	 * reverting that change would make ExecuteCleanup throw here instead of resetting the object.
+	 */
+	public function testExecuteCleanup_NullableManualShouldResetAndNotThrow()
+	{
+		$this->GivenDFRTreeInDB(<<<EOF
+			DFRToRemoveLeaf_1 <- DFRManualNullable_1
+		EOF);
+
+		$aClasses = [ 'DFRToRemoveLeaf' ];
+		$oService = new DataCleanupService();
+		// Must NOT throw: the nullable external key is reset, not reported as an issue
+		$aRes = $oService->ExecuteCleanup($aClasses);
+
+		$aExpected = [
+			['DFRManualNullable', 1, 0 ],
+			['DFRToRemoveLeaf', 0, 1 ],
+		];
+		$this->AssertSummaryEquals($aExpected, $aRes);
+	}
+
+	/**
+	 * N°9831
+	 *
+	 * Summary counterpart of the test above: a nullable DEL_MANUAL external key is reported as an
+	 * update (reset), with an issue count of 0. Reverting the RecursiveDeletion change would report
+	 * it as an issue instead.
+	 */
+	public function testGetCleanupSummary_NullableManualShouldBeUpdateNotIssue()
+	{
+		$this->GivenDFRTreeInDB(<<<EOF
+			DFRToRemoveLeaf_1 <- DFRManualNullable_1
+		EOF);
+
+		$aClasses = [ 'DFRToRemoveLeaf' ];
+		$oService = new DataCleanupService();
+		$aRes = $oService->GetCleanupSummary($aClasses);
+
+		$aExpected = [
+			['DFRManualNullable', 1, 0, 0 ],
+			['DFRToRemoveLeaf', 0, 1, 0 ],
+		];
+		$this->AssertSummaryEquals($aExpected, $aRes);
+	}
+
 	private function AssertSummaryEquals(array $expected, $actual, $sMessage = '')
 	{
 		$aExpected = [];

--- a/tests/php-unit-tests/unitary-tests/datamodels/2.x/combodo-data-feature-removal/StaticDeletionPlanTest.php
+++ b/tests/php-unit-tests/unitary-tests/datamodels/2.x/combodo-data-feature-removal/StaticDeletionPlanTest.php
@@ -9,7 +9,6 @@ namespace Combodo\iTop\Test\UnitTest\Module\DataFeatureRemoval;
 
 use Combodo\iTop\DataFeatureRemoval\Entity\DataCleanupSummaryEntity;
 use Combodo\iTop\DataFeatureRemoval\Service\StaticDeletionPlan;
-use MetaModel;
 
 require_once __DIR__."/AbstractCleanup.php";
 class StaticDeletionPlanTest extends \AbstractCleanup
@@ -147,6 +146,66 @@ EOF);
 			'DFRManual'                   => ['iIssueCount' => 1],
 		];
 
+		$this->AssertSummaryEquals($aExpected, $aRes);
+	}
+
+	/**
+	 * N°9831
+	 *
+	 * A DEL_MANUAL issue must still be reported when the referencing class (DFRManual) is itself part
+	 * of the classes to remove AND is processed AFTER the class it points to (DFRToRemoveLeaf).
+	 *
+	 * This mirrors the real "VirtualMachine -> VirtualHost" case: the setup audit sorts the removed
+	 * classes alphabetically and drops abstract classes, so a referencing class such as VirtualMachine
+	 * ends up processed after its concrete targets (Farm/Hypervisor/Cloud). Here DFRToRemove is abstract
+	 * and DFRToRemoveLeaf is its concrete child, while DFRManual points to DFRToRemove with a mandatory
+	 * DEL_MANUAL external key.
+	 *
+	 * Regression: the plan entity accumulating the issue used to be overwritten when the referencing
+	 * class was processed as a top-level class, silently dropping the issue (no blocking message on the
+	 * summary page, then a crash at execution time).
+	 */
+	public function testGetCleanupSummary_IssueKeptWhenReferencingClassListedAfterTarget(): void
+	{
+		$this->GivenDFRObjectsInDB(<<<EOF
+			create DFRToRemoveLeaf (name = DFRToRemoveLeaf_1)
+			create DFRManual       (name = DFRManual_1, extkey_id = DFRToRemoveLeaf_1)
+EOF);
+
+		// Target listed BEFORE the referencing class, as produced by the alphabetically sorted audit
+		$aClasses = ['DFRToRemoveLeaf', 'DFRManual'];
+		$oService = new StaticDeletionPlan();
+		$aRes = $oService->GetCleanupSummary($aClasses);
+
+		$aExpected = [
+			'DFRToRemoveLeaf' => ['iDeleteCount' => 1],
+			'DFRManual'       => ['iDeleteCount' => 1, 'iIssueCount' => 1],
+		];
+		$this->AssertSummaryEquals($aExpected, $aRes);
+	}
+
+	/**
+	 * N°9831
+	 *
+	 * Control case: the same issue must also be reported when the referencing class is listed BEFORE
+	 * its target (this order already worked, e.g. "Enclosure -> Rack"). Together with the test above,
+	 * this locks in that issue detection is independent of the processing order.
+	 */
+	public function testGetCleanupSummary_IssueKeptWhenReferencingClassListedBeforeTarget(): void
+	{
+		$this->GivenDFRObjectsInDB(<<<EOF
+			create DFRToRemoveLeaf (name = DFRToRemoveLeaf_1)
+			create DFRManual       (name = DFRManual_1, extkey_id = DFRToRemoveLeaf_1)
+EOF);
+
+		$aClasses = ['DFRManual', 'DFRToRemoveLeaf'];
+		$oService = new StaticDeletionPlan();
+		$aRes = $oService->GetCleanupSummary($aClasses);
+
+		$aExpected = [
+			'DFRToRemoveLeaf' => ['iDeleteCount' => 1],
+			'DFRManual'       => ['iDeleteCount' => 1, 'iIssueCount' => 1],
+		];
 		$this->AssertSummaryEquals($aExpected, $aRes);
 	}
 

--- a/tests/php-unit-tests/unitary-tests/datamodels/2.x/combodo-data-feature-removal/data_cleanup_delta.xml
+++ b/tests/php-unit-tests/unitary-tests/datamodels/2.x/combodo-data-feature-removal/data_cleanup_delta.xml
@@ -319,6 +319,58 @@
       </presentation>
       <parent>cmdbAbstractObject</parent>
     </class>
+    <class id="DFRManualNullable" _created_in="itop-structure" _delta="define">
+      <properties>
+        <category>bizmodel,searchable</category>
+        <abstract>false</abstract>
+        <db_table>dfrmanualnullable</db_table>
+        <naming>
+          <attributes/>
+        </naming>
+        <reconciliation>
+          <attributes/>
+        </reconciliation>
+      </properties>
+      <fields>
+        <field id="name" xsi:type="AttributeString">
+          <sql>name</sql>
+          <default_value/>
+          <is_null_allowed>true</is_null_allowed>
+          <validation_pattern/>
+          <dependencies/>
+          <tracking_level>all</tracking_level>
+        </field>
+        <field id="extkey_id" xsi:type="AttributeExternalKey">
+          <sql>extkey_id</sql>
+          <filter/>
+          <dependencies/>
+          <is_null_allowed>true</is_null_allowed>
+          <target_class>DFRToRemove</target_class>
+          <on_target_delete>DEL_MANUAL</on_target_delete>
+          <tracking_level>all</tracking_level>
+        </field>
+      </fields>
+      <methods/>
+      <presentation>
+        <list>
+          <items/>
+        </list>
+        <search>
+          <items/>
+        </search>
+        <details>
+          <items>
+            <item id="name">
+              <rank>10</rank>
+            </item>
+            <item id="extkey_id">
+              <rank>20</rank>
+            </item>
+          </items>
+        </details>
+      </presentation>
+      <parent>cmdbAbstractObject</parent>
+    </class>
     <class id="DFRLeafNotToRemove" _created_in="itop-structure" _delta="define">
       <properties>
         <category>bizmodel,searchable</category>
@@ -718,6 +770,14 @@
         <entry id="Class:DFRManual/Attribute:name+" _delta="define"><![CDATA[]]></entry>
         <entry id="Class:DFRManual/Attribute:extkey_id" _delta="define"><![CDATA[Dfrtoremove id]]></entry>
         <entry id="Class:DFRManual/Attribute:extkey_id+" _delta="define"><![CDATA[]]></entry>
+        <entry id="Class:DFRManualNullable/Name" _delta="define"><![CDATA[]]></entry>
+        <entry id="Class:DFRManualNullable/ComplementaryName" _delta="define"><![CDATA[]]></entry>
+        <entry id="Class:DFRManualNullable" _delta="define"><![CDATA[DFRManualNullable]]></entry>
+        <entry id="Class:DFRManualNullable+" _delta="define"><![CDATA[]]></entry>
+        <entry id="Class:DFRManualNullable/Attribute:name" _delta="define"><![CDATA[Name]]></entry>
+        <entry id="Class:DFRManualNullable/Attribute:name+" _delta="define"><![CDATA[]]></entry>
+        <entry id="Class:DFRManualNullable/Attribute:extkey_id" _delta="define"><![CDATA[Dfrtoremove id]]></entry>
+        <entry id="Class:DFRManualNullable/Attribute:extkey_id+" _delta="define"><![CDATA[]]></entry>
       </entries>
     </dictionary>
   </dictionaries>


### PR DESCRIPTION
## Base information

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | N°9831                 |
| Type of change?                                                                 | Bug fix |

**Please be advised that I tried to make a fix for both bugs but that I don't master these parts of the code, so I may not be aware of the big picture.**

## Symptom (bug) / Objective (enhancement)

When uninstalling a module through the setup, the "check compatibility" step detects the objects that must be cleaned up to keep iTop consistent and redirects to the "extension management" page, which displays a summary of what will be deleted/updated. When some of these objects **can't** be deleted automatically (e.g. an external key with `DEL_MANUAL` option), the page is supposed to show a blocking message telling the user that it must remove these data manually first, and the "Proceed with deletion" button must not lead to a deletion.

But in this case, for some modules the blocking message isn't shown even though objects cannot be deleted automatically. The "Proceed with deletion" button stays enabled, and clicking it crashes the application with:

```
Combodo\iTop\DataFeatureRemoval\Helper\DataFeatureRemovalException : Deletion Plan cannot be executed due to issues
```

Concrete cases found while troubleshooting (standard datamodel):

| Removed module | External key involved | `is_null_allowed` | `on_target_delete` | Behavior |
|---|---|---|---|---|
| Data center devices | `Enclosure.rack_id` => `Rack` | `false` | `DEL_MANUAL` | ✅ Blocking message shown |
| Virtualization | `Hypervisor.farm_id` => `Farm` | `true` | `DEL_MANUAL` | ❌ No blocking message, crash on "Proceed with deletion" (Bug #1) |
| Virtualization | `VirtualMachine.virtualhost_id` => `VirtualHost` (abstract class) | `false` | `DEL_MANUAL` | ❌ No blocking message, crash on "Proceed with deletion" (Bug #2) |


## Reproduction procedure (bug)

1. On iTop 3.3.0-dev
3. Install iTop with the sample data (so that virtualization objects exist)
4. Run setup and select all modules
5. In the backoffice, create an `Enclosure` linked to a `Rack`
6. Run the setup again but this time unselect `Virtualization`
7. Continue to the "check compatibility" step
8. Click on "Cleanup my data"
9. See that there is no blocking message below the data table
10. Click on "Proceed with deletion" and see that the application crashes

## Cause (bug)

The "summary" (whether to block) and the "actual execution" rely on two different deletion-plan services that do not do the same processing:

- Summary is done by `StaticDeletionPlan::GetCleanupSummary()` (called by `DataFeatureRemovalController::GetDeletionPlanSummaryTable()`)
- Execution is done by `DataCleanupService::RecursiveDeletion()`, which throws the exception through `ObjectService::SetIssue()`.

Two different bugs made them diverge:

**Cause of bug #1 - Wrong order between `IsNullAllowed()` and `DEL_MANUAL` (`DataCleanupService::RecursiveDeletion()`)**
The "execution" service tested `DEL_MANUAL` before `IsNullAllowed()`, so a nullable external key with `DEL_MANUAL` was treated as an unresolvable issue and threw an exception.

But the reference engine `DBObject::MakeDeletionPlan()` (and `StaticDeletionPlan`) test `IsNullAllowed()` first.

A nullable key is always a simple "reset to null" update, and `DEL_MANUAL` only matters for mandatory ext. keys. That caused for `Hypervisor.farm_id` (nullable + `DEL_MANUAL`) the "summary" reported an update (no issue, no blocking message) while "execution" threw an exception.

**Cause of bug #2 - Deletion-plan entity overwritten (`StaticDeletionPlan::GetStaticDeletionPlan()`)**
While iterating the classes to remove, the method created a new `DeletionPlanEntity` for each classes and assigned it, loosing any entity already populated for that class by a previously processed class (issues/updates are accumulated on the referencing class while its target is processed).

The setup audit feeds the classes **sorted alphabetically** and **skips abstract classes** (`AbstractSetupAudit::RunDataAudit()`). For `VirtualMachine.virtualhost_id` => `VirtualHost`:
- `VirtualHost` is abstract, so only the concrete subclasses `Cloud`/`Farm`/`Hypervisor` are listed;
- `VirtualMachine` (referencing, mandatory `DEL_MANUAL`) is sorted after them, so the issue recorded on the `VirtualMachine` entity while processing `Farm`/`Hypervisor`/`Cloud` was lost when `VirtualMachine` was later processed as a root class => `iIssueCount = 0` => no blocking message, but execution still detected it and threw an exception.

This also explains why the `Data center devices` module works as expected: `Enclosure` (referencing) is sorted before `Rack` (its target), so the issue recorded on `Enclosure` is never overwritten afterwards.

## Proposed solution (bug and enhancement)

**Fix for bug #1**
In the "summary" service, test `IsNullAllowed()` first like in the "execution" service (`StaticDeletionPlan`) and core `DBObject::MakeDeletionPlan()`.

**Fix for bug #2**
Do not overwrite an existing plan entity, create it only when missing, then merge the initial IDs.
Issues/updates already accumulated are preserved, making issue detection independent of the processing order.

**Tests**
I've tried to add test cases in `StaticDeletionPlanTest` but I really not sure how it's supposed to work, so reviews are welcome 😅

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [X] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand without digging in the code?