### PR TITLE
N°9527 - Avoid multiple notifications on user mentionned on ticket with children

### DIFF
--- a/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
+++ b/datamodels/2.x/itop-tickets/datamodel.itop-tickets.xml
@@ -350,7 +350,7 @@
         <method id="UpdateChildTicketLog">
           <comment><![CDATA[/**
             *
-            * Remove the current user associated Person from the contacts_list of this Ticket
+            * Remove the Person associated with the current user from the contacts_list of this Ticket
             * No error if there is no associated Person or if the Person is not in the list
             * @return bool Return true
              * @param string $sChildClass The class name of the child ticket (e.g. 'Incident', 'UserRequest', etc.)
@@ -383,7 +383,8 @@
 			if (MetaModel::IsValidAttCode($sParentClass, $sParentAttCode) && MetaModel::GetAttributeDef($sParentClass, $sParentAttCode) instanceof AttributeCaseLog
 			&& MetaModel::IsValidAttCode($sChildClass, $sChildAttCode) &&  MetaModel::GetAttributeDef($sChildClass, $sChildAttCode) instanceof AttributeCaseLog
 			&& (!utils::IsNullOrEmptyString($this->Get($sParentAttCode)->GetModifiedEntry('html')))) {
-			  $aChildEntries[$sChildAttCode] = Dict::Format('Class:'.$sParentClass.'/Method:UpdateChildTicketWith:'.$sParentAttCode, $this->GetKey(), $this->Get('ref')).$this->Get($sParentAttCode)->GetModifiedEntry('html');
+			  $sCleanedEntry = preg_replace('/<a\s*([^>]*)data-object-class="([^"]*)"\s.*data-object-key="([^"]*)"\s*([^>]*)>@/Ui','<a\1\4>',$this->Get($sParentAttCode)->GetModifiedEntry('html'));
+			  $aChildEntries[$sChildAttCode] = Dict::Format('Class:'.$sParentClass.'/Method:UpdateChildTicketWith:'.$sParentAttCode, $this->GetKey(), $this->Get('ref')).$sCleanedEntry;
 			}
 		}
 		if ($aChildEntries == []) {


### PR DESCRIPTION
## Base information

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a Combodo ticket? | <!-- Put the URL -->                 |
| Type of change?                                                                 | Enhancement |

## Symptom (bug) / Objective (enhancement)

When a Person is mentioned on a parent Ticket within a log entry, that log entry is copied on the children tickets as is, which result in multiple notification of the same person for the same topic

## Proposed solution (bug and enhancement)

The idea is to clean the copied log entry, removing the part which trigger the TriggerOnMention

## Checklist before requesting a review

<!--
Don't remove these lines, check them once done.
-->

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?