### PR TITLE
N°9908 - GetAllowedValues from AttributeClassAttCodeSet return no value

### DIFF
--- a/sources/Core/AttributeDefinition/AttributeClassAttCodeSet.php
+++ b/sources/Core/AttributeDefinition/AttributeClassAttCodeSet.php
@@ -84,7 +84,7 @@ class AttributeClassAttCodeSet extends AttributeSet
 					// Add attribute only if not already there (can be in leaf classes but not the root)
 					if (!array_key_exists($sAttCode, $aAllAttributes)) {
 						$oAttDef = MetaModel::GetAttributeDef($sClass, $sAttCode);
-						$sAttDefClass = get_class($oAttDef);
+						$sAttDefClass = $oAttDef->GetTypeShortClassName();
 
 						// Skip excluded attdefs
 						if (isset($aExcludeDefs[$sAttDefClass])) {


### PR DESCRIPTION
## Base information

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | https://support.combodo.com/pages/UI.php?operation=details&class=Bug&id=9908                |
| Type of change?                                                                 | Bug fix  |

## Symptom (bug) / Objective (enhancement)

AttributeClassAttCodeSet filter doesn't return correct allowed values

## Reproduction procedure (bug)

1. Install vcs integration extension
2. Create or edit VCSLogAttributeAutomation object
3. Select target object class (UserRequest)
4. See that no attribute is available

## Cause (bug)

Attribute class FQCN

## Proposed solution (bug and enhancement)

Test shortname

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand without digging in the code?