### PR TITLE
N°9911 - Fix keyboard shortcuts no working anymore since 5b9e0a1d

### DIFF
--- a/templates/base/layouts/object/object-details/layout.js.twig
+++ b/templates/base/layouts/object/object-details/layout.js.twig
@@ -15,12 +15,12 @@
         $('#{{ oUIBlock.GetId() }}').on('edit_object', function(){
             let oFavoriteButton = $(this).find('#UIMenuModify');
             if(oFavoriteButton[0]){
-                oFavoriteButton[0].trigger('click');
+                oFavoriteButton[0].click();
             }
             else{
                 let oPopupItemButton = $('[data-role="ibo-popover-menu"]').find('[data-resource-id="UI:Menu:Modify"]');
                 if(oPopupItemButton[0]){
-                    oPopupItemButton[0].trigger('click');
+                    oPopupItemButton[0].click();
                 }
             }
         });
@@ -28,12 +28,12 @@
         $('#{{ oUIBlock.GetId() }}').on('delete_object', function(){
             let oFavoriteButton = $(this).find('#UIMenuDelete');
             if(oFavoriteButton[0]){
-                oFavoriteButton[0].trigger('click');
+                oFavoriteButton[0].click();
             }
             else{
                 let oPopupItemButton = $('[data-role="ibo-popover-menu"]').find('[data-resource-id="UI:Menu:Delete"]');
                 if(oPopupItemButton[0]){
-                    oPopupItemButton[0].trigger('click');
+                    oPopupItemButton[0].click();
                 }
             }
         });
@@ -41,12 +41,12 @@
         $('#{{ oUIBlock.GetId() }}').on('new_object', function(){
             let oFavoriteButton = $(this).find('#UIMenuNew');
             if(oFavoriteButton[0]){
-                oFavoriteButton[0].trigger('click');
+                oFavoriteButton[0].click();
             }
             else{
                 let oPopupItemButton = $('[data-role="ibo-popover-menu"]').find('[data-resource-id="UI:Menu:New"]');
                 if(oPopupItemButton[0]){
-                    oPopupItemButton[0].trigger('click');
+                    oPopupItemButton[0].click();
                 }
             }
         });


### PR DESCRIPTION

<!--
IMPORTANT: Before creating your PR, please create an issue first to know if Combodo is interested in your contribution (not needed for translations PR).
Since we may refuse a PR, it's preferable to create an issue first, to avoid spending time coding something that won't be accepted.

Once you've done it, and we confirmed we're interested in it, please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.
-->

## Base information

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | N°9911                 |
| Type of change?                                                                 | Bug fix  |

## Symptom (bug) / Objective (enhancement)

Some changes made to support jQuery 3.4 were applied to non jQuery elements, leading to keyboard shortcuts being triggered as a jQuery method on vanilla JS elements.


## Cause (bug)

5b9e0a1d was commited without checking if every instance modifies were jQuery elements

## Proposed solution (bug and enhancement)

Revert changes for keyboard shortcuts triggers
## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?