### PR TITLE
N°7299 - Migrate remaining usages of deprecated JS libs

### DIFF
--- a/sources/Application/WebPage/NiceWebPage.php
+++ b/sources/Application/WebPage/NiceWebPage.php
@@ -56,7 +56,7 @@ class NiceWebPage extends WebPage
 		'js/field_sorter.js',
 		'js/table-selectable-lines.js',
 		// - Not used internally or by extensions yet
-		'js/clipboard.min.js', // 3.2.0 N°5261 moved to NPM
+		'node_modules/clipboard/dist/clipboard.min.js', // 3.2.0 N°5261 moved to NPM
 		'js/clipboardwidget.js',
 		// - SearchForm
 		'js/searchformforeignkeys.js',

--- a/sources/Application/WebPage/iTopWebPage.php
+++ b/sources/Application/WebPage/iTopWebPage.php
@@ -58,8 +58,8 @@ class iTopWebPage extends NiceWebPage implements iTabbedPage
 		// - TabContainer
 		'js/jquery.ba-bbq.min.js',
 		// - DashletGroupBy & other specific places
-		'js/d3.js', // 3.2.0 N°5261 moved to NPM
-		'js/c3.js', // 3.2.0 N°5261 moved to NPM
+		'node_modules/d3/d3.min.js', // 3.2.0 N°5261 moved to NPM
+		'node_modules/c3/c3.min.js', // 3.2.0 N°5261 moved to NPM
 		// - DisplayableGraph, impact analysis
 		'js/raphael-min.js',
 		'js/jquery.mousewheel.js',


### PR DESCRIPTION
## Base information

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | N°7299                 |
| Type of change?                                                                 | Enhancement |

## Symptom (bug) / Objective (enhancement)
None, this is just clean up

## Proposed solution (bug and enhancement)
Some JS files that have been removed from 3.3 seem to still have references within the backoffice code.
That being said it's only in constants that were supposed to useg in iTop 3.0+ in case of a regression, so I doubt there is any real consequences.

Side note: I could not found any usage of the `WebPage::COMPATIBILITY_MOVED_LINKED_SCRIPTS_REL_PATH` constant, has it been removed?

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [X] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand without digging in the code?