### PR TITLE
N°9937 - Restore modal icon spins around the text

### DIFF
--- a/datamodels/2.x/itop-backup/status.php
+++ b/datamodels/2.x/itop-backup/status.php
@@ -21,7 +21,6 @@
 use Combodo\iTop\Application\UI\Base\Component\Alert\AlertUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Component\Button\ButtonUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Component\DataTable\DataTableUIBlockFactory;
-use Combodo\iTop\Application\UI\Base\Component\FieldSet\FieldSet;
 use Combodo\iTop\Application\UI\Base\Component\Panel\PanelUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Component\Spinner\SpinnerUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Component\Title\TitleUIBlockFactory;
@@ -410,8 +409,11 @@ JS
 
 	$sEnvironment = addslashes(utils::GetCurrentEnvironment());
 
-	$oModalSpinner = SpinnerUIBlockFactory::MakeMedium(null, $sPleaseWaitBackup);
-	$sModalSpinnerHtml = BlockRenderer::RenderBlockTemplates($oModalSpinner);
+	$oBackupModalSpinner = SpinnerUIBlockFactory::MakeMedium(null, $sPleaseWaitBackup);
+	$sBackupModalSpinnerHtml = BlockRenderer::RenderBlockTemplates($oBackupModalSpinner);
+
+	$oRestoreModalSpinner = SpinnerUIBlockFactory::MakeMedium(null, $sPleaseWaitRestore);
+	$sRestoreModalSpinnerHtml = BlockRenderer::RenderBlockTemplates($oRestoreModalSpinner);
 
 	$oP->add_script(
 		<<<JS
@@ -424,7 +426,7 @@ function LaunchBackupNow()
 	{
 		const oModal = CombodoModal.OpenModal({
 				title: '$sBackUpNow',
-				content: `$sModalSpinnerHtml`
+				content: `$sBackupModalSpinnerHtml`
 		});
 
 		var oParams = {};
@@ -450,10 +452,10 @@ function LaunchRestoreNow(sBackupFile, sConfirmationMessage)
 	{
 		return;
 	}
-
+    
 	const oModal = CombodoModal.OpenModal({
 		title: '$sRestore',
-		content: '<i class="ajax-spin fas fa-sync-alt fa-spin"></i> $sPleaseWaitRestore'
+		content: `$sRestoreModalSpinnerHtml`
 	});
 
 	$('#backup_success').addClass('ibo-is-hidden');


### PR DESCRIPTION
<!--
IMPORTANT: Before creating your PR, please create an issue first to know if Combodo is interested in your contribution (not needed for translations PR).
Since we may refuse a PR, it's preferable to create an issue first, to avoid spending time coding something that won't be accepted.

Once you've done it, and we confirmed we're interested in it, please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.
-->

## Base information

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | N°9937                |
| Type of change?                                                                 | Bug fix |

## Symptom (bug) / Objective (enhancement)

When restoring a backup, the spinner is spinning around the text 
<img width="725" height="399" alt="image" src="https://github.com/user-attachments/assets/59cd862b-2709-4d6f-b77c-d5fc17268c7f" />


## Reproduction procedure (bug)

1. On iTop 3.2.3
2. Make a backup, the spinner is fine
3. Restore this backup, the spinner is not fine

## Cause (bug)

901f8f2 fixed this issue in the backup modal, but not the restore modal

## Proposed solution (bug and enhancement)
Apply the same fix as 901f8f2

## Checklist before requesting a review


- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?