### PR TITLE
N°9919 - Check it "To" exists when sendind mail with PHPMail

### DIFF
--- a/sources/Core/Email/Transport/SymfonyPHPMailTransport.php
+++ b/sources/Core/Email/Transport/SymfonyPHPMailTransport.php
@@ -20,7 +20,7 @@ class SymfonyPHPMailTransport extends AbstractTransport
 	{
 		$oHeaders = $oRawEmail->getHeaders();
 
-		return $oHeaders->get('To')->getBodyAsString();
+		return $oHeaders->get('To') ? $oHeaders->get('To')->getBodyAsString() : '';
 	}
 
 	/**

--- a/tests/php-unit-tests/unitary-tests/sources/core/Email/Transport/SymfonyPHPMailTransportTest.php
+++ b/tests/php-unit-tests/unitary-tests/sources/core/Email/Transport/SymfonyPHPMailTransportTest.php
@@ -6,7 +6,7 @@ use Symfony\Component\Mime\Email;
 
 class SymfonyPHPMailTransportTest extends ItopTestCase
 {
-	public function testPrepareToReturnsEmptyStringWhenToHeaderIsMissing(): void
+	public function testPrepareMustNotThrowErrorWhenToHeaderIsMissing(): void
 	{
 		$oEmail = new Email()
 			->from('sender@example.com')

--- a/tests/php-unit-tests/unitary-tests/sources/core/Email/Transport/SymfonyPHPMailTransportTest.php
+++ b/tests/php-unit-tests/unitary-tests/sources/core/Email/Transport/SymfonyPHPMailTransportTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Combodo\iTop\Core\Email\Transport\SymfonyPHPMailTransport;
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+use Symfony\Component\Mime\Email;
+
+class SymfonyPHPMailTransportTest extends ItopTestCase
+{
+	public function testPrepareToReturnsEmptyStringWhenToHeaderIsMissing(): void
+	{
+		$oEmail = new Email()
+			->from('sender@example.com')
+			->cc('cc1@example.com', 'cc2@example.com')
+			->text('Body');
+
+		$oTransport = new SymfonyPHPMailTransport();
+
+		$oTransport->prepareTo($oEmail);
+		$this->assertTrue(true); // if no error is thrown, the test passes
+
+	}
+}


### PR DESCRIPTION

## Base information

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | 9919                |
| Type of change?                                                                 | Bug fix |

## Symptom (bug) / Objective (enhancement)

When a notification mail doesn't have a "to" field (e.g. only CC field), mail notification won't be sent with the following error "Call to a member function getBodyAsString() on null in /var/www/html/itop/support/3.2/sources/Core/Email/Transport/SymfonyPHPMailTransport.php:23"

## Reproduction procedure (bug)

<!--
Please explain step by step how to reproduce the issue on a standard iTop Community.
If it requires a custom datamodel, provide the minimal XML delta to reproduce it on a standard iTop Community.
-->

1. On iTop on dev branch (this day)
2. With PHP 8.4
3. Create a notification on an event and only add CC field.
4. Execute an action that will trigger the notification
5. See the error and see that no mail is sent.

## Cause (bug)

In the code, getBodyAsString is called on null, while it could be avoided.

## Proposed solution (bug and enhancement)

Check is $oHeaders->get('To') exists before calling getBodyAsString

## Checklist before requesting a review

<!--
Don't remove these lines, check them once done.
-->

- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance => tested with MailPit
- [x] I have added a unit test, otherwise I have explained why I couldn't
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?