### PR TITLE
 N°9975 - PHPmailer: Sending email with same headers as before

### DIFF
--- a/sources/Core/Email/Transport/SymfonyPHPMailTransport.php
+++ b/sources/Core/Email/Transport/SymfonyPHPMailTransport.php
@@ -7,8 +7,8 @@ use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mime\Email;
 
 /**
-* Transport that uses PHP's mail() function to send emails
-*/
+ * Transport that uses PHP's mail() function to send emails
+ */
 class SymfonyPHPMailTransport extends AbstractTransport
 {
 	/**
@@ -20,7 +20,7 @@ class SymfonyPHPMailTransport extends AbstractTransport
 	{
 		$oHeaders = $oRawEmail->getHeaders();
 
-		return $oHeaders->get('To')->getBodyAsString();
+		return $oHeaders->get('To') ? $oHeaders->get('To')->getBodyAsString() : '';
 	}
 
 	/**
@@ -70,6 +70,13 @@ class SymfonyPHPMailTransport extends AbstractTransport
 		return $sHeaders;
 	}
 
+	public function prepareAdditionalParameters(SentMessage $message): string
+	{
+		$sender = $message->getEnvelope()->getSender()->getEncodedAddress();
+
+		return '-f'.escapeshellarg($sender);
+	}
+
 	protected function doSend(SentMessage $message): void
 	{
 		$oRawEmail = $message->getOriginalMessage();
@@ -82,7 +89,7 @@ class SymfonyPHPMailTransport extends AbstractTransport
 		$sSubject = $this->prepareSubject($oRawEmail);
 		$sBody = $this->prepareBody($oRawEmail);
 		$sHeaders = $this->prepareHeaders($oRawEmail);
-		$sAdditionalParameters = '-f'.escapeshellarg($message->getEnvelope()->getSender()->getEncodedAddress());
+		$sAdditionalParameters = $this->prepareAdditionalParameters($message);
 
 		$success = mail($sTo, $sSubject, $sBody, $sHeaders, $sAdditionalParameters);
 

--- a/sources/Core/Email/Transport/SymfonyPHPMailTransport.php
+++ b/sources/Core/Email/Transport/SymfonyPHPMailTransport.php
@@ -82,7 +82,7 @@ class SymfonyPHPMailTransport extends AbstractTransport
 		$sSubject = $this->prepareSubject($oRawEmail);
 		$sBody = $this->prepareBody($oRawEmail);
 		$sHeaders = $this->prepareHeaders($oRawEmail);
-		$sAdditionalParameters = '-f '.$message->getEnvelope()->getSender()->getAddress();
+		$sAdditionalParameters = '-f'.escapeshellarg($message->getEnvelope()->getSender()->getEncodedAddress());
 
 		$success = mail($sTo, $sSubject, $sBody, $sHeaders, $sAdditionalParameters);
 

--- a/sources/Core/Email/Transport/SymfonyPHPMailTransport.php
+++ b/sources/Core/Email/Transport/SymfonyPHPMailTransport.php
@@ -82,8 +82,9 @@ class SymfonyPHPMailTransport extends AbstractTransport
 		$sSubject = $this->prepareSubject($oRawEmail);
 		$sBody = $this->prepareBody($oRawEmail);
 		$sHeaders = $this->prepareHeaders($oRawEmail);
+		$sAdditionalParameters = '-f '.$message->getEnvelope()->getSender()->getAddress();
 
-		$success = mail($sTo, $sSubject, $sBody, $sHeaders);
+		$success = mail($sTo, $sSubject, $sBody, $sHeaders, $sAdditionalParameters);
 
 		if (!$success) {
 			throw new \RuntimeException('The mail() function failed to send the message. Check server mail configuration.');

--- a/sources/Core/Email/Transport/SymfonyPHPMailTransport.php
+++ b/sources/Core/Email/Transport/SymfonyPHPMailTransport.php
@@ -7,8 +7,8 @@ use Symfony\Component\Mailer\Transport\AbstractTransport;
 use Symfony\Component\Mime\Email;
 
 /**
- * Transport that uses PHP's mail() function to send emails
- */
+* Transport that uses PHP's mail() function to send emails
+*/
 class SymfonyPHPMailTransport extends AbstractTransport
 {
 	/**


### PR DESCRIPTION
## Base information

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? |9975                 |
| Type of change?                                                                 | Bug fix |

## Symptom (bug) / Objective (enhancement)

When changing mail library, some data were sent the same way as before.

## Reproduction procedure (bug)
Compare headers from a mail sent by iTop (e.g. in notifications) with iTop 3.2.2 and iTop 3.2.4

## Cause (bug)
Change of library

## Proposed solution (bug and enhancement)
Adapt called to the new library.

## Checklist before requesting a review

<!--
Don't remove these lines, check them once done.
-->

- [ ] I have performed a self-review of my code
- [ ] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [ ] Is the PR clear and detailed enough so anyone can understand without digging in the code?