### PR TITLE
 N°9181 - Fix object class name alignment in summary cards

### DIFF
--- a/templates/base/layouts/object/object-details/layout.html.twig
+++ b/templates/base/layouts/object/object-details/layout.html.twig
@@ -19,9 +19,9 @@
     {% endif %}
     <span class="ibo-object-details--object-class" data-role="ibo-object-details--object-class">
         {% if is_backoffice_menu_enabled('DataModelMenu') %}
-            <a href="{{ get_absolute_url_app_root() }}pages/schema.php?operation=details_class&class={{ oUIBlock.GetClassName() }}" target="_blank" data-tooltip-content="{{ 'UI:Layout:ObjectDetails:DatamodelSchemaLink:Tooltip' | dict_s }}" data-tooltip-html-enabled="true">{{ oUIBlock.GetClassLabel() }}</a>
+            <a class="ibo-object-details--object-class--label" href="{{ get_absolute_url_app_root() }}pages/schema.php?operation=details_class&class={{ oUIBlock.GetClassName() }}" target="_blank" data-tooltip-content="{{ 'UI:Layout:ObjectDetails:DatamodelSchemaLink:Tooltip' | dict_s }}" data-tooltip-html-enabled="true">{{ oUIBlock.GetClassLabel() }}</a>
         {% else %}
-            {{ oUIBlock.GetClassLabel() }}
+            <span class="ibo-object-details--object-class--label">{{ oUIBlock.GetClassLabel() }}</span>
         {% endif %}
     </span>
     {{ parent() }}


### PR DESCRIPTION
## Base information

| Question                                                                        | Answer                               |
|---------------------------------------------------------------------------------|--------------------------------------|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? |  N°9181                |
| Type of change?                                                                 | Bug fix |

## Symptom (bug) / Objective (enhancement)

When a non admin user hover a link and a summary card appears, the object class name is not aligned properly

<img width="519" height="89" alt="image" src="https://github.com/user-attachments/assets/bc045432-0f7f-493e-b680-da281ee9e82b" />


## Reproduction procedure (bug)

<!--
Please explain step by step how to reproduce the issue on a standard iTop Community.
If it requires a custom datamodel, provide the minimal XML delta to reproduce it on a standard iTop Community.
-->

1. On iTop 3.2.3
2. Create a support agent user and log in with this new user
3. Hover a UserRequest link
4. Finally, see that `UserRequest` class name is not aligned properly


## Proposed solution (bug and enhancement)

Add an html tag to ensure the element inherits the same rules as the two parenthesis

## Checklist before requesting a review

<!--
Don't remove these lines, check them once done.
-->

- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand without digging in the code?